### PR TITLE
Fixes for initialization of sync status

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -195,12 +195,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     private boolean serverStarted = false;
 
     /**
-     * Indicates the replication status has been set as NOT_STARTED.
-     * It should be reset if its role changes to Standby.
-     */
-    private boolean statusFlag = false;
-
-    /**
      * This is the listener to the replication event table shared by the nodes in the cluster.
      * When a non-leader node is called to do the enforcedSnapshotSync, it will write the event to
      * the shared event-table and the leader node will be notified to do the work.
@@ -497,7 +491,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 }
                 replicationManager.setTopology(topologyDescriptor);
                 replicationManager.start();
-                updateReplicationStatus();
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
                 processCountOnLockAcquire(localClusterDescriptor.getRole());
                 break;
@@ -506,7 +499,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 log.info("Start as Sink (receiver)");
                 interClusterReplicationService.getLogReplicationServer().getSinkManager().reset();
                 interClusterReplicationService.getLogReplicationServer().setLeadership(true);
-                statusFlag = false;
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
                 processCountOnLockAcquire(localClusterDescriptor.getRole());
                 break;
@@ -901,13 +893,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
     private void recordLockRelease() {
         lockAcquireSample.ifPresent(LongTaskTimer.Sample::stop);
-    }
-
-    private void updateReplicationStatus() {
-        if (!statusFlag) {
-            replicationManager.updateStatusAsNotStarted();
-            statusFlag = true;
-        }
     }
 
     private void setupLocalNodeId() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -195,12 +195,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     private boolean serverStarted = false;
 
     /**
-     * Indicates the replication status has been set as NOT_STARTED.
-     * It should be reset if its role changes to Standby.
-     */
-    private boolean statusFlag = false;
-
-    /**
      * This is the listener to the replication event table shared by the nodes in the cluster.
      * When a non-leader node is called to do the enforcedSnapshotSync, it will write the event to
      * the shared event-table and the leader node will be notified to do the work.
@@ -348,7 +342,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
             addDefaultReplicationStatus();
         } else if (localClusterDescriptor.getRole().equals(ClusterRole.STANDBY)) {
             logReplicationServerHandler.setStandby(true);
-            statusFlag = false;
         }
 
         interClusterReplicationService = new CorfuInterClusterReplicationServerNode(
@@ -623,6 +616,10 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
             // Consider the case of async configuration changes, non-lead nodes could overwrite
             // the replication status if it has already completed by the lead node
             resetReplicationStatusTableWithRetry();
+            // In the event of Standby -> Active we should add the default replication values
+            if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
+                addDefaultReplicationStatus();
+            }
         }
 
         log.debug("Persist new topologyConfigId {}, cluster id={}, role={}", topologyDescriptor.getTopologyConfigId(),
@@ -907,12 +904,9 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     }
 
     private void addDefaultReplicationStatus() {
-        if (!statusFlag) {
-            // Add default entry to Replication Status Table
-            for (ClusterDescriptor clusterDescriptor : topologyDescriptor.getStandbyClusters().values()) {
-                logReplicationMetadataManager.initializeReplicationStatusTable(clusterDescriptor.clusterId);
-            }
-            statusFlag = true;
+        // Add default entry to Replication Status Table
+        for (ClusterDescriptor clusterDescriptor : topologyDescriptor.getStandbyClusters().values()) {
+            logReplicationMetadataManager.initializeReplicationStatusTable(clusterDescriptor.clusterId);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.*;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -230,6 +230,8 @@ public class CorfuReplicationManager {
                 topology.addStandbyCluster(clusterInfo);
                 startLogReplicationRuntime(clusterInfo);
             }
+            // Initialize default replication status values for the new standby
+            metadataManager.initializeReplicationStatusTable(clusterId);
         }
 
         // The connection id or other transportation plugin's info could've changed for

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.*;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
@@ -58,8 +59,6 @@ public class CorfuReplicationManager {
         this.corfuRuntime = corfuRuntime;
         this.localNodeDescriptor = localNodeDescriptor;
         this.replicationConfigManager = replicationConfigManager;
-        // Add default entry to Replication Status Table
-        metadataManager.initializeReplicationStatusTable();
     }
 
     /**
@@ -256,5 +255,17 @@ public class CorfuReplicationManager {
             standbyRuntime.getSourceManager().stopLogReplication();
             standbyRuntime.getSourceManager().startForcedSnapshotSync(event.getEventId());
         }
+    }
+
+    /**
+     * Initialize Replication Status as NOT_STARTED.
+     * Should be called only once in an active lifecycle.
+     */
+    public void initializeStatusAsNotStarted() {
+        runtimeToRemoteCluster.values().forEach(corfuLogReplicationRuntime ->
+                corfuLogReplicationRuntime
+                        .getSourceManager()
+                        .getAckReader()
+                        .markInitialSyncStatus());
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -255,16 +255,4 @@ public class CorfuReplicationManager {
             standbyRuntime.getSourceManager().startForcedSnapshotSync(event.getEventId());
         }
     }
