### PR TITLE
Special LR Stream Listener across namespaces.

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -20,6 +20,10 @@
 *   **logreplication.opaque.count\_per\_message**: Number of opaque entries per message (rate, mean, max).
 *   **logreplication.opaque.count\_total**: Number of overall opaque entries (rate, mean, max).
 *   **logreplication.opaque.count\_valid**: Number of valid opaque entries (rate, mean, max).
+*   **logreplication.subscribe.trim.count**: Number of times a Trimmed Exception was thrown from the MVO layer when subscribing to LogReplication listener.
+*   **logreplication.subscribe.conflict.count**: Number of times a Transaction Aborted Exception was thrown due to conflicting updates when subscribing to LogReplication listener.
+*   **logreplication.subscribe.duration**: Time taken to subscribe the LogReplication listener.
+*   **logreplication.client.fullsync.duration**: Time taken by the client subscribing to LogReplication listener to perform a full sync on its tables.
 
 ### Current metrics collected for Corfu Runtime:
 

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
@@ -1,0 +1,187 @@
+package org.corfudb.runtime;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.LogReplication.ReplicationModel;
+import org.corfudb.runtime.LogReplication.ReplicationStatus;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.TableSchema;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.Address;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+
+/**
+ * This is the interface that a client must subscribe to if it needs to observe and bifurcate the data updates received
+ * on Log Entry and Snapshot Sync.  The client's usecase is that it maintains a 'merged table' which contains data
+ * received through replication and local updates.  Log Replicator does not write to this merged table.  This
+ * listener will observe the writes and apply them to the merged table based on the client implementation.
+ *
+ *
+ * This interface sees ordered updates from :
+ * 1. client-streams from client-Namespace, and,
+ * 2. LrStatusTable from corfuSystem-Namespace.
+ *
+ * The client implementing this interface will only observe the data updates from client streams
+ */
+@Slf4j
+public abstract class LogReplicationListener implements StreamListener {
+
+    // Indicates if a full sync on client tables was performed during subscription.  A full sync will not be
+    // performed if a snapshot sync is ongoing.
+    @Getter
+    private final AtomicBoolean clientFullSyncPending = new AtomicBoolean(false);
+
+    // This variable tracks if a snapshot sync is ongoing
+    @Getter
+    private final AtomicBoolean snapshotSyncInProgress = new AtomicBoolean(false);
+
+    // Timestamp at which the client performed a full sync.  Any updates below this timestamp must be ignored.
+    // At the time of subscription, a full sync cannot be performed if LR Snapshot Sync is in progress.  Full Sync is
+    // performed when this ongoing snapshot sync completes.  The listener, however, can get updates before this full
+    // sync.  So we need to maintain this timestamp and ignore any updates below it.
+    @Getter
+    private final AtomicLong clientFullSyncTimestamp = new AtomicLong(Address.NON_ADDRESS);
+
+    private final CorfuStore corfuStore;
+    private final String namespace;
+
+    /**
+     * Special LogReplication listener which a client creates to receive ordered updates for replicated data.
+     * @param corfuStore Corfu Store used on the client
+     * @param namespace Namespace of the client's tables
+     */
+    public LogReplicationListener(CorfuStore corfuStore, @Nonnull String namespace) {
+        this.corfuStore = corfuStore;
+        this.namespace = namespace;
+    }
+
+    /**
+     * This is an internal method of this abstract listener and not exposed to clients.
+     *
+     * @param results is a map of stream UUID -> list of entries of this stream.
+     */
+    public final void onNext(CorfuStreamEntries results) {
+
+        // If this update came before the client's full sync timestamp, ignore it.
+        if (results.getTimestamp().getSequence() <= clientFullSyncTimestamp.get()) {
+            return;
+        }
+
+        Set<String> tableNames =
+                results.getEntries().keySet().stream().map(schema -> schema.getTableName()).collect(Collectors.toSet());
+
+        if (tableNames.contains(REPLICATION_STATUS_TABLE_NAME)) {
+            Preconditions.checkState(results.getEntries().keySet().size() == 1,
+                "Replication Status Table Update received with other tables");
+            processReplicationStatusUpdate(results);
+            return;
+        }
+
+        // Data Updates
+        if (clientFullSyncPending.get()) {
+            // If the listener started when snapshot sync was ongoing, ignore all data updates until it ends.  When
+            // it ends, the client will perform a full sync and build a consistent state containing these updates.
+            return;
+        }
+
+        if (snapshotSyncInProgress.get()) {
+            processUpdatesInSnapshotSync(results);
+        } else {
+            processUpdatesInLogEntrySync(results);
+        }
+    }
+
+    private void processReplicationStatusUpdate(CorfuStreamEntries results) {
+        Map<TableSchema, List<CorfuStreamEntry>> entries = results.getEntries();
+
+        List<CorfuStreamEntry> replicationStatusTableEntries =
+            entries.entrySet().stream().filter(e -> e.getKey().getTableName().equals(REPLICATION_STATUS_TABLE_NAME))
+            .map(Map.Entry::getValue)
+            .findFirst()
+            .get();
+
+        for (CorfuStreamEntry entry : replicationStatusTableEntries) {
+
+            LogReplicationSession key = (LogReplicationSession)entry.getKey();
+
+            // Only process updates where the operation type == UPDATE and model == Logical Groups
+            if (entry.getOperation() == CorfuStreamEntry.OperationType.UPDATE &&
+                key.getSubscriber().getModel().equals(ReplicationModel.LOGICAL_GROUPS)) {
+                ReplicationStatus status = (ReplicationStatus)entry.getPayload();
+
+                if (status.getSinkStatus().getDataConsistent()) {
+                    // getDataConsistent() == true means that snapshot sync has ended.
+                    if (snapshotSyncInProgress.get()) {
+                        if (clientFullSyncPending.get()) {
+                            // Snapshot sync which was ongoing when the listener was subscribed has ended.  Attempt to
+                            // perform a full sync now.
+                            LogReplicationUtils.attemptClientFullSync(corfuStore, this, namespace);
+                            return;
+                        }
+                        // Process snapshot sync completion in steady state, i.e., client full sync is already complete
+                        snapshotSyncInProgress.set(false);
+                        onSnapshotSyncComplete();
+                    }
+                } else {
+                    // getDataConsistent() == false.  Snapshot sync has started.
+                    snapshotSyncInProgress.set(true);
+                    onSnapshotSyncStart();
+                }
+            }
+        }
+    }
+
+    //      -------- Methods to be implemented on the client/application  ---------------
+
+    /**
+     * Invoked when a snapshot sync start has been detected.
+     */
+    protected abstract void onSnapshotSyncStart();
+
+    /**
+     * Invoked when an ongoing snapshot sync completes
+     */
+    protected abstract void onSnapshotSyncComplete();
+
+    /**
+     * Invoked when data updates are received during a snapshot sync.  These updates will be the writes
+     * received as part of the snapshot sync
+     * @param results Entries received in a single transaction as part of a snapshot sync
+     */
+    protected abstract void processUpdatesInSnapshotSync(CorfuStreamEntries results);
+
+    /**
+     * Invoked when data updates are received as part of a LogEntry Sync.
+     * @param results Entries received in a single transaction as part of a log entry sync
+     */
+    protected abstract void processUpdatesInLogEntrySync(CorfuStreamEntries results);
+
+    /**
+     * Invoked by the Corfu runtime when this listener is being subscribed.  This method should
+     * perform a full-sync on all application tables which the client is interested in merging together.
+     * @param txnContext transaction context in which the operation must be performed
+     */
+    protected abstract void performFullSync(TxnContext txnContext);
+
+    /**
+     * Callback to indicate that an error or exception has occurred while streaming or that the stream is
+     * shutting down. Some exceptions can be handled by restarting the stream (TrimmedException) while
+     * some errors (SystemUnavailableError) are unrecoverable.
+     * To be implemented on the client/application
+     * @param throwable
+     */
+    public abstract void onError(Throwable throwable);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -92,9 +92,7 @@ public final class LogReplicationUtils {
                                 "Subscription could have been attempted before LR startup.  Subscribe the listener and" +
                                 "wait for initial Snapshot Sync", clientListener.getClientName());
                     } else {
-                        // Sharding in Log Replication is done based on a destination.  So for a given replication
-                        // model and client, any Sink node will have a session with only 1 Source node.  Hence, there
-                        // should be only 1 record corresponding to the Logical Group Replication Model and this client
+                        // For a given replication model and client, any Sink node will have a single session.
                         Preconditions.checkState(entries.size() == 1);
                         entry = entries.get(0);
                     }