-
-    /**
-     * Initialize Replication Status as NOT_STARTED.
-     * Should be called only once in an active lifecycle.
-     */
-    public void initializeStatusAsNotStarted() {
-        runtimeToRemoteCluster.values().forEach(corfuLogReplicationRuntime ->
-                corfuLogReplicationRuntime
-                        .getSourceManager()
-                        .getAckReader()
-                        .markInitialSyncStatus());
-    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -59,6 +59,8 @@ public class CorfuReplicationManager {
         this.corfuRuntime = corfuRuntime;
         this.localNodeDescriptor = localNodeDescriptor;
         this.replicationConfigManager = replicationConfigManager;
+        // Add default entry to Replication Status Table
+        metadataManager.initializeReplicationStatusTable();
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.SyncStatus;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
@@ -257,17 +256,5 @@ public class CorfuReplicationManager {
             standbyRuntime.getSourceManager().stopLogReplication();
             standbyRuntime.getSourceManager().startForcedSnapshotSync(event.getEventId());
         }
-    }
-
-    /**
-     * Update Replication Status as NOT_STARTED.
-     * Should be called only once in an active lifecycle.
-     */
-    public void updateStatusAsNotStarted() {
-        runtimeToRemoteCluster.values().forEach(corfuLogReplicationRuntime ->
-                corfuLogReplicationRuntime
-                        .getSourceManager()
-                        .getAckReader()
-                        .markSyncStatus(SyncStatus.NOT_STARTED));
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -399,7 +399,7 @@ public class LogReplicationAckReader {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     lock.lock();
-                    metadataManager.updateSyncStatus(remoteClusterId, SyncType.SNAPSHOT, SyncStatus.ONGOING);
+                    metadataManager.updateSyncStatus(remoteClusterId, lastSyncType, SyncStatus.ONGOING);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to markSnapshotSyncInfoOngoing for cluster {}.", remoteClusterId, tae);
                     throw new RetryNeededException();
@@ -473,7 +473,7 @@ public class LogReplicationAckReader {
                         long entriesToSend = calculateRemainingEntriesToSend(lastAckedTimestamp);
                         metadataManager.updateRemainingEntriesToSend(remoteClusterId, entriesToSend, lastSyncType);
                     } catch (TransactionAbortedException tae) {
-                        log.error("Error while attempting to set replication status for " +
+                        log.error("Error while attempting to set remaining entries for " +
                                         "remote cluster {} with lastSyncType {}.",
                                 remoteClusterId, lastSyncType, tae);
                         throw new RetryNeededException();
@@ -484,7 +484,7 @@ public class LogReplicationAckReader {
                     return null;
                 }).run();
             } catch (InterruptedException e) {
-                log.error("Unrecoverable exception when attempting to setReplicationStatusTable", e);
+                log.error("Unrecoverable exception when attempting to updateRemainingEntriesToSend", e);
                 throw new UnrecoverableCorfuInterruptedError(e);
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -52,7 +52,7 @@ public class LogReplicationAckReader {
     // Last ack'd timestamp from Receiver
     private long lastAckedTimestamp = Address.NON_ADDRESS;
 
-    // Sync Type for which last Ack was received, it is initialized where the timestamp polling task is created.
+    // Sync Type for which last Ack was received, it is initialized when setSyncType is called
     private SyncType lastSyncType = null;
 
     private LogEntryReader logEntryReader;
@@ -442,9 +442,8 @@ public class LogReplicationAckReader {
     /**
      * Start periodic replication status update task (completion percentage)
      */
-    public void startSyncStatusUpdatePeriodicTask(SyncType syncType) {
+    public void startSyncStatusUpdatePeriodicTask() {
         log.info("Start sync status update periodic task");
-        lastSyncType = syncType;
         lastAckedTsPoller = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("ack-timestamp-reader").build());
         lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0, ACKED_TS_READ_INTERVAL_SECONDS,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -439,31 +439,6 @@ public class LogReplicationAckReader {
         }
     }
 
-    // Set the initial sync status for the cluster as NOT_STARTED
-    public void markInitialSyncStatus() {
-        try {
-            IRetry.build(IntervalRetry.class, () -> {
-                try {
-                    lock.lock();
-                    metadataManager.initializeReplicationStatusTable(remoteClusterId);
-                } catch (TransactionAbortedException tae) {
-                    log.error("Error while attempting to initialize sync status.", tae);
-                    throw new RetryNeededException();
-                } finally {
-                    lock.unlock();
-                }
-
-                if (log.isTraceEnabled()) {
-                    log.trace("Initializing sync status succeeds.");
-                }
-                return null;
-            }).run();
-        } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to initialize sync status.", e);
-            throw new UnrecoverableCorfuInterruptedError(e);
-        }
-    }
-
     /**
      * Start periodic replication status update task (completion percentage)
      */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -439,6 +439,31 @@ public class LogReplicationAckReader {
         }
     }
 
+    // Set the initial sync status for the cluster as NOT_STARTED
+    public void markInitialSyncStatus() {
+        try {
+            IRetry.build(IntervalRetry.class, () -> {
+                try {
+                    lock.lock();
+                    metadataManager.initializeReplicationStatusTable(remoteClusterId);
+                } catch (TransactionAbortedException tae) {
+                    log.error("Error while attempting to initialize sync status.", tae);
+                    throw new RetryNeededException();
+                } finally {
+                    lock.unlock();
+                }
+
+                if (log.isTraceEnabled()) {
+                    log.trace("Initializing sync status succeeds.");
+                }
+                return null;
+            }).run();
+        } catch (InterruptedException e) {
+            log.error("Unrecoverable exception when attempting to initialize sync status.", e);
+            throw new UnrecoverableCorfuInterruptedError(e);
+        }
+    }
+
     /**
      * Start periodic replication status update task (completion percentage)
      */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -470,6 +470,10 @@ public class LogReplicationAckReader {
                 IRetry.build(IntervalRetry.class, () -> {
                     try {
                         lock.lock();
+                        if (lastSyncType == null) {
+                            log.info("lastSyncType is null before polling task run");
+                            return null;
+                        }
                         long entriesToSend = calculateRemainingEntriesToSend(lastAckedTimestamp);
                         metadataManager.updateRemainingEntriesToSend(remoteClusterId, entriesToSend, lastSyncType);
                     } catch (TransactionAbortedException tae) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -153,9 +153,7 @@ public class InSnapshotSyncState implements LogReplicationState {
         try {
             // If the transition is to itself, the snapshot sync is continuing, no need to reset the sender
             if (from != this) {
-                if (from.getType().equals(LogReplicationStateType.INITIALIZED)) {
-                    fsm.getAckReader().setSyncType(SyncType.SNAPSHOT);
-                }
+                fsm.getAckReader().setSyncType(SyncType.SNAPSHOT);
                 snapshotSender.reset();
                 fsm.getAckReader().markSnapshotSyncInfoOngoing(forcedSnapshotSync, transitionEventId);
                 snapshotSyncTransferTimerSample = MeterRegistryProvider.getInstance().map(Timer::start);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.SyncStatus;
 import org.corfudb.infrastructure.logreplication.replication.send.SnapshotSender;
 
@@ -152,6 +153,9 @@ public class InSnapshotSyncState implements LogReplicationState {
         try {
             // If the transition is to itself, the snapshot sync is continuing, no need to reset the sender
             if (from != this) {
+                if (from.getType().equals(LogReplicationStateType.INITIALIZED)) {
+                    fsm.getAckReader().setSyncType(SyncType.SNAPSHOT);
+                }
                 snapshotSender.reset();
                 fsm.getAckReader().markSnapshotSyncInfoOngoing(forcedSnapshotSync, transitionEventId);
                 snapshotSyncTransferTimerSample = MeterRegistryProvider.getInstance().map(Timer::start);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -2,7 +2,6 @@ package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
 
 /**
  * This class represents the Init state of the Log Replication State Machine.
@@ -78,14 +77,6 @@ public class InitializedState implements LogReplicationState {
 
     @Override
     public void onExit(LogReplicationState to) {
-        LogReplicationStateType type = to.getType();
-
-        if (type.equals(LogReplicationStateType.IN_SNAPSHOT_SYNC) || type.equals(LogReplicationStateType.WAIT_SNAPSHOT_APPLY)) {
-            fsm.getAckReader().setSyncType(SyncType.SNAPSHOT);
-        } else if (type.equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC)) {
-            fsm.getAckReader().setSyncType(SyncType.LOG_ENTRY);
-        }
-
         if (!to.equals(this) && !to.getType().equals(LogReplicationStateType.ERROR)) {
             fsm.getAckReader().startSyncStatusUpdatePeriodicTask();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -81,17 +81,8 @@ public class InitializedState implements LogReplicationState {
 
     @Override
     public void onExit(LogReplicationState to) {
-        LogReplicationStateType type = to.getType();
-        SyncType toSyncType = null;
-
-        if (type.equals(LogReplicationStateType.IN_SNAPSHOT_SYNC) || type.equals(LogReplicationStateType.WAIT_SNAPSHOT_APPLY)) {
-            toSyncType = SyncType.SNAPSHOT;
-        } else if (type.equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC)) {
-            toSyncType = SyncType.LOG_ENTRY;
-        }
-
         if (to != this || to.getType() != LogReplicationStateType.ERROR) {
-            fsm.getAckReader().startSyncStatusUpdatePeriodicTask(toSyncType);
+            fsm.getAckReader().startSyncStatusUpdatePeriodicTask();
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -86,7 +86,7 @@ public class InitializedState implements LogReplicationState {
             fsm.getAckReader().setSyncType(SyncType.LOG_ENTRY);
         }
 
-        if (to != this || to.getType() != LogReplicationStateType.ERROR) {
+        if (!to.equals(this) && !to.getType().equals(LogReplicationStateType.ERROR)) {
             fsm.getAckReader().startSyncStatusUpdatePeriodicTask();
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.infrastructure.logreplication.DataSender;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
@@ -156,6 +157,7 @@ public class WaitSnapshotApplyState implements LogReplicationState {
     public void onEntry(LogReplicationState from) {
         log.info("OnEntry :: wait snapshot apply state");
         if (from.getType().equals(LogReplicationStateType.INITIALIZED)) {
+            fsm.getAckReader().setSyncType(SyncType.SNAPSHOT);
             stopSnapshotApply.set(false);
             fsm.getAckReader().markSnapshotSyncInfoOngoing();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -582,7 +582,7 @@ public class LogReplicationMetadataManager {
             CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> entry =
                     txn.getRecord(replicationStatusTable, key);
 
-            ReplicationStatusVal previous  = entry.getPayload();
+            ReplicationStatusVal previous = entry.getPayload();
             SnapshotSyncInfo previousSnapshotSyncInfo = previous.getSnapshotSyncInfo();
 
             if (type == SyncType.LOG_ENTRY && (previous.getStatus().equals(SyncStatus.NOT_STARTED)

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -110,6 +110,28 @@ public class LogReplicationMetadataManager {
         setupTopologyConfigId(topologyConfigId);
     }
 
+    public void initializeReplicationStatusTable() {
+        ReplicationStatusKey replicationStatusKey = ReplicationStatusKey.newBuilder()
+                .setClusterId(localClusterId)
+                .build();
+
+        ReplicationStatusVal defaultSourceStatus = ReplicationStatusVal.newBuilder()
+                .setStatus(SyncStatus.NOT_STARTED)
+                .setRemainingEntriesToSend(-1L)
+                .setSnapshotSyncInfo(SnapshotSyncInfo.newBuilder()
+                        .setStatus(SyncStatus.NOT_STARTED)
+                        .build())
+                .build();
+
+        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+            log.debug("Adding default entry on source to Replication Status Table");
+            txn.putRecord(replicationStatusTable, replicationStatusKey, defaultSourceStatus, null);
+            txn.commit();
+        } catch (TransactionAbortedException e) {
+            log.error("Exception when adding default entry to Replication Status Table", e);
+        }
+    }
+
     public TxnContext getTxnContext() {
         return corfuStore.txn(NAMESPACE);
     }
@@ -546,8 +568,7 @@ public class LogReplicationMetadataManager {
     }
 
     /**
-     * Set replication status table.
-     * If the current sync type is log entry sync, keep Snapshot Sync Info.
+     * Updates the number of remaining entries.
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
@@ -555,83 +576,40 @@ public class LogReplicationMetadataManager {
      * @param remainingEntries num of remaining entries to send
      * @param type sync type
      */
-    public void setReplicationStatusTable(String clusterId, long remainingEntries, SyncType type) {
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
-        SnapshotSyncInfo snapshotStatus = null;
-        ReplicationStatusVal current;
-        ReplicationStatusVal previous = null;
-
+    public void updateRemainingEntriesToSend(String clusterId, long remainingEntries, SyncType type) {
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-            CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> record = txn.getRecord(replicationStatusTable, key);
-            if (record.getPayload() != null) {
-                previous = record.getPayload();
-                snapshotStatus = previous.getSnapshotSyncInfo();
-            }
-            txn.commit();
-        }
+            ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
+            CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> entry =
+                    txn.getRecord(replicationStatusTable, key);
 
-        if (type == SyncType.LOG_ENTRY) {
-            if (previous != null &&
-                    (previous.getStatus().equals(SyncStatus.NOT_STARTED)
-                            || snapshotStatus.getStatus().equals(SyncStatus.STOPPED))) {
-                log.info("syncStatusPoller :: skip replication status update, log entry replication is {}", previous.getStatus());
+            ReplicationStatusVal previous  = entry.getPayload();
+            SnapshotSyncInfo previousSnapshotSyncInfo = previous.getSnapshotSyncInfo();
+
+            if (type == SyncType.LOG_ENTRY && (previous.getStatus().equals(SyncStatus.NOT_STARTED)
+                    || previousSnapshotSyncInfo.getStatus().equals(SyncStatus.STOPPED))) {
                 // Skip update of sync status, it will be updated once replication is resumed or started
+                log.info("syncStatusPoller :: skip replication status update, log entry replication is {}",
+                        previous.getStatus());
+                txn.commit();
+                return;
+            } else if (type == SyncType.SNAPSHOT && (previousSnapshotSyncInfo.getStatus().equals(SyncStatus.NOT_STARTED)
+                    || previousSnapshotSyncInfo.getStatus().equals(SyncStatus.STOPPED))) {
+                // Skip update of sync status, it will be updated once replication is resumed or started
+                log.info("syncStatusPoller :: skip replication status update, snapshot sync is {}",
+                        previousSnapshotSyncInfo.getStatus());
+                txn.commit();
                 return;
             }
 
-            if (snapshotStatus == null){
-                log.warn("syncStatusPoller [logEntry]:: previous snapshot status is not present for cluster: {}", clusterId);
-                snapshotStatus = SnapshotSyncInfo.newBuilder().build();
-            }
-
-            current = ReplicationStatusVal.newBuilder()
+            ReplicationStatusVal current = previous.toBuilder()
                     .setRemainingEntriesToSend(remainingEntries)
-                    .setSyncType(type)
-                    .setStatus(SyncStatus.ONGOING)
-                    .setSnapshotSyncInfo(snapshotStatus)
                     .build();
 
-            try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-                txn.putRecord(replicationStatusTable, key, current, null);
-                txn.commit();
-            }
-            
-            log.debug("syncStatusPoller :: Log Entry status set to ONGOING, clusterId: {}, remainingEntries: {}, " +
-                            "snapshotSyncInfo: {}", clusterId, remainingEntries, snapshotStatus);
-        } else if (type == SyncType.SNAPSHOT) {
+            txn.putRecord(replicationStatusTable, key, current, null);
+            txn.commit();
 
-            SnapshotSyncInfo currentSnapshotSyncInfo;
-            if (snapshotStatus == null){
-                log.warn("syncStatusPoller [snapshot] :: previous status is not present for cluster: {}", clusterId);
-                currentSnapshotSyncInfo = SnapshotSyncInfo.newBuilder().build();
-            } else {
-
-                if (snapshotStatus.getStatus().equals(SyncStatus.NOT_STARTED)
-                        || snapshotStatus.getStatus().equals(SyncStatus.STOPPED)) {
-                    // Skip update of sync status, it will be updated once replication is resumed or started
-                    log.info("syncStatusPoller :: skip replication status update, snapshot sync is {}", snapshotStatus);
-                    return;
-                }
-
-                currentSnapshotSyncInfo = snapshotStatus.toBuilder()
-                        .setStatus(SyncStatus.ONGOING)
-                        .build();
-            }
-
-            current = ReplicationStatusVal.newBuilder()
-                    .setRemainingEntriesToSend(remainingEntries)
-                    .setSyncType(type)
-                    .setStatus(SyncStatus.ONGOING)
-                    .setSnapshotSyncInfo(currentSnapshotSyncInfo)
-                    .build();
-
-            try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-                txn.putRecord(replicationStatusTable, key, current, null);
-                txn.commit();
-            }
-
-            log.debug("syncStatusPoller :: sync status for {} set to ONGOING, clusterId: {}, remainingEntries: {}",
-                    type, clusterId, remainingEntries);
+            log.debug("syncStatusPoller :: remaining entries updated for {}, clusterId: {}, remainingEntries: {}" +
+                    "snapshotSyncInfo: {}", type, clusterId, remainingEntries, previousSnapshotSyncInfo);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -110,9 +110,9 @@ public class LogReplicationMetadataManager {
         setupTopologyConfigId(topologyConfigId);
     }
 
-    public void initializeReplicationStatusTable() {
+    public void initializeReplicationStatusTable(String remoteClusterId) {
         ReplicationStatusKey replicationStatusKey = ReplicationStatusKey.newBuilder()
-                .setClusterId(localClusterId)
+                .setClusterId(remoteClusterId)
                 .build();
 
         ReplicationStatusVal defaultSourceStatus = ReplicationStatusVal.newBuilder()

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -600,18 +600,11 @@ public class LogReplicationMetadataManager {
             ReplicationStatusVal previous = entry.getPayload();
             SnapshotSyncInfo previousSnapshotSyncInfo = previous.getSnapshotSyncInfo();
 
-            if (type == SyncType.LOG_ENTRY && (previous.getStatus().equals(SyncStatus.NOT_STARTED)
-                    || previousSnapshotSyncInfo.getStatus().equals(SyncStatus.STOPPED))) {
+            if ((previous.getStatus().equals(SyncStatus.NOT_STARTED) && previousSnapshotSyncInfo.getStatus().equals(SyncStatus.NOT_STARTED))
+                    || (previous.getStatus().equals(SyncStatus.STOPPED) || previousSnapshotSyncInfo.getStatus().equals(SyncStatus.STOPPED))) {
                 // Skip update of sync status, it will be updated once replication is resumed or started
-                log.info("syncStatusPoller :: skip replication status update, log entry replication is {}",
+                log.info("syncStatusPoller :: skip remaining entries update, replication status is {}",
                         previous.getStatus());
-                txn.commit();
-                return;
-            } else if (type == SyncType.SNAPSHOT && (previousSnapshotSyncInfo.getStatus().equals(SyncStatus.NOT_STARTED)
-                    || previousSnapshotSyncInfo.getStatus().equals(SyncStatus.STOPPED))) {
-                // Skip update of sync status, it will be updated once replication is resumed or started
-                log.info("syncStatusPoller :: skip replication status update, snapshot sync is {}",
-                        previousSnapshotSyncInfo.getStatus());
                 txn.commit();
                 return;
             }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -203,7 +203,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
             currentReplicationVal = txn.getRecord(statusTable, currentReplicationKey).getPayload();
         }
 
-        // Default sync value is null so current syncType should not be set.
+        // Default sync value is null so current syncType should not be set and default to SNAPSHOT.
         Assert.assertFalse(currentReplicationVal.hasField(ReplicationStatusVal.getDescriptor().findFieldByName("syncType")));
 
         // Current SyncStatus for ReplicationInfo and SnapshotSyncInfo should be NOT_STARTED
@@ -221,9 +221,6 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Set<SyncType> actualSyncTypes = new HashSet<>();
         SyncStatus actualSyncStatus;
         SyncStatus actualSnapshotInfoSyncStatus;
-
-        int expectedNumEntries = 1;
-        Assert.assertEquals(expectedNumEntries, streamListener.getEntries().size());
 
         ArrayList<CorfuStreamEntries> streamEntries = streamListener.getEntries();
         ReplicationStatusVal replicationStatusVal = (ReplicationStatusVal)
@@ -272,7 +269,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
             currentReplicationVal = txn.getRecord(statusTable, currentReplicationKey).getPayload();
         }
-        // Default sync value is null so current syncType should not be set.
+
+        // Default sync value is null so current syncType should not be set and default to SNAPSHOT.
         Assert.assertFalse(currentReplicationVal.hasField(ReplicationStatusVal.getDescriptor().findFieldByName("syncType")));
 
         // Current SyncStatus for ReplicationInfo and SnapshotSyncInfo should be NOT_STARTED
@@ -290,9 +288,6 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Set<SyncType> actualSyncTypes = new HashSet<>();
         SyncStatus actualSyncStatus;
         SyncStatus actualSnapshotInfoSyncStatus;
-
-        int expectedNumEntries = 1;
-        Assert.assertEquals(expectedNumEntries, streamListener.getEntries().size());
 
         ArrayList<CorfuStreamEntries> streamEntries = streamListener.getEntries();
         ReplicationStatusVal replicationStatusVal = (ReplicationStatusVal)
@@ -349,9 +344,6 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Set<SyncStatus> actualSyncStatus = new HashSet<>();
         Set<SyncStatus> actualSnapshotInfoSyncStatus = new HashSet<>();
 
-        int expectedNumEntries = 3;
-        Assert.assertEquals(expectedNumEntries, streamListener.getEntries().size());
-
         Iterator<CorfuStreamEntries> entriesIterator = streamListener.getEntries().iterator();
         while (entriesIterator.hasNext()) {
             for (List<CorfuStreamEntry> entry : entriesIterator.next().getEntries().values()) {
@@ -404,9 +396,6 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Set<SyncType> actualSyncTypes = new HashSet<>();
         Set<SyncStatus> actualSyncStatus = new HashSet<>();
         Set<SyncStatus> actualSnapshotInfoSyncStatus = new HashSet<>();
-
-        int expectedNumEntries = 2;
-        Assert.assertEquals(expectedNumEntries, streamListener.getEntries().size());
 
         Iterator<CorfuStreamEntries> entriesIterator = streamListener.getEntries().iterator();
         while (entriesIterator.hasNext()) {
@@ -897,9 +886,11 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         }
 
         public void onNext(CorfuStreamEntries results) {
-            entries.add(results);
-            for (int i = 0; i < results.getEntries().size(); i++) {
-                countDownLatch.countDown();
+            if (countDownLatch.getCount() > 0) {
+                entries.add(results);
+                for (int i = 0; i < results.getEntries().size(); i++) {
+                    countDownLatch.countDown();
+                }
             }
         }
 

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -648,7 +648,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 break;
         }
 
-        metadataManager.initializeReplicationStatusTable();
+        // Manually initialize the replication status table
+        metadataManager.initializeReplicationStatusTable(TEST_LOCAL_CLUSTER_ID);
+
         ackReader = new LogReplicationAckReader(metadataManager, config, runtime, TEST_LOCAL_CLUSTER_ID);
         fsm = new LogReplicationFSM(runtime, snapshotReader, dataSender, logEntryReader,
                 new DefaultReadProcessor(runtime), config, new ClusterDescriptor("Cluster-Local",

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -6,18 +6,30 @@ import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEF
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_NUM_MSG_PER_BATCH;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_DATA_MSG_SIZE_SUPPORTED;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_CACHE_NUM_ENTRIES;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STATUS_STREAM_TAG;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.NAMESPACE;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_STATUS_TABLE;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.compression.Codec;
 import org.corfudb.common.util.ObservableValue;
@@ -47,13 +59,21 @@ import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManag
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusKey;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.SyncStatus;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
 import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.TableRegistry;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -153,6 +173,128 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // Next transition might not be to INITIALIZED, as IN_LOG_ENTRY_SYNC state might have enqueued
         // a continuation before the stop is enqueued.
         transition(LogReplicationEventType.REPLICATION_STOP, LogReplicationStateType.INITIALIZED, true);
+    }
+
+    /**
+     * Verify the lastSyncType flag is being initialized properly and SnapshotSyncInfo
+     * reflects accurate sync type for snapshot sync.
+     *
+     */
+    @Test
+    public void testSyncStatusUpdatesForSnapshotOnInit() throws Exception {
+        final int updateToStatusTableFromOnEntry = 1;
+        initLogReplicationFSM(ReaderImplementation.EMPTY);
+
+        final Table<ReplicationStatusKey, ReplicationStatusVal, Message> statusTable =
+                this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE);
+
+        CountDownLatch statusTableLatch = new CountDownLatch(updateToStatusTableFromOnEntry);
+        TestStatusTableStreamListener streamListener = new TestStatusTableStreamListener(statusTableLatch);
+        corfuStore.subscribeListener(streamListener, NAMESPACE, LR_STATUS_STREAM_TAG);
+
+        // Initial state: Initialized
+        LogReplicationState initState = fsm.getState();
+        assertThat(initState.getType()).isEqualTo(LogReplicationStateType.INITIALIZED);
+
+        transitionAvailable.acquire();
+
+        ReplicationStatusVal currentReplicationVal = statusTable.entryStream().findAny().get().getPayload();
+
+        // Default sync value is null so current syncType should not be set.
+        Assert.assertFalse(currentReplicationVal.hasField(ReplicationStatusVal.getDescriptor().findFieldByName("syncType")));
+
+        // Current SyncStatus for ReplicationInfo and SnapshotSyncInfo should be NOT_STARTED
+        Assert.assertEquals(SyncStatus.NOT_STARTED, currentReplicationVal.getStatus());
+        Assert.assertEquals(SyncStatus.NOT_STARTED, currentReplicationVal.getSnapshotSyncInfo().getStatus());
+
+        // Transition #1: SNAPSHOT Sync Start
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC);
+
+        // Await for update to status table from entry of InSnapshotSyncState
+        statusTableLatch.await();
+        corfuStore.unsubscribeListener(streamListener);
+
+        Set<SyncType> expectedSyncTypes = new HashSet<>(
+                Collections.singletonList(SyncType.SNAPSHOT));
+        Set<SyncType> actualSyncTypes = new HashSet<>();
+        List<SyncStatus> actualSyncStatus = new ArrayList<>();
+
+        Iterator<CorfuStreamEntries> entriesIterator = streamListener.getEntries().iterator();
+        while (entriesIterator.hasNext()) {
+            for (List<CorfuStreamEntry> entry : entriesIterator.next().getEntries().values()) {
+                ReplicationStatusVal status = (ReplicationStatusVal) entry.get(0).getPayload();
+                actualSyncTypes.add(status.getSyncType());
+                actualSyncStatus.add(status.getSnapshotSyncInfo().getStatus());
+            }
+        }
+
+        // Status starts as NOT_STARTED set at the creation of the metadata manager,
+        // and then gets updated to ONGOING in InSnapshotSyncState
+        SyncStatus tailStatus = SyncStatus.ONGOING;
+
+        Assert.assertEquals(expectedSyncTypes, actualSyncTypes);
+        Assert.assertEquals(tailStatus, actualSyncStatus.get(actualSyncStatus.size() - 1));
+    }
+
+    /**
+     * Verify the lastSyncType flag is being initialized properly and SnapshotSyncInfo
+     * reflects accurate sync type for log entry sync.
+     *
+     */
+    @Test
+    public void testSyncStatusUpdatesForLogEntryOnInit() throws Exception {
+        final int updateToStatusTableFromOnEntry = 1;
+        initLogReplicationFSM(ReaderImplementation.EMPTY);
+
+        final Table<ReplicationStatusKey, ReplicationStatusVal, Message> statusTable =
+                this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE);
+
+        CountDownLatch statusTableLatch = new CountDownLatch(updateToStatusTableFromOnEntry);
+        TestStatusTableStreamListener streamListener = new TestStatusTableStreamListener(statusTableLatch);
+        corfuStore.subscribeListener(streamListener, NAMESPACE, LR_STATUS_STREAM_TAG);
+
+        // Initial state: Initialized
+        LogReplicationState initState = fsm.getState();
+        assertThat(initState.getType()).isEqualTo(LogReplicationStateType.INITIALIZED);
+
+        transitionAvailable.acquire();
+
+        ReplicationStatusVal currentReplicationVal = statusTable.entryStream().findAny().get().getPayload();
+
+        // Default sync value is null so current syncType should not be set.
+        Assert.assertFalse(currentReplicationVal.hasField(ReplicationStatusVal.getDescriptor().findFieldByName("syncType")));
+
+        // Current SyncStatus for ReplicationInfo and SnapshotSyncInfo should be NOT_STARTED
+        Assert.assertEquals(SyncStatus.NOT_STARTED, currentReplicationVal.getStatus());
+        Assert.assertEquals(SyncStatus.NOT_STARTED, currentReplicationVal.getSnapshotSyncInfo().getStatus());
+
+        // Transition #1: Log Entry Sync Start
+        transition(LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST, LogReplicationStateType.IN_LOG_ENTRY_SYNC);
+
+        // Await for update to status table from entry of InLogEntrySync
+        statusTableLatch.await();
+        corfuStore.unsubscribeListener(streamListener);
+
+        Set<SyncType> expectedSyncTypes = new HashSet<>(
+                Collections.singletonList(SyncType.LOG_ENTRY));
+        Set<SyncType> actualSyncTypes = new HashSet<>();
+        List<SyncStatus> actualSyncStatus = new ArrayList<>();
+
+        Iterator<CorfuStreamEntries> entriesIterator = streamListener.getEntries().iterator();
+        while (entriesIterator.hasNext()) {
+            for (List<CorfuStreamEntry> entry : entriesIterator.next().getEntries().values()) {
+                ReplicationStatusVal status = (ReplicationStatusVal) entry.get(0).getPayload();
+                actualSyncTypes.add(status.getSyncType());
+                actualSyncStatus.add(status.getSnapshotSyncInfo().getStatus());
+            }
+        }
+
+        // Status starts as NOT_STARTED set at the creation of the metadata manager,
+        // and then gets updated to COMPLETED in InLogEntrySyncState
+        SyncStatus tailStatus = SyncStatus.COMPLETED;
+
+        Assert.assertEquals(expectedSyncTypes, actualSyncTypes);
+        Assert.assertEquals(tailStatus, actualSyncStatus.get(actualSyncStatus.size() - 1));
     }
 
     /**
@@ -506,6 +648,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 break;
         }
 
+        metadataManager.initializeReplicationStatusTable();
         ackReader = new LogReplicationAckReader(metadataManager, config, runtime, TEST_LOCAL_CLUSTER_ID);
         fsm = new LogReplicationFSM(runtime, snapshotReader, dataSender, logEntryReader,
                 new DefaultReadProcessor(runtime), config, new ClusterDescriptor("Cluster-Local",
@@ -604,6 +747,42 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
             // If number of messages in snapshot reaches the expected value force termination of SNAPSHOT_SYNC
             // log.debug("Insert event: " + LogReplicationEventType.REPLICATION_STOP);
             fsm.input(new LogReplicationEvent(LogReplicationEventType.REPLICATION_STOP));
+        }
+    }
+
+    /**
+     * StreamListener for updates to statusTable, utilizes countdown latch to count entries coming
+     * from markSnapshotSyncInfoOngoing and markSnapshotSyncInfoCompleted.
+     *
+     */
+    class TestStatusTableStreamListener implements StreamListener {
+        @Getter
+        CopyOnWriteArrayList<CorfuStreamEntries> entries = new CopyOnWriteArrayList<>();
+
+        @Getter
+        Throwable throwable;
+
+        CountDownLatch countDownLatch;
+
+        public TestStatusTableStreamListener(CountDownLatch countDownLatch) {
+            this.countDownLatch = countDownLatch;
+        }
+
+        public void onNext(CorfuStreamEntries results) {
+            entries.add(results);
+            for (List<CorfuStreamEntry> entry : results.getEntries().values()) {
+                ReplicationStatusVal status = (ReplicationStatusVal) entry.get(0).getPayload();
+                SyncType syncType = status.getSyncType();
+                SyncStatus syncStatus = status.getSnapshotSyncInfo().getStatus();
+                if (syncType == SyncType.LOG_ENTRY && syncStatus == SyncStatus.COMPLETED ||
+                        syncType == SyncType.SNAPSHOT && syncStatus == SyncStatus.ONGOING) {
+                    countDownLatch.countDown();
+                }
+            }
+        }
+
+        public void onError(Throwable throwable) {
+            this.throwable = throwable;
         }
     }
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -453,7 +453,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                 .setClusterId(REMOTE_CLUSTER_ID)
                 .build();
 
-        SyncStatus syncStatus = null, previousSnapshotSyncStatus = null;
+        SyncStatus syncStatus = null;
+        SyncStatus previousSnapshotSyncStatus = null;
 
         Table<ReplicationStatusKey, ReplicationStatusVal, Message> replicationStatusTable =
                 srcCorfuStore.openTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE,

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -36,7 +36,6 @@ import org.corfudb.util.Utils;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -107,9 +106,6 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     static private final int BATCH_SIZE = 4;
 
     static private final int SMALL_MSG_SIZE = 12000;
-
-    private static final Duration WAIT_INTERVAL = Duration.ofSeconds(5);
-    private static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
 
     static private TestConfig testConfig = new TestConfig();
 
@@ -1196,6 +1192,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                                                 boolean injectTxData, TransitionSource function) throws Exception {
 
         logReplicationSourceManager = setupSourceManagerAndObservedValues(waitConditions, function);
+
         // Start Log Entry Sync
         log.info("****** Start Log Entry Sync with src tail " + srcDataRuntime.getAddressSpaceView().getLogTail()
                 + " dst tail " + dstDataRuntime.getAddressSpaceView().getLogTail());

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1,6 +1,5 @@
 package org.corfudb.integration;
 
-import com.google.protobuf.Message;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
@@ -12,26 +11,19 @@ import org.corfudb.infrastructure.logreplication.proto.Sample;
 import org.corfudb.infrastructure.logreplication.proto.Sample.IntValue;
 import org.corfudb.infrastructure.logreplication.proto.Sample.Metadata;
 import org.corfudb.infrastructure.logreplication.proto.Sample.StringKey;
-import org.corfudb.infrastructure.logreplication.replication.LogReplicationAckReader;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourceManager;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationFSM;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationStateType;
 import org.corfudb.infrastructure.logreplication.replication.fsm.ObservableAckMsg;
-import org.corfudb.infrastructure.logreplication.replication.fsm.TestLogEntryReader;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
-import org.corfudb.infrastructure.logreplication.replication.send.logreader.LogEntryReader;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusKey;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.SyncStatus;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.Table;
@@ -41,11 +33,9 @@ import org.corfudb.runtime.proto.service.CorfuMessage;
 
 import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.util.Utils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,7 +51,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.TimeUnit;
 
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,7 +58,6 @@ import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED;
 import static org.corfudb.integration.LogReplicationAbstractIT.checkpointAndTrimCorfuStore;
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
-import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
  * Test the core components of log replication, namely, Snapshot Sync and Log Entry Sync,
@@ -397,83 +385,6 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     }
 
     /* ***************************** LOG REPLICATION IT TESTS ***************************** */
-
-    /**
-     * This test helps to emulate the raceCondition where statusSyncUpdater thread gets
-     * the precedence over the state transition to LOG_ENTRY_SYNC.
-     * A statusSyncUpdater service is run independently without the FSM and
-     * NOT_STARTED status is verified from the replicationStatus table.
-     * @throws Exception
-     */
-    @Test
-    public void testSyncStatusBeforeLogEntrySync() throws Exception {
-        setupEnv();
-        testSyncStatus(SyncType.LOG_ENTRY, SyncStatus.NOT_STARTED, SyncStatus.UNAVAILABLE);
-        cleanEnv();
-    }
-
-    /**
-     * This test helps to emulate the raceCondition where statusSyncUpdater thread gets
-     * the precedence over the state transition to SNAPSHOT_SYNC.
-     * A statusSyncUpdater service is run independently without the FSM and
-     * NOT_STARTED status is verified from the replicationStatus table.
-     * @throws Exception
-     */
-    @Test
-    public void testSyncStatusBeforeSnapshotSync() throws Exception {
-        setupEnv();
-        testSyncStatus(SyncType.SNAPSHOT, SyncStatus.NOT_STARTED, SyncStatus.NOT_STARTED);
-        cleanEnv();
-    }
-
-    private void testSyncStatus(SyncType type, SyncStatus expectedSyncStatus,
-                                SyncStatus expectedPreviousSnapshotSyncStatus)
-            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
-
-        LogReplicationMetadataManager srcMetadataManager = new LogReplicationMetadataManager(srcTestRuntime, 0, ACTIVE_CLUSTER_ID);
-        LogReplicationConfigManager configManager = new LogReplicationConfigManager(srcTestRuntime);
-        LogReplicationConfig config = new LogReplicationConfig(configManager, BATCH_SIZE,
-                SMALL_MSG_SIZE, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
-
-        LogEntryReader logEntryReader = new TestLogEntryReader();
-        LogReplicationAckReader ackReader = new LogReplicationAckReader(srcMetadataManager, config, srcDataRuntime, REMOTE_CLUSTER_ID);
-        ackReader.setLogEntryReader(logEntryReader);
-
-        try {
-            ackReader.setSyncType(type);
-            ackReader.startSyncStatusUpdatePeriodicTask(type);
-            TimeUnit.SECONDS.sleep(WAIT_INTERVAL.getSeconds());
-        } catch (InterruptedException e) {
-            System.out.println("Sleep interrupted: " + e);
-        } finally {
-            ackReader.shutdown();
-        }
-
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder()
-                .setClusterId(REMOTE_CLUSTER_ID)
-                .build();
-
-        SyncStatus syncStatus = null;
-        SyncStatus previousSnapshotSyncStatus = null;
-
-        Table<ReplicationStatusKey, ReplicationStatusVal, Message> replicationStatusTable =
-                srcCorfuStore.openTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE,
-                        ReplicationStatusKey.class, ReplicationStatusVal.class, null,
-                        TableOptions.fromProtoSchema(ReplicationStatusVal.class));
-
-        try (TxnContext txn = srcCorfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> entry =
-                    txn.getRecord(replicationStatusTable, key);
-            if (entry.getPayload() != null) {
-                syncStatus = entry.getPayload().getStatus();
-                previousSnapshotSyncStatus = entry.getPayload().getSnapshotSyncInfo().getStatus();
-            }
-            txn.commit();
-        }
-
-        Assert.assertEquals(expectedSyncStatus, syncStatus);
-        Assert.assertEquals(expectedPreviousSnapshotSyncStatus, previousSnapshotSyncStatus);
-    }
 
     /**
      * This test attempts to perform a snapshot sync and log entry sync through the Log Replication Manager.

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
@@ -309,7 +309,7 @@ public class DeltaStreamTest {
 
         producer.setName("producer");
         producer.start();
-        done.await(1, TimeUnit.SECONDS);
+        done.await();
 
         assertThat(consumed.size()).isEqualTo(numToProduce);
         for (int x = 0; x < numToProduce; x++) {

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
@@ -309,7 +309,7 @@ public class DeltaStreamTest {
 
         producer.setName("producer");
         producer.start();
-        done.await();
+        done.await(1, TimeUnit.SECONDS);
 
         assertThat(consumed.size()).isEqualTo(numToProduce);
         for (int x = 0; x < numToProduce; x++) {


### PR DESCRIPTION
## Overview

Description:

The lastSyncType init value was set to log entry which is not accurate, this change sets the field only after entering the next state. Added initialization of the status table on bootstrap, and modified the TsPollingingTask to only be used to update the remaining number of entries. Also fixes race condition from #3435.

Why should this be merged: 

When transitioning states there exists a window between the exit of InitializedState to the next state where the lastSyncType is marked as LOG_ENTRY regardless of the actual last sync type. This is due to the lastSyncType being set on entry of the next state. In this window any query to lastSyncType is not guaranteed to be accurate. This change adds the logic to set the lastSyncType only after entry to the next state, and initialize the status table during the bootstrap phase so when queried it can properly reflect that replication has not started. With these changes the TsPollingingTask is now only needed to update the remaining number of entires.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