@@ -106,8 +104,12 @@ public final class LogReplicationUtils {
                         log.info("No Snapshot Sync is in progress.  Request the client to perform a full sync on its " +
                             "tables.");
                         Optional<Timer.Sample> clientFullSyncTimer = MicroMeterUtils.startTimer();
+                        long clientFullSyncStartTime = System.currentTimeMillis();
                         clientListener.performFullSyncAndMerge(txnContext);
+                        long clientFullSyncEndTime = System.currentTimeMillis();
                         MicroMeterUtils.time(clientFullSyncTimer, "logreplication.client.fullsync.duration");
+                        log.info("Client Full Sync and Merge took {} ms",
+                                clientFullSyncEndTime - clientFullSyncStartTime);
                     } else {
                         // Snapshot sync is in progress.  Subscribe without performing a full sync on the tables.
                         log.info("Snapshot Sync is in progress.  Subscribing without performing a full sync on client" +

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -1,12 +1,179 @@
 package org.corfudb.runtime;
 
+import com.google.common.base.Preconditions;
+import com.google.protobuf.Message;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStoreEntry;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.StreamingException;
+import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.LogReplication.ReplicationStatus;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.IntervalRetry;
+import org.corfudb.util.retry.RetryNeededException;
+import javax.annotation.Nonnull;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
 /**
  * LogReplication code resides in the infrastructure package.  Adding a dependency from this package(runtime) to
  * infrastructure introduces a circular dependency.  This class defines LR-specific constants and utility methods
  * required in runtime.  Note that the constants are unique and not duplicated from infrastructure.
  */
+@Slf4j
 public final class LogReplicationUtils {
     public static final String LR_STATUS_STREAM_TAG = "lr_status";
 
     public static final String REPLICATION_STATUS_TABLE_NAME = "LogReplicationStatusSource";
+
+    private LogReplicationUtils() { }
+
+    public static void subscribe(@Nonnull LogReplicationListener clientListener, @Nonnull String namespace,
+                          @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest, int bufferSize,
+                          CorfuStore corfuStore) {
+
+        long subscriptionTimestamp = getSubscriptionTimestamp(corfuStore, namespace, clientListener);
+        corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationListener(
+                clientListener, namespace, streamTag, tablesOfInterest, subscriptionTimestamp, bufferSize);
+        log.info("Client subscription at timestamp {} successful.", subscriptionTimestamp);
+    }
+
+
+    private static long getSubscriptionTimestamp(CorfuStore corfuStore, String namespace,
+                                                 LogReplicationListener clientListener) {
+        Optional<Counter> mvoTrimCounter = MicroMeterUtils.counter("logreplication.subscribe.trim.count");
+        Optional<Counter> conflictCounter = MicroMeterUtils.counter("logreplication.subscribe.conflict.count");
+        Optional<Timer.Sample> subscribeTimer = MicroMeterUtils.startTimer();
+
+        Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable =
+            openReplicationStatusTable(corfuStore);
+
+        try {
+            return IRetry.build(IntervalRetry.class, () -> {
+                try (TxnContext txnContext = corfuStore.txn(namespace)) {
+                    // The transaction is started in the client's namespace and the Replication Status table resides in the
+                    // system namespace.  Corfu Store does not validate the cross-namespace access as long as there are no
+                    // writes on the table in the different namespace.  This hack is required here as we want client full
+                    // sync to happen in the same transaction which checks the status of a snapshot sync so that there is no
+                    // window between the check and full sync.
+                    List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
+                        txnContext.executeQuery(replicationStatusTable,
+                                record -> record.getKey().getSubscriber().getModel()
+                                    .equals(LogReplication.ReplicationModel.LOGICAL_GROUPS));
+
+                    // Sharding in Log Replication is done based on a destination.  So for a given replication model,
+                    // any Sink node will have a session with only 1 Source node.  Hence, there should be only 1
+                    // record corresponding to the Logical Group Replication Model.
+                    Preconditions.checkState(entries.size() == 1);
+                    CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message> entry = entries.get(0);
+
+                    boolean snapshotSyncInProgress = false;
+
+                    if (entry.getPayload().getSinkStatus().getDataConsistent()) {
+                        // No snapshot sync is in progress
+                        log.info("No Snapshot Sync is in progress.  Request the client to perform a full sync on its " +
+                            "tables.");
+                        Optional<Timer.Sample> clientFullSyncTimer = MicroMeterUtils.startTimer();
+                        clientListener.performFullSync(txnContext);
+                        MicroMeterUtils.time(clientFullSyncTimer, "logreplication.client.fullsync.duration");
+                    } else {
+                        // Snapshot sync is in progress.  Subscribe without performing a full sync on the tables.
+                        log.info("Snapshot Sync is in progress.  Subscribing without performing a full sync on client" +
+                            " tables.");
+                        snapshotSyncInProgress = true;
+                    }
+                    txnContext.commit();
+
+                    // Subscribe from the snapshot timestamp of this transaction, i.e., log tail when the transaction started.
+                    // Subscribing from the commit address will result in missed updates which took place between the start
+                    // and end of the transaction because reads in a transaction observe updates only till the snapshot when it
+                    // started.
+                    long subscriptionTimestamp = txnContext.getTxnSequence();
+
+                    // Update the flags and variables on the listener based on whether snapshot sync was in progress.
+                    // This must be done only after the transaction commits.
+                    setListenerParamsForSnapshotSync(clientListener, subscriptionTimestamp, snapshotSyncInProgress);
+
+                    return subscriptionTimestamp;
+                } catch (TransactionAbortedException tae) {
+                    if (tae.getCause() instanceof TrimmedException) {
+                        // If the snapshot version where this transaction started has been evicted from the JVM's MVO
+                        // cache, a trimmed exception is thrown and requires a retry at a later timestamp.
+                        incrementCount(mvoTrimCounter);
+                        log.warn("Snapshot no longer available in the cache.  Retrying.", tae);
+                    } else if (tae.getAbortCause() == AbortCause.CONFLICT) {
+                        // Concurrent updates to the client's tables
+                        incrementCount(conflictCounter);
+                        log.warn("Concurrent updates to client tables.  Retrying.", tae);
+                    } else {
+                        log.error("Unexpected type of Transaction Aborted Exception", tae);
+                    }
+                    throw new RetryNeededException();
+                } catch (Exception e) {
+                    log.error("Unexpected exception type hit", e);
+                    throw new RetryNeededException();
+                }
+            }).run();
+        } catch (InterruptedException e) {
+            throw new StreamingException(e);
+        } finally {
+            MicroMeterUtils.time(subscribeTimer, "logreplication.subscribe.duration");
+        }
+    }
+
+
+    private static Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(CorfuStore corfuStore) {
+        try {
+            return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE_NAME,
+                    LogReplicationSession.class, ReplicationStatus.class, null,
+                    TableOptions.fromProtoSchema(ReplicationStatus.class));
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            log.error("Failed to open the Replication Status table", e);
+            throw new StreamingException(e);
+        }
+    }
+
+    private static void setListenerParamsForSnapshotSync(LogReplicationListener listener, long subscriptionTimestamp,
+                                                         boolean snapshotSyncInProgress) {
+        updateListenerFlagsForSnapshotSync(listener, snapshotSyncInProgress);
+
+        // If client full sync was done, set its timestamp
+        if (!snapshotSyncInProgress) {
+            listener.getClientFullSyncTimestamp().set(subscriptionTimestamp);
+        }
+    }
+
+    private static void updateListenerFlagsForSnapshotSync(LogReplicationListener clientListener,
+                                                           boolean snapshotSyncInProgress) {
+        clientListener.getClientFullSyncPending().set(snapshotSyncInProgress);
+        clientListener.getSnapshotSyncInProgress().set(snapshotSyncInProgress);
+    }
+
+    private static void incrementCount(Optional<Counter> counter) {
+        counter.ifPresent(Counter::increment);
+    }
+
+    /**
+     * If full sync on client tables was not performed during subscription, attempt to perform it now and complete
+     * the subscription.
+     * @param corfuStore
+     * @param clientListener
+     * @param namespace
+     */
+    public static void attemptClientFullSync(CorfuStore corfuStore, LogReplicationListener clientListener,
+                                             String namespace) {
+        getSubscriptionTimestamp(corfuStore, namespace, clientListener);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -12,6 +12,8 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
 import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
+import org.corfudb.runtime.LogReplicationListener;
+import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.TableRegistry;
@@ -279,7 +281,7 @@ public class CorfuStore {
      * <p>
      * This will subscribe to transaction updates starting from the latest state of the log.
      * <p>
-     * Note: if memory is a consideration consider use the other version of subscribe that is
+     * Note: if memory is a consideration consider using the other version of subscribe that is
      * able to specify the size of buffered transactions entries.
      *
      * @param streamListener   callback context
@@ -298,7 +300,7 @@ public class CorfuStore {
      * <p>
      * This will subscribe to transaction updates starting from the latest state of the log.
      * <p>
-     * Note: if memory is a consideration consider use the other version of subscribe that is
+     * Note: if memory is a consideration consider using the other version of subscribe that is
      * able to specify the size of buffered transactions entries.
      *
      * @param streamListener   callback context
@@ -314,7 +316,7 @@ public class CorfuStore {
      * Subscribe to transaction updates on specific tables with the streamTag in the namespace.
      * Objects returned will honor transactional boundaries.
      * <p>
-     * Note: if memory is a consideration consider use the other version of subscribe that is
+     * Note: if memory is a consideration consider using the other version of subscribe that is
      * able to specify the size of buffered transactions entries.
      *
      * @param streamListener   callback context
@@ -372,19 +374,6 @@ public class CorfuStore {
     }
 
     /**
-     * Get names of opened tables under the given namespace and stream tag.
-     *
-     * @param namespace
-     * @param streamTag
-     * @return table names (without namespace prefix)
-     */
-    private List<String> getTablesOfInterest(@Nonnull String namespace, @Nonnull String streamTag) {
-        List<String> tablesOfInterest = runtime.getTableRegistry().listTables(namespace, streamTag);
-        log.info("Tag[{}${}] :: Subscribing to {} tables - {}", namespace, streamTag, tablesOfInterest.size(), tablesOfInterest);
-        return tablesOfInterest;
-    }
-
-    /**
      * Subscribe to transaction updates on all tables with the specified streamTag and namespace.
      * Objects returned will honor transactional boundaries.
      * <p>
@@ -403,6 +392,65 @@ public class CorfuStore {
                                   @Nonnull String streamTag, @Nullable Timestamp timestamp) {
         List<String> tablesOfInterest = getTablesOfInterest(namespace, streamTag);
         subscribeListener(streamListener, namespace, streamTag, tablesOfInterest, timestamp);
+    }
+
+
+    /**
+     * Subscription API exclusively for Log Replicator(LR).  It is used for subscribing to transaction updates for
+     * replicated tables containing 'streamTag'.  Internally, the API delivers updates such that
+     * LogReplicationListener(stream listener) is able to bifurcate replicated data received within or outside an LR
+     * snapshot sync.
+     * Objects returned will honour transaction boundaries.
+     *
+     * Note: All replicated tables belonging to this stream tag must be opened on the Log Replication Sink(receiver)
+     * regardless of whether any data is replicated for it.
+     *
+     * Note: If memory is a consideration, consider using the other version of this API which takes a custom buffer
+     * size for updates.
+     *
+     * @param streamListener log replication client listener
+     * @param namespace      namespace of the replicated tables
+     * @param streamTag      stream tag of the replicated tables
+     */
+    public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
+                                                @Nonnull String namespace, @Nonnull String streamTag) {
+        int uninitializedBufferSize = 0;
+        LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
+                uninitializedBufferSize, this);
+    }
+
+    /**
+     * Subscription API exclusively for Log Replicator(LR).  It is used for subscribing to transaction updates for
+     * replicated tables containing 'streamTag'.  Internally, the API delivers updates such that
+     * LogReplicationListener(stream listener) is able to bifurcate replicated data received within or outside an LR
+     * snapshot sync.
+     * Objects returned will honour transaction boundaries.
+     *
+     * Note: All replicated tables belonging to this stream tag must be opened on the Log Replication Sink(receiver)
+     * regardless of whether any data is replicated for it.
+     *
+     * @param streamListener   log replication client listener
+     * @param namespace        namespace of the replicated tables
+     * @param streamTag        stream tag of the replicated tables
+     * @param bufferSize       maximum size of buffered transaction entries
+     */
+    public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
+                                                @Nonnull String namespace, @Nonnull String streamTag, int bufferSize) {
+        LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
+                bufferSize, this);
+    }
+
+    /**
+     * Get names of opened tables under the given namespace and stream tag.
+     *
+     * @param namespace
+     * @param streamTag
+     * @return table names (without namespace prefix)
+     */
+    private List<String> getTablesOfInterest(@Nonnull String namespace, @Nonnull String streamTag) {
+        List<String> tablesOfInterest = runtime.getTableRegistry().listTables(namespace, streamTag);
+        log.info("Tag[{}${}] :: Subscribing to {} tables - {}", namespace, streamTag, tablesOfInterest.size(), tablesOfInterest);
+        return tablesOfInterest;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/DeltaStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/DeltaStream.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.collections.streaming;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -56,6 +57,8 @@ public class DeltaStream {
     /**
      * The last trim mark that has been observed
      */
+    @VisibleForTesting
+    @Getter
     private final AtomicLong trimMark;
 
     /**
@@ -222,8 +225,7 @@ public class DeltaStream {
 
         if (!logData.isHole()) {
             // if its not a hole then it must belong to our stream
-            Preconditions.checkState(logData.hasBackpointer(streamId), "%s must contain %s",
-                    logData.getBackpointerMap().keySet(), streamId);
+            validateBackpointerPresence(logData);
         }
 
         Preconditions.checkState(logData.getGlobalAddress().equals(readAddress));
@@ -237,5 +239,10 @@ public class DeltaStream {
         MicroMeterUtils.time(Duration.ofNanos(System.nanoTime() - stampedRead.getTimestamp()),
                 "delta_stream.queuing_delay", "streamId", streamId.toString());
         return logData;
+    }
+
+    protected void validateBackpointerPresence(ILogData logData) {
+        Preconditions.checkState(logData.hasBackpointer(streamId), "%s must contain %s",
+            logData.getBackpointerMap().keySet(), streamId);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/LRDeltaStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/LRDeltaStream.java
@@ -1,0 +1,44 @@
+package org.corfudb.runtime.collections.streaming;
+
+import lombok.Getter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.runtime.view.AddressSpaceView;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * This class represents a composite {@link DeltaStream} which tracks multiple streams(stream tags) in a single ordered
+ * buffer.  The buffer is constructed from the unified address space of all streams being tracked.  The consumption
+ * and read apis have the same behavior as its super class - DeltaStream.
+ *
+ * LRDeltaStream is exclusively used by external applications of Log Replication(LR) to receive ordered streaming
+ * updates across the System Table(LogReplicationStatus) and application tables.
+ */
+@Slf4j
+public class LRDeltaStream extends DeltaStream {
+
+    @Getter
+    private final List<UUID> streamsTracked;
+
+    public LRDeltaStream(AddressSpaceView addressSpaceView, UUID streamId, long lastAddressRead, int bufferSize,
+                         List<UUID> streamsTracked) {
+        super(addressSpaceView, streamId, lastAddressRead, bufferSize);
+        this.streamsTracked = streamsTracked;
+    }
+
+    @Override
+    protected void validateBackpointerPresence(ILogData logData) {
+        Set<UUID> streamsWithBackpointer = logData.getBackpointerMap().keySet();
+        for (UUID stream : streamsTracked) {
+            if (streamsWithBackpointer.contains(stream)) {
+                return;
+            }
+        }
+        throw new IllegalStateException(String.format("%s does not contain a backpointer to any stream being tracked %s",
+                Arrays.toString(streamsWithBackpointer.toArray()), Arrays.toString(streamsTracked.toArray())));
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/LRStreamingTask.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/LRStreamingTask.java
@@ -1,0 +1,82 @@
+package org.corfudb.runtime.collections.streaming;
+
+import com.google.common.base.Preconditions;
+import com.google.protobuf.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableSchema;
+import org.corfudb.runtime.exceptions.StreamingException;
+import org.corfudb.runtime.view.TableRegistry;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+
+
+/**
+ * This class is an extension of {@link StreamingTask}.  It tracks {@link LRDeltaStream} which is a composite stream
+ * tracking multiple streams(stream tags) in a single ordered buffer.  All other behavior is the same as its super
+ * class {@link StreamingTask}.
+ * @param <K>
+ * @param <V>
+ * @param <M>
+ */
+@Slf4j
+public class LRStreamingTask<K extends Message, V extends Message, M extends Message> extends StreamingTask {
+
+    private static final String LR_MULTI_NAMESPACE_LOGICAL_STREAM = "LR_MultiNamespace_Logical_Stream";
+    public static final UUID LR_MULTI_NAMESPACE_LOGICAL_STREAM_ID =
+            UUID.nameUUIDFromBytes(LR_MULTI_NAMESPACE_LOGICAL_STREAM.getBytes());
+
+    public LRStreamingTask(CorfuRuntime runtime, ExecutorService workerPool, @Nonnull Map<String, String> nsToStreamTag,
+                           @Nonnull Map<String, List<String>> nsToTableNames, StreamListener listener, long address,
+                           int bufferSize) {
+        super(runtime, workerPool, listener, String.format("listener_%s_%s", listener,
+                LR_MULTI_NAMESPACE_LOGICAL_STREAM_ID));
+
+        // The namespaces in both maps should be the same
+        Preconditions.checkState(Objects.equals(nsToStreamTag.keySet(), nsToTableNames.keySet()));
+
+        TableRegistry registry = runtime.getTableRegistry();
+
+        List<UUID> streamsTracked = new ArrayList<>();
+        nsToStreamTag.entrySet().stream().forEach(nsToTag -> {
+            final UUID streamId = TableRegistry.getStreamIdForStreamTag(nsToTag.getKey(), nsToTag.getValue());
+            streamsTracked.add(streamId);
+        });
+
+        this.stream = new LRDeltaStream(runtime.getAddressSpaceView(), LR_MULTI_NAMESPACE_LOGICAL_STREAM_ID, address,
+                bufferSize, streamsTracked);
+
+        for (Map.Entry<String, List<String>> nsToTableNamesEntry : nsToTableNames.entrySet()) {
+            for (String tableName : nsToTableNamesEntry.getValue()) {
+                UUID streamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(
+                        nsToTableNamesEntry.getKey(), tableName));
+                Table<K, V, M> table;
+                try {
+                    table = registry.getTable(nsToTableNamesEntry.getKey(), tableName);
+                } catch (IllegalArgumentException e) {
+                    // The table was not opened using the client's runtime
+                    log.error("Replicated Table {} was not opened using the client runtime.  Please open the table " +
+                            "before subscribing", nsToTableNamesEntry.getKey(), tableName);
+                    throw new StreamingException(String.format("Please open the replicated table [%s:%s] using the " +
+                            "client runtime.", nsToTableNamesEntry.getKey(), tableName));
+                }
+                String streamTag = nsToStreamTag.get(nsToTableNamesEntry.getKey());
+                UUID streamTagId = TableRegistry.getStreamIdForStreamTag(nsToTableNamesEntry.getKey(), streamTag);
+                if (!table.getStreamTags().contains(streamTagId)) {
+                    throw new IllegalArgumentException(String.format("Interested table: %s does not " +
+                        "have specified stream tag: %s", table.getFullyQualifiedTableName(), streamTag));
+                }
+                tableSchemas.put(streamId, new TableSchema<>(tableName, table.getKeyClass(), table.getValueClass(),
+                        table.getMetadataClass()));
+            }
+        }
+        status.set(StreamStatus.RUNNABLE);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
@@ -102,6 +102,7 @@ public class StreamPollingScheduler {
     private final SequencerView sequencerView;
     private final CorfuRuntime runtime;
 
+
     public StreamPollingScheduler(CorfuRuntime runtime, ScheduledExecutorService scheduler, ExecutorService workers,
                                   Duration pollPeriod, int pollBatchSize, int pollThreshold) {
         Preconditions.checkArgument(pollBatchSize > 1, "pollBatchSize=%s has to be > 1",
@@ -159,6 +160,26 @@ public class StreamPollingScheduler {
         }
     }
 
+    public void addLRTask(@Nonnull StreamListener streamListener,
+                        @Nonnull Map<String, String> nsToStreamTags,
+                        @Nonnull Map<String, List<String>> nsToTables, long lastAddress,
+                        int bufferSize) {
+        Preconditions.checkArgument(bufferSize >= pollThreshold);
+        synchronized (allTasks) {
+            if (allTasks.containsKey(streamListener)) {
+                // Multiple subscribers subscribing to same namespace and table is allowed
+                // as long as the hashcode() and equals() method of the listeners are different.
+                throw new StreamingException(
+                        "StreamingManager::subscribe: listener already registered " + streamListener);
+            }
+            StreamingTask task = new LRStreamingTask(runtime, workers, nsToStreamTags, nsToTables, streamListener,
+                    lastAddress, bufferSize);
+            allTasks.put(streamListener, task);
+            log.info("addTask: added {} for {} address {}", streamListener, nsToStreamTags, lastAddress);
+            allTasks.notifyAll();
+        }
+    }
+
     public void removeTask(@Nonnull StreamListener streamListener) {
         synchronized (allTasks) {
             allTasks.remove(streamListener);
@@ -190,8 +211,15 @@ public class StreamPollingScheduler {
     private List<StreamAddressRange> getPollQueries(List<StreamingTask> tasks) {
         List<StreamAddressRange> pollRequests = new ArrayList<>(tasks.size());
         for (StreamingTask task : tasks) {
-            DeltaStream stream = task.getStream();
-            pollRequests.add(new StreamAddressRange(stream.getStreamId(), Address.MAX, stream.getMaxAddressSeen()));
+            DeltaStream deltaStream = task.getStream();
+            if (task instanceof LRStreamingTask) {
+                List<UUID> streamsTracked = ((LRDeltaStream)deltaStream).getStreamsTracked();
+                streamsTracked.forEach(streamTracked -> pollRequests.add(new StreamAddressRange(streamTracked,
+                        Address.MAX, deltaStream.getMaxAddressSeen())));
+            } else {
+                pollRequests.add(new StreamAddressRange(deltaStream.getStreamId(), Address.MAX,
+                        deltaStream.getMaxAddressSeen()));
+            }
         }
         return pollRequests;
     }
@@ -226,23 +254,75 @@ public class StreamPollingScheduler {
             allQueryResults.putAll(res);
         }
 
-        Preconditions.checkState(tasks.size() == queries.size());
+        validateQuerySize(tasks, queries);
 
-        for (int idx = 0; idx < tasks.size(); idx++) {
-            StreamingTask task = tasks.get(idx);
+        int queryIdx = 0;
+        for (StreamingTask task : tasks) {
+            StreamAddressSpace sas;
             try {
-                StreamAddressRange taskQuery = queries.get(idx);
-                Preconditions.checkState(task.getStream().getStreamId().equals(taskQuery.getStreamID()));
-                Preconditions.checkState(allQueryResults.containsKey(taskQuery.getStreamID()),
+                if (task instanceof LRStreamingTask) {
+                    sas = getMergedAddressSpace((LRStreamingTask)task, queries, allQueryResults, queryIdx);
+                    // LRDeltaStream(used in LRStreamingTask) tracks 2 streams.  The list of streamAddressRangeQueries is a
+                    // flattened list of all streams across all tasks.  For LRDeltaStream, the mapping of task -> query will not
+                    // be 1:1.  So queryIdx is incremented by the number of streams tracked
+                    queryIdx += ((LRDeltaStream)task.getStream()).getStreamsTracked().size();
+                } else {
+                    StreamAddressRange taskQuery = queries.get(queryIdx);
+                    Preconditions.checkState(task.getStream().getStreamId().equals(taskQuery.getStreamID()));
+                    Preconditions.checkState(allQueryResults.containsKey(taskQuery.getStreamID()),
                         "StreamAddressSpace missing for %s", task.getStream().getStreamId());
-                StreamAddressSpace sas = allQueryResults.get(task.getStream().getStreamId()).getAddressesInRange(taskQuery);
+                    sas = allQueryResults.get(task.getStream().getStreamId()).getAddressesInRange(taskQuery);
+                    queryIdx++;
+                }
                 task.getStream().refresh(sas);
             } catch (Throwable throwable) {
                 task.setError(throwable);
                 log.error("StreamingPollingScheduler: encountered exception {} during streaming task scheduling. " +
-                        "Notify stream listener {} with id={} onError.", throwable, task.getListener(), task.getListenerId());
+                    "Notify stream listener {} with id={} onError.", throwable, task.getListener(), task.getListenerId());
             }
         }
+    }
+
+    private void validateQuerySize(List<StreamingTask> tasks, List<StreamAddressRange> addressRangeQueries) {
+        int numLRStreamingTasks = 0;
+        for (StreamingTask task : tasks) {
+            if (task instanceof LRStreamingTask) {
+                numLRStreamingTasks++;
+            }
+        }
+
+        int numRemainingTasks = tasks.size() - numLRStreamingTasks;
+
+        // LRDeltaStream(used in LRStreamingTask) tracks 2 streams for which the stream address space is queried.  So
+        // the number of queries should be numLRStreamingTasks*2 + numRemainingStreamingTasks
+        int numExpectedQueries = numLRStreamingTasks*2 + numRemainingTasks;
+        Preconditions.checkState(numExpectedQueries == addressRangeQueries.size());
+    }
+
+    /**
+     * Return a merged address space of the streams tracked by this LRStreamingTask
+     */
+    private StreamAddressSpace getMergedAddressSpace(LRStreamingTask task, List<StreamAddressRange> queries,
+                                                     Map<UUID, StreamAddressSpace> allQueryResults, int queryIdx) {
+
+        int idx = queryIdx;
+        List<StreamAddressSpace> streamAddressSpaces = new ArrayList<>();
+
+        for (UUID stream : ((LRDeltaStream)task.getStream()).getStreamsTracked()) {
+            StreamAddressRange taskQuery = queries.get(idx);
+            Preconditions.checkState(stream.equals(taskQuery.getStreamID()));
+            Preconditions.checkState(allQueryResults.containsKey(stream),
+                    "StreamAddressSpace missing for %s", task.getStream().getStreamId());
+            streamAddressSpaces.add(allQueryResults.get(stream).getAddressesInRange(taskQuery));
+            idx++;
+        }
+
+        StreamAddressSpace mergedStreamAddressSpace = streamAddressSpaces.get(0);
+        for (int i = 1; i < streamAddressSpaces.size(); i++) {
+            mergedStreamAddressSpace = StreamAddressSpace.merge(mergedStreamAddressSpace,
+                streamAddressSpaces.get(i));
+        }
+        return mergedStreamAddressSpace;
     }
 
     @Data

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingManager.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplicationListener;
 import org.corfudb.runtime.collections.StreamListener;
 
 import org.corfudb.runtime.exceptions.StreamingException;
@@ -14,11 +15,18 @@ import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.Utils;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+
+import static org.corfudb.runtime.LogReplicationUtils.LR_STATUS_STREAM_TAG;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
  * A streaming subscription manager that allows clients to listen on
@@ -89,6 +97,31 @@ public class StreamingManager {
         this.scheduler.addTask(streamListener, namespace, streamTag, tablesOfInterest, lastAddress, bufferSize);
     }
 
+    /**
+     * This subscription is exclusive to Log Replication(LR).  It is used for subscribing to transaction updates across
+     * LR's metadata table(ReplicationStatus) in the CorfuSystem namespace and application-specific tables containing
+     * 'streamTag' within the application namespace.
+     *
+     * @param streamListener   client listener for callback
+     * @param namespace       namespace of application tables on which updates should be received
+     * @param streamTag       only updates of application tables with the stream tag will be polled
+     * @param tablesOfInterest only updates from these tables will be returned
+     * @param lastAddress      last processed address, new notifications start from lastAddress + 1
+     */
+    public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener, @Nonnull String namespace,
+                                                @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest,
+                                                long lastAddress, int bufferSize) {
+        Map<String, List<String>> nsToTableName = new HashMap<>();
+        nsToTableName.put(namespace, tablesOfInterest);
+        nsToTableName.put(CORFU_SYSTEM_NAMESPACE, Arrays.asList(REPLICATION_STATUS_TABLE_NAME));
+
+        Map<String, String> nsToStreamTags = new HashMap<>();
+        nsToStreamTags.put(namespace, streamTag);
+        nsToStreamTags.put(CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
+        this.scheduler.addLRTask(streamListener, nsToStreamTags, nsToTableName, lastAddress,
+                bufferSize == 0 ? defaultBufferSize : bufferSize);
+    }
+
 
     // TODO(Maithem): this is obsolete, delta stream already detects this case, but can't be
     // removed until some tests that depend on this internal behavior are fixed
@@ -121,7 +154,6 @@ public class StreamingManager {
         // log warn message if it didnt exist?
         this.scheduler.removeTask(streamListener);
     }
-
 
     /**
      * Shutdown the streaming manager and clean up resources.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
@@ -56,7 +56,7 @@ public class StreamingTask<K extends Message, V extends Message, M extends Messa
     private final StreamListener listener;
 
     // The table id to schema map of the interested tables.
-    private final Map<UUID, TableSchema<K, V, M>> tableSchemas;
+    protected final Map<UUID, TableSchema<K, V, M>> tableSchemas = new HashMap<>();
 
     @Getter
     private final String listenerId;
@@ -65,24 +65,28 @@ public class StreamingTask<K extends Message, V extends Message, M extends Messa
 
     private final ExecutorService workerPool;
 
-    private final DeltaStream stream;
+    protected DeltaStream stream;
 
-    private final AtomicReference<StreamStatus> status;
+    protected final AtomicReference<StreamStatus> status = new AtomicReference<>();
 
     private volatile Throwable error;
+
+    protected StreamingTask(CorfuRuntime runtime, ExecutorService workerPool, StreamListener listener,
+                            String listenerId) {
+        this.runtime = runtime;
+        this.workerPool = workerPool;
+        this.listener = listener;
+        this.listenerId = listenerId;
+    }
 
     public StreamingTask(CorfuRuntime runtime, ExecutorService workerPool, String namespace, String streamTag,
                          StreamListener listener,
                          List<String> tablesOfInterest,
                          long address,
                          int bufferSize) {
-
-        this.runtime = runtime;
-        this.workerPool = workerPool;
-        this.listenerId = String.format("listener_%s_%s_%s", listener, namespace, streamTag);
-        this.listener = listener;
+        this(runtime, workerPool, listener, String.format("listener_%s_%s_%s", listener, namespace, streamTag));
         TableRegistry registry = runtime.getTableRegistry();
-        final UUID streamId;
+        UUID streamId;
         // Federated tables do not have a stream tag, only an option isFederated set to true. Internally,
         // their stream tag is constructed when the table is opened. This stream tag is constructed differently than
         // other tables. So for subscribers on this tag, do not construct the streamId using the generic algorithm.
@@ -92,37 +96,37 @@ public class StreamingTask<K extends Message, V extends Message, M extends Messa
             streamId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
         }
         this.stream = new DeltaStream(runtime.getAddressSpaceView(), streamId, address, bufferSize);
-        this.tableSchemas = tablesOfInterest
-                .stream()
-                .collect(Collectors.toMap(
-                        tName -> CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(namespace, tName)),
-                        tName -> {
-                            // Subscription on special tables(ProtobufDescriptor and Registry tables) is not possible
-                            // with the regular workflow as they are not opened using CorfuStore.openTable().
-                            // However, these tables do have the stream tag for Log Replication and it is useful to
-                            // subscribe to them for testing purposes. The below is special handling to allow for such a
-                            // subscription.
-                            if (streamId.equals(ObjectsView.getLogReplicatorStreamId()) && namespace.equals(
-                                TableRegistry.CORFU_SYSTEM_NAMESPACE) &&
-                                tName.equals(TableRegistry.PROTOBUF_DESCRIPTOR_TABLE_NAME)) {
-                                return new TableSchema(tName, ProtobufFileName.class, ProtobufFileDescriptor.class,
-                                        TableMetadata.class);
-                            } else if (streamId.equals(ObjectsView.getLogReplicatorStreamId()) && namespace.equals(
-                                TableRegistry.CORFU_SYSTEM_NAMESPACE) &&
-                                tName.equals(TableRegistry.REGISTRY_TABLE_NAME)) {
-                                return new TableSchema(tName, TableName.class, TableDescriptors.class,
-                                        TableMetadata.class);
-                            } else {
-                                // The table should be opened with full schema before subscription.
-                                Table<K, V, M> t = registry.getTable(namespace, tName);
-                                if (!t.getStreamTags().contains(streamId)) {
-                                    throw new IllegalArgumentException(String.format("Interested table: %s does not " +
-                                        "have specified stream tag: %s", t.getFullyQualifiedTableName(), streamTag));
-                                }
-                                return new TableSchema<>(tName, t.getKeyClass(), t.getValueClass(), t.getMetadataClass());
-                            }
-                        }));
-        this.status = new AtomicReference<>(StreamStatus.RUNNABLE);
+
+        for (String tableOfInterest : tablesOfInterest) {
+            UUID tableId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(namespace, tableOfInterest));
+
+            // Subscription on special tables(ProtobufDescriptor and Registry tables) is not possible
+            // with the regular workflow as they are not opened using CorfuStore.openTable().
+            // However, these tables do have the stream tag for Log Replication and it is useful to
+            // subscribe to them for testing purposes. The below is special handling to allow for such a
+            // subscription.
+            if (streamId.equals(ObjectsView.getLogReplicatorStreamId()) && namespace.equals(
+                TableRegistry.CORFU_SYSTEM_NAMESPACE) &&
+                tableOfInterest.equals(TableRegistry.PROTOBUF_DESCRIPTOR_TABLE_NAME)) {
+                tableSchemas.put(tableId, new TableSchema(tableOfInterest, ProtobufFileName.class, ProtobufFileDescriptor.class,
+                        TableMetadata.class));
+            } else if (streamId.equals(ObjectsView.getLogReplicatorStreamId()) && namespace.equals(
+                TableRegistry.CORFU_SYSTEM_NAMESPACE) &&
+                tableOfInterest.equals(TableRegistry.REGISTRY_TABLE_NAME)) {
+                tableSchemas.put(tableId, new TableSchema(tableOfInterest, TableName.class, TableDescriptors.class,
+                        TableMetadata.class));
+            } else {
+                // The table should be opened with full schema before subscription.
+                Table<K, V, M> t = registry.getTable(namespace, tableOfInterest);
+                if (!t.getStreamTags().contains(streamId)) {
+                        throw new IllegalArgumentException(String.format("Interested table: %s does not " +
+                            "have specified stream tag: %s", t.getFullyQualifiedTableName(), streamTag));
+                }
+                tableSchemas.put(tableId, new TableSchema<>(tableOfInterest, t.getKeyClass(), t.getValueClass(),
+                        t.getMetadataClass()));
+            }
+        }
+        status.set(StreamStatus.RUNNABLE);
     }
 
     public StreamStatus getStatus() {

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -1,0 +1,134 @@
+package org.corfudb.infrastructure.logreplication;
+
+import com.google.protobuf.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.LogReplicationListener;
+import org.corfudb.runtime.LogReplicationUtils;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.Address;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.ArrayList;
+
+/**
+ * Tests the apis in LogReplicationUtils.
+ */
+@Slf4j
+public class LogReplicationUtilsTest extends AbstractViewTest {
+
+    private CorfuRuntime corfuRuntime;
+    private CorfuStore corfuStore;
+    private LogReplicationListener lrListener;
+    private Table<LogReplication.LogReplicationSession, LogReplication.ReplicationStatus, Message> replicationStatusTable;
+    private String namespace = "test_namespace";
+
+    @Before
+    public void setUp() throws Exception {
+        corfuRuntime = getDefaultRuntime();
+        corfuStore = new CorfuStore(corfuRuntime);
+        lrListener = new LogReplicationTestListener(corfuStore, namespace);
+        replicationStatusTable = TestUtils.openReplicationStatusTable(corfuStore);
+    }
+
+    /**
+     * Test the behavior of attemptClientFullSync() when LR Snapshot sync is ongoing.  The flags and variables on the
+     * listener must be updated correctly.
+     */
+    @Test
+    public void testAttemptClientFullSyncSnapshotSyncOngoing() {
+        testAttemptClientFullSync(true);
+    }
+
+    /**
+     * Test the behavior of attemptClientFullSync() when LR Snapshot sync is complete.  The flags and variables on
+     * the listener must be updated correctly.
+     */
+    @Test
+    public void testAttempClientFullSyncSnapshotSyncComplete() {
+        testAttemptClientFullSync(false);
+    }
+
+    private void testAttemptClientFullSync(boolean ongoing) {
+        TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, ongoing);
+        LogReplicationUtils.attemptClientFullSync(corfuStore, lrListener, namespace);
+        verifyListenerFlags(ongoing);
+    }
+
+    /**
+     * Test the behavior of subscribe() when LR Snapshot sync is ongoing.  The flags and variables on the listener
+     * must be updated correctly.
+     */
+    @Test
+    public void testSubscribeSnapshotSyncOngoing() {
+        testSubscribe(true);
+    }
+
+    /**
+     * Test the behavior of subscribe() when LR Snapshot sync is complete.  The flags and variables on the listener
+     * must be updated correctly.
+     */
+    @Test
+    public void testSubscribeSnapshotSyncComplete() {
+        testSubscribe(false);
+    }
+
+    private void testSubscribe(boolean ongoing) {
+        TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, ongoing);
+
+        String streamTag = "test_tag";
+        LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
+        verifyListenerFlags(ongoing);
+    }
+
+    private void verifyListenerFlags(boolean ongoing) {
+        if (ongoing) {
+            Assert.assertTrue(lrListener.getClientFullSyncPending().get());
+            Assert.assertTrue(lrListener.getSnapshotSyncInProgress().get());
+            Assert.assertEquals(Address.NON_ADDRESS, lrListener.getClientFullSyncTimestamp().get());
+            Assert.assertFalse(((LogReplicationTestListener)lrListener).performFullSyncInvoked);
+        } else {
+            Assert.assertFalse(lrListener.getClientFullSyncPending().get());
+            Assert.assertFalse(lrListener.getSnapshotSyncInProgress().get());
+            Assert.assertNotEquals(Address.NON_ADDRESS, lrListener.getClientFullSyncTimestamp().get());
+            Assert.assertTrue(((LogReplicationTestListener)lrListener).performFullSyncInvoked);
+        }
+    }
+
+    @After
+    public void cleanUp() {
+        corfuRuntime.shutdown();
+    }
+
+    private class LogReplicationTestListener extends LogReplicationListener {
+
+        private boolean performFullSyncInvoked = false;
+
+        LogReplicationTestListener(CorfuStore corfuStore, String namespace) {
+            super(corfuStore, namespace);
+        }
+
+        protected void onSnapshotSyncStart() {}
+
+        protected void onSnapshotSyncComplete() {}
+
+        protected void processUpdatesInSnapshotSync(CorfuStreamEntries results) {}
+
+        protected void processUpdatesInLogEntrySync(CorfuStreamEntries results) {}
+
+        protected void performFullSync(TxnContext txnContext) {
+            performFullSyncInvoked = true;
+        }
+
+        public void onError(Throwable throwable) {
+            log.error("Error in Test Listener", throwable);
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -44,7 +44,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
      */
     @Test
     public void testAttemptClientFullSyncSnapshotSyncOngoing() {
-        testAttemptClientFullSync(true);
+        testAttemptClientFullSync(true,true);
     }
 
     /**
@@ -52,12 +52,24 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
      * the listener must be updated correctly.
      */
     @Test
-    public void testAttempClientFullSyncSnapshotSyncComplete() {
-        testAttemptClientFullSync(false);
+    public void testAttemptClientFullSyncSnapshotSyncComplete() {
+        testAttemptClientFullSync(true,false);
     }
 
-    private void testAttemptClientFullSync(boolean ongoing) {
-        TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, ongoing);
+    /**
+     * Test the behavior of attemptClientFullSync() when the LR Status table does not have any entry for the Logical
+     * Group Replication Model.  The expected behavior is that no ongoing Snapshot Sync is detected and client full
+     * sync succeeds.
+     */
+    @Test
+    public void testAttemptClientFullSyncStatusNotFound() {
+        testAttemptClientFullSync(false, false);
+    }
+
+    private void testAttemptClientFullSync(boolean initializeTable, boolean ongoing) {
+        if (initializeTable) {
+            TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, ongoing);
+        }
         LogReplicationUtils.attemptClientFullSync(corfuStore, lrListener, namespace);
         verifyListenerFlags(ongoing);
     }
@@ -68,7 +80,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
      */
     @Test
     public void testSubscribeSnapshotSyncOngoing() {
-        testSubscribe(true);
+        testSubscribe(true, true);
     }
 
     /**
@@ -77,11 +89,23 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
      */
     @Test
     public void testSubscribeSnapshotSyncComplete() {
-        testSubscribe(false);
+        testSubscribe(true, false);
     }
 
-    private void testSubscribe(boolean ongoing) {
-        TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, ongoing);
+    /**
+     * Test the behavior of subscribe() when the LR Status table does not have any entry for the Logical
+     * Group Replication Model.  The expected behavior is that no ongoing Snapshot Sync is detected and
+     * subscription succeeds.
+     */
+    @Test
+    public void testSubscribeSyncStatusNotFound() {
+        testSubscribe(false, false);
+    }
+
+    private void testSubscribe(boolean initializeTable, boolean ongoing) {
+        if (initializeTable) {
+            TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, ongoing);
+        }
 
         String streamTag = "test_tag";
         LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
@@ -1,24 +1,42 @@
 package org.corfudb.infrastructure.logreplication;
 
+import com.google.protobuf.Message;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.service.CorfuProtocolLogReplication;
 import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
+import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
+import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
+import org.corfudb.runtime.LogReplication.ReplicationModel;
+import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.LogReplication.ReplicationStatus;
+import org.corfudb.runtime.LogReplication.ReplicationSubscriber;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static com.google.protobuf.UnsafeByteOperations.unsafeWrap;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
  * This class contains the common helper functions which can be used by multiple Log Replication unit tests.
  */
 public class TestUtils {
 
+    private static final String defaultClusterId = UUID.randomUUID().toString();
+    private static final String clientName = "test_client";
+
     /**
      * Create a LogEntry message with opaque entries starting from startTs to endTs.  Each opaque entry corresponds to a
      * transaction.  The metadata of the message is populated as per the input arguments.
      */
-    LogReplication.LogReplicationEntryMsg generateLogEntryMsg(long startTs, long endTs, long prevTs, long topologyConfigId,
+    LogReplicationEntryMsg generateLogEntryMsg(long startTs, long endTs, long prevTs, long topologyConfigId,
                                                               long snapshotTs) {
         List<OpaqueEntry> opaqueEntryList = new ArrayList<>();
 
@@ -28,8 +46,8 @@ public class TestUtils {
         }
 
         // Create sample metadata
-        LogReplication.LogReplicationEntryMetadataMsg metadata = LogReplication.LogReplicationEntryMetadataMsg.newBuilder()
-            .setEntryType(LogReplication.LogReplicationEntryType.LOG_ENTRY_MESSAGE)
+        LogReplicationEntryMetadataMsg metadata = LogReplicationEntryMetadataMsg.newBuilder()
+            .setEntryType(LogReplicationEntryType.LOG_ENTRY_MESSAGE)
             .setTimestamp(endTs)
             .setSnapshotTimestamp(snapshotTs)
             .setPreviousTimestamp(prevTs)
@@ -38,9 +56,44 @@ public class TestUtils {
             .build();
 
         // Generate the protobuf message to be given to LogEntryWriter
-        LogReplication.LogReplicationEntryMsg lrEntryMsg = CorfuProtocolLogReplication.getLrEntryMsg(unsafeWrap(
+        LogReplicationEntryMsg lrEntryMsg = CorfuProtocolLogReplication.getLrEntryMsg(unsafeWrap(
             CorfuProtocolLogReplication.generatePayload(opaqueEntryList)), metadata);
 
         return lrEntryMsg;
+    }
+
+    public static  Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(
+        CorfuStore corfuStore) throws Exception {
+
+        return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE_NAME,
+            LogReplicationSession.class, ReplicationStatus.class, null,
+            TableOptions.fromProtoSchema(ReplicationStatus.class));
+    }
+
+    public static void setSnapshotSyncOngoing(CorfuStore corfuStore,
+                                              Table<LogReplicationSession, ReplicationStatus, Message>
+                                                  replicationStatusTable,
+                                              boolean ongoing) {
+        try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+            LogReplicationSession key = getTestSession();
+            ReplicationStatus val = getTestReplicationStatus(ongoing);
+            txn.putRecord(replicationStatusTable, key, val, null);
+            txn.commit();
+        }
+    }
+
+    private static LogReplicationSession getTestSession() {
+        ReplicationSubscriber subscriber = ReplicationSubscriber.newBuilder().setClientName(clientName)
+            .setModel(ReplicationModel.LOGICAL_GROUPS)
+            .build();
+        return LogReplicationSession.newBuilder().setSourceClusterId(defaultClusterId)
+            .setSinkClusterId(defaultClusterId).setSubscriber(subscriber)
+            .build();
+    }
+
+    private static ReplicationStatus getTestReplicationStatus(boolean ongoing) {
+        return ReplicationStatus.newBuilder()
+            .setSinkStatus(LogReplication.SinkReplicationStatus.newBuilder().setDataConsistent(!ongoing))
+            .build();
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
@@ -30,7 +30,6 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 public class TestUtils {
 
     private static final String defaultClusterId = UUID.randomUUID().toString();
-    private static final String clientName = "test_client";
 
     /**
      * Create a LogEntry message with opaque entries starting from startTs to endTs.  Each opaque entry corresponds to a
@@ -72,17 +71,17 @@ public class TestUtils {
 
     public static void setSnapshotSyncOngoing(CorfuStore corfuStore,
                                               Table<LogReplicationSession, ReplicationStatus, Message>
-                                                  replicationStatusTable,
+                                                  replicationStatusTable, String clientName,
                                               boolean ongoing) {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            LogReplicationSession key = getTestSession();
+            LogReplicationSession key = getTestSession(clientName);
             ReplicationStatus val = getTestReplicationStatus(ongoing);
             txn.putRecord(replicationStatusTable, key, val, null);
             txn.commit();
         }
     }
 
-    private static LogReplicationSession getTestSession() {
+    private static LogReplicationSession getTestSession(String clientName) {
         ReplicationSubscriber subscriber = ReplicationSubscriber.newBuilder().setClientName(clientName)
             .setModel(ReplicationModel.LOGICAL_GROUPS)
             .build();

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
@@ -61,7 +61,7 @@ public class TestUtils {
         return lrEntryMsg;
     }
 
-    public static  Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(
+    public static Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(
         CorfuStore corfuStore) throws Exception {
 
         return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE_NAME,

--- a/test/src/test/java/org/corfudb/integration/LogReplicationListenerIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationListenerIT.java
@@ -1,0 +1,698 @@
+package org.corfudb.integration;
+
+import com.google.protobuf.Message;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.LogReplication.ReplicationModel;
+import org.corfudb.runtime.LogReplication.ReplicationStatus;
+import org.corfudb.runtime.LogReplication.ReplicationSubscriber;
+import org.corfudb.runtime.LogReplication.SinkReplicationStatus;
+import org.corfudb.runtime.LogReplicationListener;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStoreEntry;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TableSchema;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.test.SampleSchema;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.junit.Assert.fail;
+
+@Slf4j
+public class LogReplicationListenerIT extends AbstractIT {
+
+    private final String corfuSingleNodeHost;
+    private final int corfuStringNodePort;
+    private final String singleNodeEndpoint;
+    private CorfuStore store;
+
+    private final String namespace = "test_namespace";
+    private final String userTableName = "data_table";
+    private final String userTag = "sample_streamer_1";
+    private final String defaultClusterId = UUID.randomUUID().toString();
+    private final String testClientName = "lr_test_client";
+
+    // LR Listener for data and system tables
+    private LRTestListener lrListener;
+
+    // Regular(non-LR) listener for the data table
+    private TestListener listener;
+
+    Table<SampleSchema.Uuid, SampleSchema.SampleTableAMsg, SampleSchema.Uuid> userDataTable;
+    Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable;
+
+    public LogReplicationListenerIT() {
+        corfuSingleNodeHost = PROPERTIES.getProperty("corfuSingleNodeHost");
+        corfuStringNodePort = Integer.valueOf(PROPERTIES.getProperty("corfuSingleNodePort"));
+        singleNodeEndpoint = String.format("%s:%d", corfuSingleNodeHost, corfuStringNodePort);
+    }
+
+    private void initializeCorfu() throws Exception {
+        new AbstractIT.CorfuServerRunner()
+            .setHost(corfuSingleNodeHost)
+            .setPort(corfuStringNodePort)
+            .setLogPath(getCorfuServerLogPath(corfuSingleNodeHost, corfuStringNodePort))
+            .setSingle(true)
+            .runServer();
+        runtime = createRuntime(singleNodeEndpoint);
+        store = new CorfuStore(runtime);
+    }
+
+    @Test
+    public void testWritesToDataTableStartInLogEntrySync() throws Exception {
+        testWritesToDataTable(false);
+    }
+
+    @Test
+    public void testWritesToDataTableStartInSnapshotSync() throws Exception {
+        testWritesToDataTable(true);
+    }
+
+    /**
+     * This test verifies that all data written to the user table is received in increasing order of the timestamps and
+     * the streaming updates match the data in the table.  The final number of entries seen by performFullSync(if
+     * starting in snapshot sync) + streaming updates must be equal to the total
+     * number of writes to the table.
+     * @throws Exception
+     */
+    private void testWritesToDataTable(boolean startInSnapshotSync) throws Exception {
+        initializeCorfu();
+        openTables();
+
+        // Start snapshot sync if requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(false);
+        }
+
+        final int numUpdates = 10;
+        CountDownLatch countDownLatch = new CountDownLatch(numUpdates);
+        lrListener = new LRTestListener(store, namespace, countDownLatch);
+
+        // Subscribe the listener
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+
+        // End snapshot sync if it had been requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(true);
+        }
+
+        // Write numUpdates records in the data table
+        writeToDataTable(numUpdates, 0);
+
+        // Wait for the data to arrive.  Since performFullSync() is executed later if a snapshot sync is ongoing, the
+        // number of streaming updates in that case will be lesser.  But the final number of entries seen by
+        // performFullSync() + streaming updates must be equal to numUpdates
+        countDownLatch.await();
+
+        // If the test started when in log entry sync, performFullSync() should not find any existing data as no
+        // updates have been written prior to subscription.
+        if (!startInSnapshotSync) {
+            Assert.assertTrue(lrListener.getExistingEntries().isEmpty());
+        }
+
+        // Verify the sequence(timestamp) of the streaming updates
+        verifyUpdatesSequence(lrListener.getUpdates());
+
+        // Verify all the data observed by the listener - existing entries before subscription + updates afterwards
+        verifyData(lrListener.getUpdates(), lrListener.getExistingEntries());
+    }
+
+    @Test
+    public void testMultipleWritesToDataTableInTxStartInLogEntrySync() throws Exception {
+        testMultipleWritesToDataTableInTx(false);
+    }
+
+    @Test
+    public void testMultipleWritesToDataTableInTxStartInSnapshotSync() throws Exception {
+        testMultipleWritesToDataTableInTx(true);
+    }
+
+    /**
+     * This test verifies that all data written to the user table is received in increasing order of the timestamps and
+     * the streaming updates match the data in the table.  Multiple entries to the table are written in a single
+     * transaction (batch size >1).
+     * The final number of entries seen by performFullSync(if starting in snapshot sync) + streaming updates must be
+     * equal to the total number of writes to the table.
+     */
+    private void testMultipleWritesToDataTableInTx(boolean startInSnapshotSync) throws Exception {
+        initializeCorfu();
+        openTables();
+
+        // Start snapshot sync if requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(false);
+        }
+
+        final int numUpdates = 10;
+        final int numStreamingUpdates = 1;
+        CountDownLatch countDownLatch = new CountDownLatch(numStreamingUpdates);
+
+        // As all updates are written in the same transaction, set this countdown latch to 1
+        CountDownLatch numTxLatch = new CountDownLatch(1);
+
+        lrListener = new LRTestListener(store, namespace, countDownLatch);
+        lrListener.setNumTxLatch(numTxLatch);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+
+        // End snapshot sync if it had been requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(true);
+        }
+
+        writeToDataTableMultipleUpdatesInATx(numUpdates, 0);
+
+        countDownLatch.await();
+        numTxLatch.await();
+
+        // If the test started when in log entry sync, performFullSync() should not find any existing data as no
+        // updates have been written prior to subscription.
+        if (!startInSnapshotSync) {
+            Assert.assertTrue(lrListener.getExistingEntries().isEmpty());
+        }
+
+        verifyUpdatesSequence(lrListener.getUpdates());
+        verifyData(lrListener.getUpdates(), lrListener.getExistingEntries());
+    }
+
+    @Test
+    public void testSubscriptionWithCustomBufferSizeStartInLogEntrySync() throws Exception {
+        testSubscriptionWithCustomBufferSize(false);
+    }
+
+    @Test
+    public void testSubscriptionWithCustomBufferSizeStartInSnapshotSync() throws Exception {
+        testSubscriptionWithCustomBufferSize(true);
+    }
+
+    /**
+     * This test verifies that a listener with a custom buffer size works as expected.  All data written to the
+     * user table is received in increasing order of timestamps and the streaming updates match the data in the table.
+     * The final number of entries seen by performFullSync(if starting in snapshot sync) + streaming updates must be
+     * equal to the total number of writes to the table.
+     */
+    private void testSubscriptionWithCustomBufferSize(boolean startInSnapshotSync) throws Exception {
+        initializeCorfu();
+        openTables();
+
+        // Start snapshot sync if requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(false);
+        }
+
+        final int bufferSize = 10;
+        final int numUpdates = 50;
+
+        CountDownLatch countDownLatch = new CountDownLatch(numUpdates);
+        lrListener = new LRTestListener(store, namespace, countDownLatch);
+
+        // Subscribe a listener with a buffer size of 10
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, bufferSize);
+
+        // End snapshot sync if it had been requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(true);
+        }
+
+        log.info("Write updates to the data table");
+        writeToDataTable(numUpdates, 0);
+
+        log.info("Wait for data to arrive");
+        countDownLatch.await();
+
+        // If the test started when in log entry sync, performFullSync() should not find any existing data as no
+        // updates have been written prior to subscription.
+        if (!startInSnapshotSync) {
+            Assert.assertTrue(lrListener.getExistingEntries().isEmpty());
+        }
+
+        log.info("Verify the sequence of updates and received data");
+        verifyUpdatesSequence(lrListener.getUpdates());
+        verifyData(lrListener.getUpdates(), lrListener.getExistingEntries());
+    }
+
+    /**
+     * This test simultates a concurrent toggling of the 'dataConsistent' flag along with writes to the data
+     * table.  For every X writes to the data table, there is a concurrent write toggling this flag on the System
+     * table.  This is repeated several times.  In the end, it is expected that the number of entries seen by
+     * performFullSync() + streaming updates must be equal to the total writes across all iterations.  The updates
+     * must also be in increasing order of timestamps.
+     * @throws Exception
+     */
+    @Test
+    public void testConcurrentDataWritesAndDataConsistentToggle() throws Exception {
+        initializeCorfu();
+        openTables();
+
+        final int numIterations = 10;
+        final int numWritesToDataTable = 10;
+
+        // In each iteration, numWritesToDataTable are made
+        final int numExpectedStreamingUpdates = numIterations * numWritesToDataTable;
+
+        CountDownLatch countDownLatch = new CountDownLatch(numExpectedStreamingUpdates);
+        lrListener = new LRTestListener(store, namespace, countDownLatch);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+
+        log.info("Write data concurrently on both tables");
+        writeDataAndToggleDataConsistentConcurrently(numIterations, numWritesToDataTable);
+
+        log.info("Wait for data to arrive");
+        countDownLatch.await();
+
+        log.info("Verify the sequence of updates and received data");
+        verifyUpdatesSequence(lrListener.getUpdates());
+        verifyData(lrListener.getUpdates(), lrListener.getExistingEntries());
+    }
+
+    @Test
+    public void testSubscriptionAfterDataWrittenStartInLogEntrySync() throws Exception {
+        testSubscriptionAfterDataWritten(false);
+    }
+
+    @Test
+    public void testSubscriptionAfterDataWrittenStartInSnapshotSync() throws Exception {
+        testSubscriptionAfterDataWritten(true);
+    }
+
+    /**
+     * This test tests the behavior of subscription done after some data is written.  It has the following workflow:
+     * 1. Write data to the table
+     * 2. Subscribe for streaming updates
+     * 3. Write more data
+     * In the end, it verifies that the number of entries observed in performFullSync(if starting in snapshot sync) +
+     * streaming updates is the total of the writes in 1 and 3.
+     * Also verifies the order of streaming updates and the data seen in the listener.
+     * @throws Exception
+     */
+    private void testSubscriptionAfterDataWritten(boolean startInSnapshotSync) throws Exception {
+        initializeCorfu();
+        openTables();
+
+        // Start snapshot sync if requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(false);
+        }
+
+        final int numUpdates = 10;
+        writeToDataTable(numUpdates, 0);
+
+        final int newUpdates = 5;
+        final int totalUpdates = numUpdates + newUpdates;
+        CountDownLatch countDownLatch = new CountDownLatch(totalUpdates);
+        lrListener = new LRTestListener(store, namespace, countDownLatch);
+
+        // Subscribe the listener at the obtained timestamp
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+
+        // End snapshot sync if it had been requested
+        if (startInSnapshotSync) {
+            writeToStatusTable(true);
+        }
+
+        log.info("Write updates to the data table after subscription");
+        writeToDataTable(newUpdates, numUpdates);
+
+        log.info("Wait for subscription and for all updates to be received");
+        countDownLatch.await();
+
+        // If the test started when in log entry sync, performFullSync() should only find the data written prior to
+        // subscription
+        if (!startInSnapshotSync) {
+            Assert.assertEquals(numUpdates, lrListener.getExistingEntries().size());
+        }
+
+        log.info("Verify the sequence of updates");
+        verifyUpdatesSequence(lrListener.getUpdates());
+
+        log.info("Verify that updates made only after the subscription are received");
+        verifyData(lrListener.getUpdates(), lrListener.getExistingEntries());
+    }
+
+    /**
+     * This test verifies that no updates are received from any other table which the LR listener does not
+     * subscribe to.  It writes updates to the LR Metadata table.  This table is not subscribed to so no updates on
+     * it must be received.
+     * @throws Exception
+     */
+    @Test
+    public void testNoUpdatesReceivedFromNonSubscribedTables() throws Exception {
+        initializeCorfu();
+        openTables();
+
+        lrListener = new LRTestListener(store, namespace, new CountDownLatch(0));
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+
+        // Write to a redundant table to which the listener has not subscribed
+        writeToNonSubscribedSystemTable();
+
+        // Sleep for 1 second and verify that no updates were received on the listener
+        Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+
+        Assert.assertEquals(0, lrListener.getUpdates().size());
+    }
+
+    /**
+     * This test verifies that both LR and non-LR streaming tasks can exist together and function as expected.  The
+     * test subscribes a non-LR listener an LR listener and verifies that the expected updates were received on each.
+     * @throws Exception
+     */
+    @Test
+    public void testNonLRStreamingTaskCoexistence() throws Exception {
+        initializeCorfu();
+        openTables();
+
+        final int numUpdates = 10;
+
+        CountDownLatch countDownLatch = new CountDownLatch(numUpdates);
+        listener = new TestListener(countDownLatch);
+
+        CountDownLatch lrCountDownLatch = new CountDownLatch(numUpdates);
+        lrListener = new LRTestListener(store, namespace, lrCountDownLatch);
+
+        store.subscribeListener(listener, namespace, userTag, Arrays.asList(userTableName));
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+
+        writeToDataTable(numUpdates, 0);
+
+        log.info("Wait for the expected number of updates to arrive");
+        countDownLatch.await();
+        lrCountDownLatch.await();
+
+        log.info("Verify the sequence of updates and received data on both listeners");
+        verifyUpdatesSequence(lrListener.getUpdates());
+        verifyData(lrListener.getUpdates(), lrListener.getExistingEntries());
+
+        verifyUpdatesSequence(listener.getUpdates());
+        verifyData(listener.getUpdates(), new ArrayList<>());
+    }
+
+    private void openTables() throws Exception {
+        userDataTable = store.openTable(namespace, userTableName, SampleSchema.Uuid.class,
+                SampleSchema.SampleTableAMsg.class, SampleSchema.Uuid.class,
+                TableOptions.fromProtoSchema(SampleSchema.SampleTableAMsg.class)
+        );
+
+        replicationStatusTable = store.openTable(CORFU_SYSTEM_NAMESPACE,
+                REPLICATION_STATUS_TABLE_NAME, LogReplicationSession.class,
+                ReplicationStatus.class, null,
+                TableOptions.fromProtoSchema(ReplicationStatus.class));
+
+        try (TxnContext tx = store.txn(CORFU_SYSTEM_NAMESPACE)) {
+            LogReplicationSession key = getTestSession();
+            ReplicationStatus val = getTestReplicationStatus(true);
+            tx.putRecord(replicationStatusTable, key, val, null);
+            tx.commit();
+        }
+    }
+
+    private LogReplicationSession getTestSession() {
+        ReplicationSubscriber subscriber = ReplicationSubscriber.newBuilder().setClientName(testClientName)
+                .setModel(ReplicationModel.LOGICAL_GROUPS)
+                .build();
+        return LogReplicationSession.newBuilder().setSourceClusterId(defaultClusterId)
+                .setSinkClusterId(defaultClusterId).setSubscriber(subscriber)
+                .build();
+    }
+
+    private ReplicationStatus getTestReplicationStatus(boolean dataConsistent) {
+        return ReplicationStatus.newBuilder()
+                .setSinkStatus(SinkReplicationStatus.newBuilder().setDataConsistent(dataConsistent))
+                .build();
+    }
+
+    private void writeDataAndToggleDataConsistentConcurrently(int numIterations, int numUpdatesToDataTable) throws Exception {
+        for (int i = 0; i < numIterations; i++) {
+            boolean dataConsistent;
+            // Toggle Data Consistent in each iteration
+            if (i % 2 == 0) {
+                dataConsistent = false;
+            } else {
+                dataConsistent = true;
+            }
+            int dataTableStart = i * numUpdatesToDataTable;
+            int dataTableEnd = dataTableStart + numUpdatesToDataTable;
+
+            // For every 'numUpdatesToDataTable', there is 1 update to the System Table.
+            scheduleConcurrently(f -> {
+                    for (int index = dataTableStart; index < dataTableEnd; index++) {
+                        try (TxnContext txn = store.txn(namespace)) {
+                            SampleSchema.Uuid uuid = SampleSchema.Uuid.newBuilder().setMsb(index).setLsb(index).build();
+                            SampleSchema.SampleTableAMsg msgA =
+                                SampleSchema.SampleTableAMsg.newBuilder().setPayload(String.valueOf(index))
+                                    .build();
+                            txn.putRecord(userDataTable, uuid, msgA, uuid);
+                            txn.commit();
+                        }
+                    }
+                });
+
+            scheduleConcurrently(f -> {
+                try (TxnContext txn = store.txn(CORFU_SYSTEM_NAMESPACE)) {
+                    LogReplicationSession key = getTestSession();
+                    ReplicationStatus val = getTestReplicationStatus(dataConsistent);
+                    txn.putRecord(replicationStatusTable, key, val, null);
+                    txn.commit();
+                }
+            });
+
+            executeScheduled(2, PARAMETERS.TIMEOUT_NORMAL);
+        }
+    }
+
+    private void writeToDataTable(int numUpdates, int offset) {
+        for (int i = offset; i < offset + numUpdates; i++) {
+            try (TxnContext tx = store.txn(namespace)) {
+                SampleSchema.Uuid uuid = SampleSchema.Uuid.newBuilder().setMsb(i).setLsb(i).build();
+                SampleSchema.SampleTableAMsg msgA = SampleSchema.SampleTableAMsg.newBuilder()
+                        .setPayload(String.valueOf(i)).build();
+                tx.putRecord(userDataTable, uuid, msgA, uuid);
+                tx.commit();
+            }
+        }
+    }
+
+    private void writeToStatusTable(boolean dataConsistent) {
+        try (TxnContext txn = store.txn(CORFU_SYSTEM_NAMESPACE)) {
+            LogReplicationSession key = getTestSession();
+            ReplicationStatus val = getTestReplicationStatus(dataConsistent);
+            txn.putRecord(replicationStatusTable, key, val, null);
+            txn.commit();
+        }
+    }
+
+    private void writeToDataTableMultipleUpdatesInATx(int numUpdates, int offset) {
+        try (TxnContext txn = store.txn(namespace)) {
+            for (int index = offset; index < (offset + numUpdates); index++) {
+                SampleSchema.Uuid uuid = SampleSchema.Uuid.newBuilder().setMsb(index).setLsb(index).build();
+                SampleSchema.SampleTableAMsg msgA =
+                    SampleSchema.SampleTableAMsg.newBuilder().setPayload(String.valueOf(index))
+                        .build();
+                txn.putRecord(userDataTable, uuid, msgA, uuid);
+            }
+            txn.commit();
+        }
+    }
+
+    private void writeToNonSubscribedSystemTable() throws Exception {
+        Table<LogReplicationMetadata.LogReplicationMetadataKey, LogReplicationMetadata.LogReplicationMetadataVal,
+                Message> metadataTable = store.openTable(CORFU_SYSTEM_NAMESPACE,
+                LogReplicationMetadataManager.METADATA_TABLE_NAME,
+                LogReplicationMetadata.LogReplicationMetadataKey.class,
+                LogReplicationMetadata.LogReplicationMetadataVal.class,
+                null,
+                TableOptions.fromProtoSchema(LogReplicationMetadata.LogReplicationMetadataVal.class));
+
+        final int numUpdates = 5;
+        for (int i = 0; i < numUpdates; i++) {
+            try (TxnContext txn = store.txn(CORFU_SYSTEM_NAMESPACE)) {
+                LogReplicationMetadata.LogReplicationMetadataKey key = LogReplicationMetadata.LogReplicationMetadataKey
+                        .newBuilder().setKey(Integer.toString(i)).build();
+                LogReplicationMetadata.LogReplicationMetadataVal val = LogReplicationMetadata.LogReplicationMetadataVal
+                        .newBuilder().setVal(Integer.toString(i)).build();
+                txn.putRecord(metadataTable, key, val, null);
+                txn.commit();
+            }
+        }
+    }
+
+    private void verifyUpdatesSequence(LinkedList<CorfuStreamEntries> updates) {
+        long startTs = -1;
+
+        for (CorfuStreamEntries update : updates) {
+            if(startTs == -1) {
+                startTs = update.getTimestamp().getSequence();
+                continue;
+            }
+            Assert.assertTrue(startTs < update.getTimestamp().getSequence());
+            startTs = update.getTimestamp().getSequence();
+        }
+    }
+
+    private void verifyData(LinkedList<CorfuStreamEntries> updates,
+                            List<CorfuStoreEntry<SampleSchema.Uuid, SampleSchema.SampleTableAMsg, SampleSchema.Uuid>> existingEntries) {
+        Map<String, List<CorfuStreamEntry>> updatesPerTable = new HashMap<>();
+
+        // Group the incoming updates as per the table name
+        for (CorfuStreamEntries update : updates) {
+            for (Map.Entry<TableSchema, List<CorfuStreamEntry>> entry : update.getEntries().entrySet()) {
+                List<CorfuStreamEntry> entries = updatesPerTable.getOrDefault(entry.getKey().getTableName(),
+                    new ArrayList<>());
+                entries.addAll(entry.getValue());
+                updatesPerTable.put(entry.getKey().getTableName(), entries);
+            }
+        }
+
+        // Verify that the streaming data received for each table with the corresponding original table
+        for (String tableName : updatesPerTable.keySet()) {
+            log.info("TableName {}", tableName);
+            // Verify the actual data
+            for (CorfuStreamEntry entry : updatesPerTable.get(tableName)) {
+                    SampleSchema.Uuid key = (SampleSchema.Uuid) entry.getKey();
+                    SampleSchema.SampleTableAMsg val = (SampleSchema.SampleTableAMsg) entry.getPayload();
+                    try (TxnContext txn = store.txn(namespace)) {
+                        Assert.assertEquals(txn.getRecord(tableName, key).getPayload(), val);
+                        txn.commit();
+                    }
+
+            }
+        }
+
+        for (CorfuStoreEntry entry : existingEntries) {
+            try (TxnContext txn = store.txn(namespace)) {
+                SampleSchema.Uuid key = (SampleSchema.Uuid) entry.getKey();
+                SampleSchema.SampleTableAMsg val = (SampleSchema.SampleTableAMsg) entry.getPayload();
+                Assert.assertEquals(txn.getRecord(userTableName, key).getPayload(), val);
+            }
+        }
+    }
+
+    @After
+    @Override
+    public void cleanUp() throws Exception {
+        if (lrListener != null) {
+            store.unsubscribeListener(lrListener);
+        }
+        if (listener != null) {
+            store.unsubscribeListener(listener);
+        }
+        super.cleanUp();
+    }
+
+    private class TestListener implements StreamListener {
+        private CountDownLatch countDownLatch;
+
+        @Getter
+        private final LinkedList<CorfuStreamEntries> updates = new LinkedList<>();
+
+        TestListener(CountDownLatch countDownLatch) {
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public void onNext(CorfuStreamEntries results) {
+            results.getEntries().forEach((key, val) -> countDownLatch.countDown());
+            updates.add(results);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log.error("Error on listener", throwable);
+            fail("onError for CrossNamespaceListener: " + throwable.toString());
+        }
+    }
+
+    private class LRTestListener extends LogReplicationListener {
+        private CountDownLatch countDownLatch;
+
+        // CountDown latch which checks the number of transactions received.
+        // Depending on the type of update, a single overridden method is invoked on the listener per update received
+        // in onNext().  So this latch can be counted down in each method.
+        @Setter
+        CountDownLatch numTxLatch = null;
+
+        // Updates received through streaming
+        @Getter
+        private final LinkedList<CorfuStreamEntries> updates = new LinkedList<>();
+
+        // Entries discovered in performFullSync() before streaming updates are received
+        @Getter
+        private final List<CorfuStoreEntry<SampleSchema.Uuid, SampleSchema.SampleTableAMsg, SampleSchema.Uuid>>
+                existingEntries = new ArrayList<>();
+
+        LRTestListener(CorfuStore corfuStore, String namespace, CountDownLatch countDownLatch) {
+            super(corfuStore, namespace);
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log.error("Error on listener", throwable);
+            fail("onError for LRTestListener: " + throwable.toString());
+        }
+
+        @Override
+        protected void onSnapshotSyncStart() {
+            log.info("Snapshot sync started");
+            countDownNumTxLatch();
+        }
+
+        @Override
+        protected void onSnapshotSyncComplete() {
+            log.info("Snapshot sync complete");
+            countDownNumTxLatch();
+        }
+
+        @Override
+        protected void processUpdatesInSnapshotSync(CorfuStreamEntries results) {
+            log.info("Processing updates in snapshot sync.");
+            updates.add(results);
+            results.getEntries().forEach((key, val) -> countDownLatch.countDown());
+            countDownNumTxLatch();
+        }
+
+        @Override
+        protected void processUpdatesInLogEntrySync(CorfuStreamEntries results) {
+            log.info("Processing updates in log entry sync.");
+            updates.add(results);
+            results.getEntries().forEach((key, val) -> countDownLatch.countDown());
+            countDownNumTxLatch();
+        }
+
+        @Override
+        protected void performFullSync(TxnContext txnContext) {
+            List<CorfuStoreEntry<SampleSchema.Uuid, SampleSchema.SampleTableAMsg, SampleSchema.Uuid>> entries =
+                    txnContext.executeQuery(userTableName, p -> true);
+            existingEntries.addAll(entries);
+
+            existingEntries.forEach(existingEntry -> countDownLatch.countDown());
+            countDownNumTxLatch();
+        }
+
+        private void countDownNumTxLatch() {
+            if (numTxLatch != null) {
+                numTxLatch.countDown();
+            }
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
@@ -17,10 +17,10 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,6 +29,9 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("checkstyle:magicnumber")
 public class DeltaStreamTest {
+    protected final AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+    protected UUID streamId = UUID.randomUUID();
+    protected DeltaStream deltaStream;
 
     private final ReadOptions options = ReadOptions
             .builder()
@@ -40,34 +43,34 @@ public class DeltaStreamTest {
 
     @Test
     public void badArguments() {
-        assertThatThrownBy(() -> new DeltaStream(mock(AddressSpaceView.class), UUID.randomUUID(),
-                -2, 0))
+        assertThatThrownBy(() -> createDeltaStream(-2, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("lastAddressRead -2 must be >= -1");
-        assertThatThrownBy(() -> new DeltaStream(mock(AddressSpaceView.class), UUID.randomUUID(),
-                0, 0))
+        assertThatThrownBy(() -> createDeltaStream(0,0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The size must be greater than 0");
     }
 
+    protected void createDeltaStream(long lastAddressRead, int bufferSize) {
+        deltaStream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+    }
+
     @Test
     public void trimmedLastAddressRead() {
-        UUID streamId = UUID.randomUUID();
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
         final int bufferSize = 10;
         final long lastAddressRead = Address.NON_ADDRESS;
-        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+        createDeltaStream(lastAddressRead, bufferSize);
 
-        assertThat(stream.hasNext()).isFalse();
+        assertThat(deltaStream.hasNext()).isFalse();
         StreamAddressSpace sas = new StreamAddressSpace();
         sas.setTrimMark(Address.NON_ADDRESS);
-        stream.refresh(sas);
-        assertThat(stream.hasNext()).isFalse();
+        deltaStream.refresh(sas);
+        assertThat(deltaStream.hasNext()).isFalse();
 
         sas.setTrimMark(5);
-        stream.refresh(sas);
-        assertThat(stream.hasNext()).isTrue();
-        assertThatThrownBy(stream::next)
+        deltaStream.refresh(sas);
+        assertThat(deltaStream.hasNext()).isTrue();
+        assertThatThrownBy(deltaStream::next)
                 .isInstanceOf(TrimmedException.class)
                 .hasMessage("lastAddressRead -1 trimMark 5");
     }
@@ -100,75 +103,71 @@ public class DeltaStreamTest {
 
     @Test
     public void deltaStreamTest() {
-        UUID streamId = UUID.randomUUID();
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
         final int bufferSize = 10;
         final long lastAddressRead = 0;
-        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
-        assertThat(stream.getStreamId()).isEqualTo(streamId);
-        assertThat(stream.availableSpace()).isEqualTo(bufferSize);
+        createDeltaStream(lastAddressRead, bufferSize);
+        assertThat(deltaStream.getStreamId()).isEqualTo(streamId);
+        assertThat(deltaStream.availableSpace()).isEqualTo(bufferSize);
 
-        assertThat(stream.hasNext()).isFalse();
-        assertThat(stream.getMaxAddressSeen()).isEqualTo(lastAddressRead);
+        assertThat(deltaStream.hasNext()).isFalse();
+        assertThat(deltaStream.getMaxAddressSeen()).isEqualTo(lastAddressRead);
 
-        assertThatThrownBy(stream::next)
+        assertThatThrownBy(deltaStream::next)
                 .isInstanceOf(BufferUnderflowException.class);
 
         // Trigger a trim on an empty stream. This can happen when a stream lags behind, or isn't
         // checkpointed (i.e., data loss)
         StreamAddressSpace sas = new StreamAddressSpace();
         sas.setTrimMark(lastAddressRead);
-        assertThat(sas.getTrimMark()).isEqualTo(stream.getMaxAddressSeen());
-        stream.refresh(sas);
+        assertThat(sas.getTrimMark()).isEqualTo(deltaStream.getMaxAddressSeen());
+        deltaStream.refresh(sas);
 
         // Verify that hasNext() returns true after the refresh (i.e., when the buffer is empty, but a trim
         // exception has occurred
-        assertThat(stream.hasNext()).isFalse();
+        assertThat(deltaStream.hasNext()).isFalse();
 
         StreamAddressSpace sas2 = new StreamAddressSpace();
         sas2.setTrimMark(1);
-        stream.refresh(sas2);
-        assertThat(stream.hasNext()).isTrue();
-        assertThatThrownBy(stream::next)
+        deltaStream.refresh(sas2);
+        assertThat(deltaStream.hasNext()).isTrue();
+        assertThatThrownBy(deltaStream::next)
                 .isInstanceOf(TrimmedException.class)
                 .hasMessage("lastAddressRead 0 trimMark 1");
 
         // Verify that hasNext persists next has thrown an exception
-        assertThat(stream.hasNext()).isTrue();
+        assertThat(deltaStream.hasNext()).isTrue();
 
         sas.addAddress(1);
         sas.addAddress(2);
         sas.trim(1);
-        stream.refresh(sas);
-        assertThat(stream.hasNext()).isTrue();
+        deltaStream.refresh(sas);
+        assertThat(deltaStream.hasNext()).isTrue();
         // Verify that refresh doesn't add new addresses to the buffer once it detects a trimmed exception
-        assertThat(stream.availableSpace()).isEqualTo(bufferSize);
+        assertThat(deltaStream.availableSpace()).isEqualTo(bufferSize);
     }
 
     @Test
     public void deltaStreamReadTest() {
-        UUID streamId = UUID.randomUUID();
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
         final int bufferSize = 10;
         final long lastAddressRead = 0;
-        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+        createDeltaStream(lastAddressRead, bufferSize);
 
-        assertThat(stream.availableSpace()).isEqualTo(bufferSize);
-        assertThat(stream.hasNext()).isFalse();
+        assertThat(deltaStream.availableSpace()).isEqualTo(bufferSize);
+        assertThat(deltaStream.hasNext()).isFalse();
 
         StreamAddressSpace sas = new StreamAddressSpace();
         sas.addAddress(1);
         sas.addAddress(2);
 
-        stream.refresh(sas);
-        assertThat(stream.availableSpace()).isEqualTo(bufferSize - 2);
+        deltaStream.refresh(sas);
+        assertThat(deltaStream.availableSpace()).isEqualTo(bufferSize - 2);
 
         MultiObjectSMREntry mos = new MultiObjectSMREntry();
         mos.addTo(streamId, new SMREntry());
         mos.setGlobalAddress(1);
 
         LogData ld = new LogData(DataType.DATA, mos);
-        ld.setBackpointerMap(Collections.singletonMap(streamId, Address.NON_EXIST));
+        ld.setBackpointerMap(getTestBackpointerMap());
         ld.setGlobalAddress(1L);
 
         LogData hole = new LogData(DataType.HOLE);
@@ -179,68 +178,68 @@ public class DeltaStreamTest {
 
         // Verify that next can retrieve the addresses refreshed from the StreamAddressSpace
         // and that the buffer is being maintained correctly
-        assertThat(stream.hasNext()).isTrue();
-        assertThat(stream.next()).isEqualTo(ld);
-        assertThat(stream.availableSpace()).isEqualTo(bufferSize - 1);
-        assertThat(stream.hasNext()).isTrue();
-        assertThat(stream.next()).isEqualTo(hole);
-        assertThat(stream.hasNext()).isFalse();
-        assertThat(stream.availableSpace()).isEqualTo(bufferSize);
+        assertThat(deltaStream.hasNext()).isTrue();
+        assertThat(deltaStream.next()).isEqualTo(ld);
+        assertThat(deltaStream.availableSpace()).isEqualTo(bufferSize - 1);
+        assertThat(deltaStream.hasNext()).isTrue();
+        assertThat(deltaStream.next()).isEqualTo(hole);
+        assertThat(deltaStream.hasNext()).isFalse();
+        assertThat(deltaStream.availableSpace()).isEqualTo(bufferSize);
 
         // Verify that refreshing stream with the same stream address space, won't produce duplicates
-        assertThatThrownBy(() -> stream.refresh(sas))
+        assertThatThrownBy(() -> deltaStream.refresh(sas))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("maxAddressSeen 2 not < 1");
-        assertThat(stream.hasNext()).isFalse();
-        assertThat(stream.availableSpace()).isEqualTo(bufferSize);
+        assertThat(deltaStream.hasNext()).isFalse();
+        assertThat(deltaStream.availableSpace()).isEqualTo(bufferSize);
+    }
+
+    protected Map<UUID, Long> getTestBackpointerMap() {
+        return Collections.singletonMap(streamId, Address.NON_EXIST);
     }
 
     @Test
     public void refreshOverflow() {
-        UUID streamId = UUID.randomUUID();
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
         final int bufferSize = 2;
         final long lastAddressRead = 0;
-        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+        createDeltaStream(lastAddressRead, bufferSize);
         StreamAddressSpace sas = new StreamAddressSpace();
         sas.addAddress(1L);
         sas.addAddress(2L);
-        stream.refresh(sas);
-        assertThat(stream.availableSpace()).isEqualTo(0);
-        assertThat(stream.getMaxAddressSeen()).isEqualTo(2L);
+        deltaStream.refresh(sas);
+        assertThat(deltaStream.availableSpace()).isEqualTo(0);
+        assertThat(deltaStream.getMaxAddressSeen()).isEqualTo(2L);
 
         StreamAddressSpace sas2 = new StreamAddressSpace();
         sas2.addAddress(3L);
         sas2.addAddress(4L);
-        stream.refresh(sas2);
-        assertThat(stream.availableSpace()).isEqualTo(0);
-        assertThat(stream.getMaxAddressSeen()).isEqualTo(2L);
+        deltaStream.refresh(sas2);
+        assertThat(deltaStream.availableSpace()).isEqualTo(0);
+        assertThat(deltaStream.getMaxAddressSeen()).isEqualTo(2L);
 
         // Verify that the buffer can be partially replenished
         LogData hole = new LogData(DataType.HOLE);
         hole.setGlobalAddress(1L);
         when(addressSpaceView.read(1L, options)).thenReturn(hole);
-        assertThat(stream.next()).isEqualTo(hole);
-        assertThat(stream.availableSpace()).isEqualTo(1L);
-        assertThat(stream.getMaxAddressSeen()).isEqualTo(2L);
+        assertThat(deltaStream.next()).isEqualTo(hole);
+        assertThat(deltaStream.availableSpace()).isEqualTo(1L);
+        assertThat(deltaStream.getMaxAddressSeen()).isEqualTo(2L);
         // After partially replenishing the buffer the max address seen is incremented and the buffer is full again
-        stream.refresh(sas2);
-        assertThat(stream.availableSpace()).isEqualTo(0L);
-        assertThat(stream.getMaxAddressSeen()).isEqualTo(3L);
-        assertThat(stream.hasNext()).isTrue();
+        deltaStream.refresh(sas2);
+        assertThat(deltaStream.availableSpace()).isEqualTo(0L);
+        assertThat(deltaStream.getMaxAddressSeen()).isEqualTo(3L);
+        assertThat(deltaStream.hasNext()).isTrue();
     }
 
     @Test
     public void badStreamRead() {
-        UUID streamId = UUID.randomUUID();
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
         final int bufferSize = 2;
         final long lastAddressRead = 0;
-        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+        createDeltaStream(lastAddressRead, bufferSize);
         StreamAddressSpace sas = new StreamAddressSpace();
         sas.addAddress(1L);
         sas.addAddress(2L);
-        stream.refresh(sas);
+        deltaStream.refresh(sas);
 
         CheckpointEntry cp1 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
                 "checkpointAuthor", UUID.randomUUID(), streamId,
@@ -252,29 +251,30 @@ public class DeltaStreamTest {
                 Address.NON_EXIST));
         when(addressSpaceView.read(1, options)).thenReturn(ld);
 
-        // We should only LogData that belongs to the stream
-        assertThatThrownBy(stream::next)
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(String.format("[%s] must contain %s",
-                        CorfuRuntime.getCheckpointStreamIdFromId(streamId), streamId));
+        // We should only received LogData that belongs to the stream
+        verifyExceptionAndErrorBasedOnStreamType();
+    }
+
+    protected void verifyExceptionAndErrorBasedOnStreamType() {
+        assertThatThrownBy(deltaStream::next)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(String.format("[%s] must contain %s",
+                CorfuRuntime.getCheckpointStreamIdFromId(streamId), streamId));
     }
 
     @Test
     public void concurrencyTest() throws Exception {
-
-        UUID streamId = UUID.randomUUID();
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
         final int bufferSize = 1;
         final long lastAddressRead = -1;
-        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+        createDeltaStream(lastAddressRead, bufferSize);
         List<ILogData> consumed = new CopyOnWriteArrayList<>();
         final int numToProduce = 50;
 
         CountDownLatch done = new CountDownLatch(numToProduce);
         Thread consumer = new Thread(() -> {
             while (true) {
-                if (stream.hasNext()) {
-                    consumed.add(stream.next());
+                if (deltaStream.hasNext()) {
+                    consumed.add(deltaStream.next());
                     done.countDown();
                     if (done.getCount() == 0) {
                         break;
@@ -295,12 +295,12 @@ public class DeltaStreamTest {
         Thread producer = new Thread(() -> {
             int numProduced = 0;
             while (numProduced < numToProduce) {
-                if (stream.availableSpace() > 0) {
+                if (deltaStream.availableSpace() > 0) {
                     // produce in batches of 3
-                    long nextAddressToProduce = stream.getMaxAddressSeen() + 1;
+                    long nextAddressToProduce = deltaStream.getMaxAddressSeen() + 1;
                     StreamAddressSpace sas = new StreamAddressSpace();
                     sas.addAddress(nextAddressToProduce);
-                    stream.refresh(sas);
+                    deltaStream.refresh(sas);
                     numProduced++;
                 }
             }
@@ -309,7 +309,7 @@ public class DeltaStreamTest {
 
         producer.setName("producer");
         producer.start();
-        done.await(1, TimeUnit.SECONDS);
+        done.await();
 
         assertThat(consumed.size()).isEqualTo(numToProduce);
         for (int x = 0; x < numToProduce; x++) {

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/LRDeltaStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/LRDeltaStreamTest.java
@@ -1,0 +1,52 @@
+package org.corfudb.runtime.collections.streaming;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.Address;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * This class runs all tests from its superclass - DeltaStreamTest, with the stream type as LRDeltaStream.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public class LRDeltaStreamTest extends DeltaStreamTest {
+
+    private final List<UUID> streamsTracked = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
+
+    @Override
+    protected void createDeltaStream(long lastAddressRead, int bufferSize) {
+        deltaStream = new LRDeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize, streamsTracked);
+    }
+
+    @Override
+    protected void verifyExceptionAndErrorBasedOnStreamType() {
+        assertThatThrownBy(deltaStream::next)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(String.format("[%s] does not contain a backpointer to any stream being tracked %s",
+                CorfuRuntime.getCheckpointStreamIdFromId(streamId), Arrays.toString(streamsTracked.toArray())));
+    }
+
+    @Override
+    protected Map<UUID, Long> getTestBackpointerMap() {
+        return Collections.singletonMap(streamsTracked.iterator().next(), Address.NON_EXIST);
+    }
+
+    @Override
+    @Test
+    public void badArguments() {
+        assertThatThrownBy(() -> new LRDeltaStream(addressSpaceView, streamId,
+            -2, 0, streamsTracked))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("lastAddressRead -2 must be >= -1");
+        assertThatThrownBy(() -> new LRDeltaStream(addressSpaceView, streamId,
+            0, 0, streamsTracked))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The size must be greater than 0");
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/LRStreamingTaskTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/LRStreamingTaskTest.java
@@ -1,0 +1,66 @@
+package org.corfudb.runtime.collections.streaming;
+
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.TableRegistry;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.LR_STATUS_STREAM_TAG;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.corfudb.runtime.collections.streaming.LRStreamingTask.LR_MULTI_NAMESPACE_LOGICAL_STREAM_ID;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class runs all tests from its superclass - StreamingTaskTest, with the task type as LRStreamingTask.
+ */
+public class LRStreamingTaskTest extends StreamingTaskTest {
+
+    // Variables for the Data table
+    private final String dataNamespace = "test_namespace";
+    private final String dataTableName = "table";
+    private final String dataStreamTag = "tag_1";
+    private final UUID dataStreamTagId = TableRegistry.getStreamIdForStreamTag(dataNamespace, dataStreamTag);
+
+    // Variables for the System table
+    private final String systemNamespace = CORFU_SYSTEM_NAMESPACE;
+    private final String systemTableName = REPLICATION_STATUS_TABLE_NAME;
+    private final String systemStreamTag = LR_STATUS_STREAM_TAG;
+    private final UUID systemStreamTagId = TableRegistry.getStreamIdForStreamTag(systemNamespace, systemStreamTag);
+
+    @Override
+    protected void taskTypeSpecificSetup() {
+        TableRegistry registry = mock(TableRegistry.class);
+        when(runtime.getTableRegistry()).thenReturn(registry);
+
+        Table dataTable = mock(Table.class);
+        when(registry.getTable(dataNamespace, dataTableName)).thenReturn(dataTable);
+        when(dataTable.getStreamTags()).thenReturn(Collections.singleton(dataStreamTagId));
+
+        Table systemTable = mock(Table.class);
+        when(registry.getTable(systemNamespace, systemTableName)).thenReturn(systemTable);
+        when(systemTable.getStreamTags()).thenReturn(Collections.singleton(systemStreamTagId));
+
+        Map<String, List<String>> nsToTableNames = new HashMap<>();
+        nsToTableNames.put(dataNamespace, Arrays.asList(dataTableName));
+        nsToTableNames.put(systemNamespace, Arrays.asList(systemTableName));
+
+        Map<String, String> nsToStreamTags = new HashMap<>();
+        nsToStreamTags.put(dataNamespace, dataStreamTag);
+        nsToStreamTags.put(systemNamespace, systemStreamTag);
+
+        task = new LRStreamingTask(runtime, workers, nsToStreamTags, nsToTableNames, listener, Address.NON_ADDRESS,
+            bufferSize);
+    }
+
+    @Override
+    protected UUID getTaskStreamId() {
+        return LR_MULTI_NAMESPACE_LOGICAL_STREAM_ID;
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/StreamPollingSchedulerLRTaskTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/StreamPollingSchedulerLRTaskTest.java
@@ -1,0 +1,114 @@
+package org.corfudb.runtime.collections.streaming;
+
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.LR_STATUS_STREAM_TAG;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class runs all tests from its superclass - StreamPollingSchedulerTest, with the task type as LRStreamingTask.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public class StreamPollingSchedulerLRTaskTest extends StreamPollingSchedulerTest {
+
+    // Variables for the Data table
+    private final String dataNamespace = "test_namespace";
+    private final String dataTableName = "table";
+    private final String dataStreamTag = "tag_1";
+    private final UUID dataStreamTagId = TableRegistry.getStreamIdForStreamTag(dataNamespace, dataStreamTag);
+
+    // Variables for the System table
+    private final String systemNamespace = CORFU_SYSTEM_NAMESPACE;
+    private final String systemTableName = REPLICATION_STATUS_TABLE_NAME;
+    private final String systemStreamTag = LR_STATUS_STREAM_TAG;
+    private final UUID systemStreamTagId = TableRegistry.getStreamIdForStreamTag(systemNamespace, systemStreamTag);
+
+    private final Map<String, List<String>> nsToTableNames = new HashMap<>();
+    private final Map<String, String> nsToStreamTags = new HashMap<>();
+
+    @Override
+    @Test
+    public void testShutdown() {
+        // Do nothing.  This is a generic test in the super class and need not be run again.
+    }
+
+    @Override
+    protected void taskTypeSpecificSetup() {
+        TableRegistry registry = mock(TableRegistry.class);
+        when(runtime.getTableRegistry()).thenReturn(registry);
+
+        Table dataTable = mock(Table.class);
+        when(registry.getTable(dataNamespace, dataTableName)).thenReturn(dataTable);
+        when(dataTable.getStreamTags()).thenReturn(Collections.singleton(dataStreamTagId));
+
+        Table systemTable = mock(Table.class);
+        when(registry.getTable(systemNamespace, systemTableName)).thenReturn(systemTable);
+        when(systemTable.getStreamTags()).thenReturn(Collections.singleton(systemStreamTagId));
+
+        nsToTableNames.put(dataNamespace, Arrays.asList(dataTableName));
+        nsToTableNames.put(systemNamespace, Arrays.asList(systemTableName));
+
+        nsToStreamTags.put(dataNamespace, dataStreamTag);
+        nsToStreamTags.put(systemNamespace, systemStreamTag);
+    }
+
+    @Override
+    protected void addTask(long lastAddress, int bufferSize) {
+        streamPoller.addLRTask(listener, nsToStreamTags, nsToTableNames, lastAddress, bufferSize);
+    }
+
+    @Override
+    protected Map<UUID, StreamAddressSpace> constructMockAddressMap(long lastAddressRead, boolean trim) {
+        StreamAddressSpace dataSas = new StreamAddressSpace();
+        StreamAddressSpace systemSas = new StreamAddressSpace();
+
+        if (trim) {
+            dataSas.setTrimMark(lastAddressRead+5);
+            systemSas.setTrimMark(lastAddressRead+10);
+        } else {
+            dataSas.addAddress(lastAddressRead+1);
+            addressesInStreamAddressSpace.add(lastAddressRead+1);
+
+            systemSas.addAddress(lastAddressRead+2);
+            addressesInStreamAddressSpace.add(lastAddressRead+2);
+        }
+        Map<UUID, StreamAddressSpace> map = new HashMap<>();
+        map.put(dataStreamTagId, dataSas);
+        map.put(systemStreamTagId, systemSas);
+        return map;
+    }
+
+    @Override
+    protected List<StreamAddressRange> constructRangeQueryList(long end) {
+        StreamAddressRange dataRange = new StreamAddressRange(dataStreamTagId, Address.MAX, end);
+        StreamAddressRange systemRange = new StreamAddressRange(systemStreamTagId, Address.MAX, end);
+        return Arrays.asList(dataRange, systemRange);
+    }
+
+    // Constructs the next address after 'end'
+    @Override
+    protected Map<UUID, StreamAddressSpace> constructNextAddress(long end) {
+        StreamAddressSpace dataSas = new StreamAddressSpace();
+        StreamAddressSpace systemSas = new StreamAddressSpace();
+        dataSas.addAddress(end+1);
+        systemSas.addAddress(end+2);
+        Map<UUID, StreamAddressSpace> map = new HashMap<>();
+        map.put(dataStreamTagId, dataSas);
+        map.put(systemStreamTagId, systemSas);
+        return map;
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/StreamPollingSchedulerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/StreamPollingSchedulerTest.java
@@ -1,7 +1,5 @@
 package org.corfudb.runtime.collections.streaming;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.LogData;
@@ -18,13 +16,17 @@ import org.corfudb.runtime.view.ReadOptions;
 import org.corfudb.runtime.view.SequencerView;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -43,6 +45,19 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("checkstyle:magicnumber")
 public class StreamPollingSchedulerTest {
 
+    protected final ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    protected final ExecutorService workers = mock(ExecutorService.class);
+    protected final CorfuRuntime runtime = mock(CorfuRuntime.class);
+    protected final SequencerView sequencerView = mock(SequencerView.class);
+    protected final AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+    protected final TestStreamListener listener = new TestStreamListener();
+    protected StreamPollingScheduler streamPoller;
+    protected final List<Long> addressesInStreamAddressSpace = new ArrayList<>();
+    private final String namespace = "test_namespace";
+    private final String tableName = "table";
+    private final String streamTag = "tag_1";
+    private final UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
+
     private final ReadOptions options = ReadOptions
             .builder()
             .clientCacheable(false)
@@ -50,6 +65,25 @@ public class StreamPollingSchedulerTest {
             .waitForHole(true)
             .serverCacheable(false)
             .build();
+
+    @Before
+    public void setUp() {
+        commonSetup();
+        taskTypeSpecificSetup();
+    }
+
+    private void commonSetup() {
+        when(runtime.getSequencerView()).thenReturn(sequencerView);
+        when(runtime.getAddressSpaceView()).thenReturn(addressSpaceView);
+    }
+
+    protected void taskTypeSpecificSetup() {
+        Table table = mock(Table.class);
+        TableRegistry registry = mock(TableRegistry.class);
+        when(runtime.getTableRegistry()).thenReturn(registry);
+        when(registry.getTable(namespace, tableName)).thenReturn(table);
+        when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
+    }
 
     @Test
     public void badConfigs() {
@@ -90,82 +124,24 @@ public class StreamPollingSchedulerTest {
         }
     }
 
-    @Data
-    @AllArgsConstructor
-    class MockedContext {
-        private final ScheduledExecutorService scheduler;
-        private final ExecutorService workers;
-        private final CorfuRuntime runtime;
-        private final AddressSpaceView addressSpaceView;
-        private final SequencerView sequencerView;
-        private final Table table;
-        private final TableRegistry registry;
-        private final String namespace;
-        private final String tableName;
-        private final String streamTag;
-        private final UUID streamTagId;
-    }
-
-    /**
-     * Creates a mocked context for a single registered table.
-     */
-    MockedContext getContext() {
-        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        SequencerView sequencerView = mock(SequencerView.class);
-        when(runtime.getSequencerView()).thenReturn(sequencerView);
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
-        when(runtime.getAddressSpaceView()).thenReturn(addressSpaceView);
-
-        final String namespace = "test_namespace";
-        final String tableName = "table";
-
-        String streamTag = "tag_1";
-        Table table = mock(Table.class);
-        TableRegistry registry = mock(TableRegistry.class);
-        when(runtime.getTableRegistry()).thenReturn(registry);
-        when(registry.getTable(namespace, tableName)).thenReturn(table);
-        UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
-        when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
-
-        return new MockedContext(scheduler, workers, runtime, addressSpaceView, sequencerView,
-                table, registry, namespace, tableName, streamTag, streamTagId);
-    }
-
     @Test
     public void testAddTask() throws Exception {
-        MockedContext ctx = getContext();
-        final ScheduledExecutorService scheduler = ctx.getScheduler();
-        final ExecutorService workers = ctx.getWorkers();
-        final CorfuRuntime runtime = ctx.getRuntime();
-        final AddressSpaceView addressSpaceView = ctx.getAddressSpaceView();
-        final SequencerView sequencerView = ctx.getSequencerView();
-        final String namespace = ctx.getNamespace();
-        final String tableName = ctx.getTableName();
-        final String streamTag = ctx.getStreamTag();
-        final UUID streamTagId = ctx.getStreamTagId();
-
-        final StreamPollingScheduler streamPoller = new StreamPollingScheduler(runtime, scheduler,
-                workers, Duration.ofMillis(50), 25, 5);
+        streamPoller = new StreamPollingScheduler(runtime, scheduler, workers, Duration.ofMillis(50), 25, 5);
 
         verify(scheduler, times(1)).submit(any(StreamPollingScheduler.Tick.class));
-
-        StreamListener listener = new TestStreamListener();
-        streamPoller.addTask(listener, namespace, streamTag, Collections.singletonList(tableName), 0, 10);
+        addTask(0, 10);
 
         // Verify that the same listener can't be registered more than once
-        assertThatThrownBy(() -> streamPoller.addTask(listener, namespace, streamTag,
-                Collections.singletonList(tableName), 0, 10))
+        assertThatThrownBy(() -> addTask(0, 10))
                 .isInstanceOf(StreamingException.class)
                 .hasMessage("StreamingManager::subscribe: listener already registered " + listener);
 
-        StreamAddressRange rangeQuery = new StreamAddressRange(streamTagId, Address.MAX, 0);
-        StreamAddressSpace sas = new StreamAddressSpace();
-        sas.addAddress(1);
-        sas.addAddress(2);
-        when(sequencerView.getStreamsAddressSpace(Collections.singletonList(rangeQuery)))
-                .thenReturn(Collections.singletonMap(streamTagId, sas));
+        Map<UUID, StreamAddressSpace> streamAddressSpaceMap = constructMockAddressMap(0, false);
+        List<StreamAddressRange> rangeQueryList = constructRangeQueryList(0);
+        when(sequencerView.getStreamsAddressSpace(rangeQueryList)).thenReturn(streamAddressSpaceMap);
+
+        int numAddressesReceived = addressesInStreamAddressSpace.size();
+
         streamPoller.schedule();
 
         // verify that the scheduler submitted a syncing task to read address 1 and 2
@@ -178,21 +154,21 @@ public class StreamPollingSchedulerTest {
         StreamingTask task = taskCaptor.getValue();
         assertThat(task.getStatus()).isEqualTo(StreamStatus.SYNCING);
         // Verify that the scheduler polled the stream correctly
-        assertThat(task.getStream().getMaxAddressSeen()).isEqualTo(2);
+        assertThat(task.getStream().getMaxAddressSeen()).isEqualTo(numAddressesReceived);
         LogData hole = new LogData(DataType.HOLE);
-        hole.setGlobalAddress(1L);
-        when(addressSpaceView.read(1, options)).thenReturn(hole);
+        hole.setGlobalAddress(addressesInStreamAddressSpace.get(0));
+        when(addressSpaceView.read(addressesInStreamAddressSpace.get(0), options)).thenReturn(hole);
         task.run();
-        verify(addressSpaceView, times(1)).read(1, options);
+        verify(addressSpaceView, times(1)).read(addressesInStreamAddressSpace.get(0), options);
 
         // Verify that after the first run, the task will re-submit itself to produce again
         verify(workers, times(2)).execute(taskCaptor.capture());
         assertThat(taskCaptor.getValue()).isEqualTo(task);
         LogData hole2 = new LogData(DataType.HOLE);
-        hole2.setGlobalAddress(2L);
-        when(addressSpaceView.read(2, options)).thenReturn(hole2);
+        hole2.setGlobalAddress(addressesInStreamAddressSpace.get(1));
+        when(addressSpaceView.read(addressesInStreamAddressSpace.get(1), options)).thenReturn(hole2);
         task.run();
-        verify(addressSpaceView, times(1)).read(2, options);
+        verify(addressSpaceView, times(1)).read(addressesInStreamAddressSpace.get(1), options);
         // verify that after consuming all the deltas, it changes it's status to runnable
         // and doesn't reschedule itself
         assertThat(task.getStatus()).isEqualTo(StreamStatus.RUNNABLE);
@@ -201,40 +177,16 @@ public class StreamPollingSchedulerTest {
 
     @Test
     public void testTrimmedExceptionOnRefresh() throws Exception {
-        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        SequencerView sequencerView = mock(SequencerView.class);
-        when(runtime.getSequencerView()).thenReturn(sequencerView);
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
-        when(runtime.getAddressSpaceView()).thenReturn(addressSpaceView);
-
-        final StreamPollingScheduler streamPoller = new StreamPollingScheduler(runtime, scheduler, workers,
-                Duration.ofMillis(50), 25, 5);
+        streamPoller = new StreamPollingScheduler(runtime, scheduler, workers, Duration.ofMillis(50),
+                25, 5);
 
         verify(scheduler, times(1)).submit(any(StreamPollingScheduler.Tick.class));
 
-        final String namespace = "test_namespace";
-        final String tableName = "table";
+        addTask(5, 10);
 
-        final TestStreamListener listener = new TestStreamListener();
-
-        String streamTag = "tag_1";
-        Table table = mock(Table.class);
-        TableRegistry registry = mock(TableRegistry.class);
-        when(runtime.getTableRegistry()).thenReturn(registry);
-        when(registry.getTable(namespace, tableName)).thenReturn(table);
-        UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
-        when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
-
-        streamPoller.addTask(listener, namespace, streamTag, Collections.singletonList(tableName), 5, 10);
-
-        StreamAddressRange rangeQuery = new StreamAddressRange(streamTagId, Address.MAX, 5);
-        StreamAddressSpace sas = new StreamAddressSpace();
-        sas.setTrimMark(10L);
-
-        when(sequencerView.getStreamsAddressSpace(Collections.singletonList(rangeQuery)))
-                .thenReturn(Collections.singletonMap(streamTagId, sas));
+        List<StreamAddressRange> rangeQueryList = constructRangeQueryList(5);
+        Map<UUID, StreamAddressSpace> streamAddressSpaceMap = constructMockAddressMap(5, true);
+        when(sequencerView.getStreamsAddressSpace(rangeQueryList)).thenReturn(streamAddressSpaceMap);
 
         streamPoller.schedule();
 
@@ -249,54 +201,26 @@ public class StreamPollingSchedulerTest {
         task.propagateError();
         assertThat(listener.getThrowable())
                 .isInstanceOf(StreamingException.class)
-                .hasCause(new TrimmedException("lastAddressRead 5 trimMark 10"));
+                .hasCause(new TrimmedException("lastAddressRead 5 trimMark " + task.getStream().getTrimMark()));
     }
 
     @Test
     public void testTrimmedExceptionOnRead() throws Exception {
-        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        SequencerView sequencerView = mock(SequencerView.class);
-        when(runtime.getSequencerView()).thenReturn(sequencerView);
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
-        when(runtime.getAddressSpaceView()).thenReturn(addressSpaceView);
-
-        final StreamPollingScheduler streamPoller = new StreamPollingScheduler(runtime, scheduler, workers,
-                Duration.ofMillis(50), 25, 5);
+        streamPoller = new StreamPollingScheduler(runtime, scheduler, workers, Duration.ofMillis(50), 25,
+                5);
 
         verify(scheduler, times(1)).submit(any(StreamPollingScheduler.Tick.class));
 
-        final String namespace = "test_namespace";
-        final String tableName = "table";
-
-        final TestStreamListener listener = new TestStreamListener();
-
-        String streamTag = "tag_1";
-        Table table = mock(Table.class);
-        TableRegistry registry = mock(TableRegistry.class);
-        when(runtime.getTableRegistry()).thenReturn(registry);
-        when(registry.getTable(namespace, tableName)).thenReturn(table);
-        UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
-        when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
-        // listener, namespace, "sample_streamer_1", Collections.singletonList(tableName)
-
-        streamPoller.addTask(listener, namespace, streamTag, Collections.singletonList(tableName), 5, 10);
+        addTask(5, 10);
 
         // Verify that the same listener can't be registered more than once
-        assertThatThrownBy(() -> streamPoller.addTask(listener, namespace, streamTag,
-                Collections.singletonList(tableName), 0, 10))
+        assertThatThrownBy(() -> addTask(5, 10))
                 .isInstanceOf(StreamingException.class)
                 .hasMessage("StreamingManager::subscribe: listener already registered " + listener);
 
-
-        StreamAddressRange rangeQuery = new StreamAddressRange(streamTagId, Address.MAX, 5);
-        StreamAddressSpace sas = new StreamAddressSpace();
-        sas.addAddress(6);
-        sas.addAddress(7);
-
-        when(sequencerView.getStreamsAddressSpace(Collections.singletonList(rangeQuery)))
-                .thenReturn(Collections.singletonMap(streamTagId, sas));
+        List<StreamAddressRange> rangeQueryList = constructRangeQueryList(5);
+        Map<UUID, StreamAddressSpace> streamAddressSpaceMap = constructMockAddressMap(5, false);
+        when(sequencerView.getStreamsAddressSpace(rangeQueryList)).thenReturn(streamAddressSpaceMap);
 
         streamPoller.schedule();
 
@@ -312,13 +236,14 @@ public class StreamPollingSchedulerTest {
 
         // Verify that trimmed exceptions can be discovered during syncing
         LogData hole = new LogData(DataType.HOLE);
-        hole.setGlobalAddress(6L);
-        when(addressSpaceView.read(6, options)).thenReturn(hole);
+        hole.setGlobalAddress(addressesInStreamAddressSpace.get(0));
+        when(addressSpaceView.read(addressesInStreamAddressSpace.get(0), options)).thenReturn(hole);
         task.run();
         assertThat(task.getStatus()).isEqualTo(StreamStatus.SYNCING);
 
-        hole.setGlobalAddress(7L);
-        when(addressSpaceView.read(7, options)).thenThrow(new TrimmedException(7L));
+        hole.setGlobalAddress(addressesInStreamAddressSpace.get(1));
+        when(addressSpaceView.read(addressesInStreamAddressSpace.get(1), options)).thenThrow(
+            new TrimmedException(addressesInStreamAddressSpace.get(1)));
         task.run();
         assertThat(task.getStatus()).isEqualTo(StreamStatus.ERROR);
         streamPoller.schedule();
@@ -334,49 +259,25 @@ public class StreamPollingSchedulerTest {
         task.propagateError();
         assertThat(listener.getThrowable())
                 .isInstanceOf(StreamingException.class)
-                .hasCause(new TrimmedException(7L));
+                .hasCause(new TrimmedException(addressesInStreamAddressSpace.get(1)));
     }
 
     @Test
     public void testRefreshWhileSyncing() throws Exception {
-        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        SequencerView sequencerView = mock(SequencerView.class);
-        when(runtime.getSequencerView()).thenReturn(sequencerView);
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
-        when(runtime.getAddressSpaceView()).thenReturn(addressSpaceView);
-
         final int pollThreshold = 5;
 
-        final StreamPollingScheduler streamPoller = new StreamPollingScheduler(runtime, scheduler, workers,
-                Duration.ofMillis(50), 25, pollThreshold);
+        streamPoller = new StreamPollingScheduler(runtime, scheduler, workers, Duration.ofMillis(50), 25,
+                pollThreshold);
 
         verify(scheduler, times(1)).submit(any(StreamPollingScheduler.Tick.class));
+        addTask(0, 6);
 
-        final String namespace = "test_namespace";
-        final String tableName = "table";
-
-        final StreamListener listener = new TestStreamListener();
-
-        String streamTag = "tag_1";
-        Table table = mock(Table.class);
-        TableRegistry registry = mock(TableRegistry.class);
-        when(runtime.getTableRegistry()).thenReturn(registry);
-        when(registry.getTable(namespace, tableName)).thenReturn(table);
-        UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
-        when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
-        streamPoller.addTask(listener, namespace, streamTag, Collections.singletonList(tableName), 0, 6);
-
-        StreamAddressRange rangeQuery = new StreamAddressRange(streamTagId, Address.MAX, 0);
-        StreamAddressSpace sas = new StreamAddressSpace();
-        sas.addAddress(1);
-        sas.addAddress(2);
-        when(sequencerView.getStreamsAddressSpace(Collections.singletonList(rangeQuery)))
-                .thenReturn(Collections.singletonMap(streamTagId, sas));
+        List<StreamAddressRange> rangeQueryList = constructRangeQueryList(0);
+        Map<UUID, StreamAddressSpace> streamAddressSpaceMap = constructMockAddressMap(0, false);
+        when(sequencerView.getStreamsAddressSpace(rangeQueryList)).thenReturn(streamAddressSpaceMap);
         streamPoller.schedule();
 
-        // verify that the scheduler submitted a syncing task to read address 1 and 2
+        // verify that the scheduler submitted a syncing task to read the addresses obtained so far
         //verify(workers, times(1)).submit(streamingTaskCaptor.capture(), any(StreamingTask.class));
         ArgumentCaptor<StreamingTask> taskCaptor = ArgumentCaptor.forClass(StreamingTask.class);
         verify(workers, times(1)).execute(taskCaptor.capture());
@@ -396,30 +297,28 @@ public class StreamPollingSchedulerTest {
         // Verify that while the task is syncing, it hasn't been polled (because its backed up, that is
         // availableSpace is less than the pollThreshold) or scheduled, and that it hasn't been rescheduled
         verify(workers, only()).execute(any(StreamingTask.class));
-        verify(sequencerView, only()).getStreamsAddressSpace(Collections.singletonList(rangeQuery));
+        verify(sequencerView, only()).getStreamsAddressSpace(rangeQueryList);
         verify(workers, times(1)).execute(any(StreamingTask.class));
 
         // Allow the stream to free some space
         LogData hole = new LogData(DataType.HOLE);
-        hole.setGlobalAddress(1L);
-        when(addressSpaceView.read(1, options)).thenReturn(hole);
+        hole.setGlobalAddress(addressesInStreamAddressSpace.get(0));
+        when(addressSpaceView.read(addressesInStreamAddressSpace.get(0), options)).thenReturn(hole);
         task.run();
         verify(workers, times(2)).execute(any(StreamingTask.class));
-        verify(addressSpaceView, times(1)).read(1, options);
+        verify(addressSpaceView, times(1)).read(addressesInStreamAddressSpace.get(0), options);
 
         // Verify that the task is still syncing, but now has available space to be refreshed
         assertThat(task.getStatus()).isEqualTo(StreamStatus.SYNCING);
         assertThat(task.getStream().availableSpace()).isEqualTo(pollThreshold);
 
         // run the scheduler and verify that it actually polls the task and refreshes it without rescheduling
+        rangeQueryList = constructRangeQueryList(2);
+        streamAddressSpaceMap = constructNextAddress(2);
 
-        StreamAddressRange rangeQuery2 = new StreamAddressRange(streamTagId, Address.MAX, 2);
-        StreamAddressSpace sas2 = new StreamAddressSpace();
-        sas2.addAddress(3);
-        when(sequencerView.getStreamsAddressSpace(Collections.singletonList(rangeQuery2)))
-                .thenReturn(Collections.singletonMap(streamTagId, sas2));
+        when(sequencerView.getStreamsAddressSpace(rangeQueryList)).thenReturn(streamAddressSpaceMap);
         streamPoller.schedule();
-        verify(sequencerView, times(1)).getStreamsAddressSpace(Collections.singletonList(rangeQuery2));
+        verify(sequencerView, times(1)).getStreamsAddressSpace(rangeQueryList);
         assertThat(task.getStatus()).isEqualTo(StreamStatus.SYNCING);
         // After refreshing the stream, it goes below the threshold again
         assertThat(task.getStream().availableSpace()).isLessThan(pollThreshold);
@@ -428,48 +327,61 @@ public class StreamPollingSchedulerTest {
 
     @Test
     public void testAddRemoveListener() {
-        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        final StreamPollingScheduler streamingScheduler = new StreamPollingScheduler(runtime, scheduler, workers,
-                Duration.ofMillis(50), 25, 5);
+        streamPoller = new StreamPollingScheduler(runtime, scheduler, workers, Duration.ofMillis(50), 25,
+                5);
 
-        TestStreamListener listener = new TestStreamListener();
-        final String namespace = "test_namespace";
-        final String tableName = "table";
-        String streamTag = "tag_1";
+        addTask(0, 6);
 
-        Table table = mock(Table.class);
-        TableRegistry registry = mock(TableRegistry.class);
-        when(runtime.getTableRegistry()).thenReturn(registry);
-        when(registry.getTable(namespace, tableName)).thenReturn(table);
-        UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
-        when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
-
-        streamingScheduler.addTask(listener, namespace, streamTag, Collections.singletonList(tableName), 0, 6);
-
-        assertThatThrownBy(() -> streamingScheduler.addTask(listener, namespace, streamTag,
-                Collections.singletonList(tableName), 0, 6))
+        assertThatThrownBy(() -> addTask(0, 6))
                 .isInstanceOf(StreamingException.class)
                 .hasMessage("StreamingManager::subscribe: listener already registered " + listener);
 
         // Remove the listener and re-add, it shouldn't throw an exception
-        streamingScheduler.removeTask(listener);
-        streamingScheduler.addTask(listener, namespace, streamTag, Collections.singletonList(tableName), 0, 6);
+        streamPoller.removeTask(listener);
+        addTask(0, 6);
     }
 
     @Test
     public void testShutdown() {
-        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        StreamPollingScheduler streamingScheduler = new StreamPollingScheduler(runtime, scheduler, workers,
-                Duration.ofMillis(50), 25, 5);
-        streamingScheduler.shutdown();
+        streamPoller = new StreamPollingScheduler(runtime, scheduler, workers, Duration.ofMillis(50), 25,
+                5);
+        streamPoller.shutdown();
         verify(scheduler, times(1)).submit(any(StreamPollingScheduler.Tick.class));
         verify(scheduler, times(1)).shutdown();
         verify(workers, times(1)).shutdown();
     }
 
+    protected void addTask(long lastAddress, int bufferSize) {
+        streamPoller.addTask(listener, namespace, streamTag, Collections.singletonList(tableName), lastAddress, bufferSize);
+    }
 
+    protected Map<UUID, StreamAddressSpace> constructMockAddressMap(long lastAddressRead, boolean trim) {
+        StreamAddressSpace sas = new StreamAddressSpace();
+        if (trim) {
+            sas.setTrimMark(lastAddressRead*2);
+        } else {
+            sas.addAddress(lastAddressRead+1);
+            sas.addAddress(lastAddressRead+2);
+            addressesInStreamAddressSpace.add(lastAddressRead+1);
+            addressesInStreamAddressSpace.add(lastAddressRead+2);
+        }
+
+        Map<UUID, StreamAddressSpace> map = new HashMap<>();
+        map.put(streamTagId, sas);
+        return map;
+    }
+
+    protected List<StreamAddressRange> constructRangeQueryList(long end) {
+        StreamAddressRange range = new StreamAddressRange(streamTagId, Address.MAX, end);
+        return Arrays.asList(range);
+    }
+
+    // Constructs the next address after 'end'
+    protected Map<UUID, StreamAddressSpace> constructNextAddress(long end) {
+        StreamAddressSpace sas = new StreamAddressSpace();
+        sas.addAddress(end+1);
+        Map<UUID, StreamAddressSpace> map = new HashMap<>();
+        map.put(streamTagId, sas);
+        return map;
+    }
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/StreamingTaskTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/StreamingTaskTest.java
@@ -21,6 +21,7 @@ import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.test.SampleSchema;
 import org.corfudb.test.TestSchema;
 import org.corfudb.util.serializer.ISerializer;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -39,32 +40,46 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("checkstyle:magicnumber")
 public class StreamingTaskTest {
 
-    @Test
-    public void testStreamingTaskLifeCycle() {
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        SequencerView sequencerView = mock(SequencerView.class);
+    protected final ExecutorService workers = mock(ExecutorService.class);
+    protected final CorfuRuntime runtime = mock(CorfuRuntime.class);
+    protected final SequencerView sequencerView = mock(SequencerView.class);
+    protected final AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+
+    private final String namespace = "test_namespace";
+    private final String tableName = "table";
+    private final String streamTag = "tag_1";
+    private final UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
+
+    protected final StreamListener listener = mock(StreamListener.class);
+    protected final int bufferSize = 10;
+
+    protected StreamingTask task;
+
+    @Before
+    public void setUp() {
+        commonSetup();
+        taskTypeSpecificSetup();
+    }
+
+    private void commonSetup() {
         when(runtime.getSequencerView()).thenReturn(sequencerView);
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
         when(runtime.getAddressSpaceView()).thenReturn(addressSpaceView);
+    }
 
-        final String namespace = "test_namespace";
-        final String tableName = "table";
-        final String streamTag = "tag_1";
-
-        StreamListener listener = mock(StreamListener.class);
-
+    protected void taskTypeSpecificSetup() {
         Table table = mock(Table.class);
         TableRegistry registry = mock(TableRegistry.class);
         when(runtime.getTableRegistry()).thenReturn(registry);
         when(registry.getTable(namespace, tableName)).thenReturn(table);
-        UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
         when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
 
-        StreamingTask task = new StreamingTask(runtime, workers, namespace, streamTag, listener,
-                Collections.singletonList(tableName), Address.NON_ADDRESS, 10);
+        task = new StreamingTask(runtime, workers, namespace, streamTag, listener, Collections.singletonList(tableName),
+                Address.NON_ADDRESS, bufferSize);
+    }
 
-        assertThat(task.getStream().getStreamId()).isEqualTo(streamTagId);
+    @Test
+    public void testStreamingTaskLifeCycle() {
+        assertThat(task.getStream().getStreamId()).isEqualTo(getTaskStreamId());
         assertThat(task.getStatus()).isEqualTo(StreamStatus.RUNNABLE);
         task.move(StreamStatus.RUNNABLE, StreamStatus.SCHEDULING);
         assertThat(task.getStatus()).isEqualTo(StreamStatus.SCHEDULING);
@@ -85,30 +100,6 @@ public class StreamingTaskTest {
 
     @Test
     public void testStreamingTaskProduce() {
-        ExecutorService workers = mock(ExecutorService.class);
-        CorfuRuntime runtime = mock(CorfuRuntime.class);
-        SequencerView sequencerView = mock(SequencerView.class);
-        when(runtime.getSequencerView()).thenReturn(sequencerView);
-        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
-        when(runtime.getAddressSpaceView()).thenReturn(addressSpaceView);
-
-        final String namespace = "test_namespace";
-        final String tableName = "table";
-        final String streamTag = "tag_1";
-
-        StreamListener listener = mock(StreamListener.class);
-
-        Table table = mock(Table.class);
-        TableRegistry registry = mock(TableRegistry.class);
-        when(runtime.getTableRegistry()).thenReturn(registry);
-        when(registry.getTable(namespace, tableName)).thenReturn(table);
-        UUID streamTagId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
-        when(table.getStreamTags()).thenReturn(Collections.singleton(streamTagId));
-
-        StreamingTask task = new StreamingTask(runtime, workers, namespace, streamTag, listener,
-                Collections.singletonList(tableName), Address.NON_ADDRESS, 10);
-
-
         StreamAddressSpace sas = new StreamAddressSpace();
         sas.addAddress(1L);
         sas.addAddress(2L);
@@ -184,11 +175,16 @@ public class StreamingTaskTest {
         when(addressSpaceView.read(3L, options)).thenThrow(new TrimmedException());
 
         // Verify that trimmed exceptions are discovered and propagated correctly
+        task.move(StreamStatus.RUNNABLE, StreamStatus.SYNCING);
         task.run();
         assertThat(task.getStatus()).isEqualTo(StreamStatus.ERROR);
         task.propagateError();
         verify(listener, times(1)).onError(any(StreamingException.class));
         // Verify that the task doesnt submit any more work to the worker thread pool
         verify(workers, times(1)).execute(task);
+    }
+
+    protected UUID getTaskStreamId() {
+        return streamTagId;
     }
 }


### PR DESCRIPTION
## Overview
Currently, stream subscription can be done on a single namespace.  This PR introduces a special LR-specific streaming subscription to receive ordered updates across namespaces.  This behavior is required by clients
of the Logical Group-based replication.

Why should this be merged: 

Related issue(s) (if applicable): #<number>

### Testing
**Integration Tests**
Test the first 4 workflows with stream subscription done 1)when in log entry sync and 2)when in snapshot sync: 
- Test streaming updates received on the special LR Multi Namespace Listener.  Verify the order and actual data.
- Test the above with different Tx batch size
- Test the above with a custom buffer size of the LR Streaming Task
- Subscribe the special listener at a timestamp after data is written.  Write more data after subscription.  Verify that data written both before and after subscription is available through mergeTableOnSubscription() and streaming updates.
- Test with concurrent updates to the data and LR status tables after subscription.  Simulates data updates being received within and outside a Snapshot sync.
- Test that updates from non-subscribed tables are not received
- Test that LR listeners from different clients using the Logical Group Replication Model do not interfere with each other.
- Regression Test: Test the coexistence of an LR and non-LR streaming task and verify that both work as expected.

**Unit Tests**
LRStreampPollingSchedulerTest (extension of StreamingPollingSchedulerTest)
- Test addition of an LR Streaming Task by StreamPollingScheduler.
- Test that a duplicate addition of an LR task with the same listener has the same behavior as a regular streaming task
- Test removal of an LR Task
- Verify that a trimmed exception is thrown when maxAddressSeen < trimMark
- Verify that a trimmed exception is thrown when reading an address which was trimmed
- Verify that LRDeltaStream is polled only when availableSpace >= stream polling threshold

LRStreamingTaskTest (extension of StreamingTaskTest)
- Verify that only valid transitions of the task state are allowed.
- Verify that a hole is not propagated to the client.  Other(data) writes are propagated.

LRDeltaStreamTest (extension of LRStreamingTaskTest)
- Verify the hasNext() and next() apis.  hasNext() returns false when no data to consume.  Returns true on a trim gap.  next() throws a trimmed exception if a trimmed address is read.
- Verify that the LRDelta stream does not add new addresses once it detects a trimMark > lastAddressRead
- Verify that a duplicated/redundant refresh of the stream address space is a no-op
- Verify that the buffer maintained in DeltaStream is refreshed as space it gets consumed(read)
- Verify that updates from a stream not tracked by LRDeltaStream is not expected and leads to an exception
- Start a producer and consumer thread which run concurrently to fill and consume from the LR Delta Stream.  Verify that all expected updates are seen by the consumer.

LogReplicationUtilsTest
- Test the behavior of LogReplicationUtils.subscribe() when invoked during and outside a snapshot sync
- Test the behavior of LogReplicationUtils.attemptClientFullSync() when invoked during and outside a snapshot sync
- Test the above when no record for the given client and model is found in the Replication Status table.
- Test that listeners for different clients observe the expected behavior for subscribe() and attemptFullSync(), i.e., these methods can differentiate the clients.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
