### PR TITLE
FailureDetection: get dynamic localEndpoint

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
@@ -88,6 +88,8 @@ public class RemoteMonitoringService implements ManagementService {
      */
     private CompletableFuture<DetectorTask> failureDetectorFuture = DETECTOR_TASK_NOT_COMPLETED;
 
+    private final FailureDetectorService fdService;
+
     /**
      * Number of workers for failure detector. Three workers used by default:
      * - failure/healing detection
@@ -106,7 +108,10 @@ public class RemoteMonitoringService implements ManagementService {
         this.clusterContext = clusterContext;
         this.failureDetector = failureDetector;
         this.localMonitoringService = localMonitoringService;
-
+        ClusterAdvisor advisor = ClusterAdvisorFactory.createForStrategy(
+                ClusterType.COMPLETE_GRAPH,
+                serverContext.getLocalEndpoint()
+        );
         this.detectionTasksScheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder()
                         .setDaemon(true)
@@ -121,6 +126,50 @@ public class RemoteMonitoringService implements ManagementService {
                 .setNameFormat(serverContext.getThreadPrefix() + "DetectionWorker-%d")
                 .build();
         this.failureDetectorWorker = Executors.newFixedThreadPool(detectionWorkersCount, fdThreadFactory);
+
+        FailureDetectorDataStore fdDataStore = FailureDetectorDataStore.builder()
+                .localEndpoint(serverContext.getLocalEndpoint())
+                .dataStore(serverContext.getDataStore())
+                .build();
+
+        FileSystemAdvisor fsAdvisor = new FileSystemAdvisor();
+
+        EpochHandler epochHandler = EpochHandler.builder()
+                .runtimeSingletonResource(runtimeSingletonResource)
+                .serverContext(serverContext)
+                .failureDetectorWorker(failureDetectorWorker)
+                .build();
+
+        HealingAgent healingAgent = HealingAgent.builder()
+                .advisor(advisor)
+                .fsAdvisor(fsAdvisor)
+                .runtimeSingleton(runtimeSingletonResource)
+                .failureDetectorWorker(failureDetectorWorker)
+                .dataStore(fdDataStore)
+                .build();
+
+        FailuresAgent failuresAgent = FailuresAgent.builder()
+                .fdDataStore(fdDataStore)
+                .advisor(advisor)
+                .fsAdvisor(fsAdvisor)
+                .runtimeSingleton(runtimeSingletonResource)
+                .build();
+
+        SequencerBootstrapper sequencerBootstrapper = SequencerBootstrapper.builder()
+                .runtimeSingletonResource(runtimeSingletonResource)
+                .clusterContext(clusterContext)
+                .failureDetectorWorker(failureDetectorWorker)
+                .build();
+
+        this.fdService = FailureDetectorService.builder()
+                .epochHandler(epochHandler)
+                .failuresAgent(failuresAgent)
+                .healingAgent(healingAgent)
+                .sequencerBootstrapper(sequencerBootstrapper)
+                .failureDetectorWorker(failureDetectorWorker)
+                .build();
+
+
     }
 
     private CorfuRuntime getCorfuRuntime() {
@@ -194,61 +243,12 @@ public class RemoteMonitoringService implements ManagementService {
      *  </pre>
      */
     private synchronized CompletableFuture<DetectorTask> runDetectionTasks() {
-        ClusterAdvisor advisor = ClusterAdvisorFactory.createForStrategy(
-                ClusterType.COMPLETE_GRAPH,
-                serverContext.getLocalEndpoint()
-        );
-
-        EpochHandler epochHandler = EpochHandler.builder()
-                .runtimeSingletonResource(runtimeSingletonResource)
-                .serverContext(serverContext)
-                .failureDetectorWorker(failureDetectorWorker)
-                .build();
-
-        FailureDetectorDataStore fdDataStore = FailureDetectorDataStore.builder()
-                .localEndpoint(serverContext.getLocalEndpoint())
-                .dataStore(serverContext.getDataStore())
-                .build();
-
-        FileSystemAdvisor fsAdvisor = new FileSystemAdvisor();
-
-        HealingAgent healingAgent = HealingAgent.builder()
-                .advisor(advisor)
-                .fsAdvisor(fsAdvisor)
-                .localEndpoint(serverContext.getLocalEndpoint())
-                .runtimeSingleton(runtimeSingletonResource)
-                .failureDetectorWorker(failureDetectorWorker)
-                .dataStore(fdDataStore)
-                .build();
-
-        FailuresAgent failuresAgent = FailuresAgent.builder()
-                .localEndpoint(serverContext.getLocalEndpoint())
-                .fdDataStore(fdDataStore)
-                .advisor(advisor)
-                .fsAdvisor(fsAdvisor)
-                .runtimeSingleton(runtimeSingletonResource)
-                .build();
-
-        SequencerBootstrapper sequencerBootstrapper = SequencerBootstrapper.builder()
-                .runtimeSingletonResource(runtimeSingletonResource)
-                .clusterContext(clusterContext)
-                .failureDetectorWorker(failureDetectorWorker)
-                .build();
-
-        FailureDetectorService fdService = FailureDetectorService.builder()
-                .epochHandler(epochHandler)
-                .failuresAgent(failuresAgent)
-                .healingAgent(healingAgent)
-                .sequencerBootstrapper(sequencerBootstrapper)
-                .failureDetectorWorker(failureDetectorWorker)
-                .build();
-
+        String localEndpoint = serverContext.getLocalEndpoint();
         return getCorfuRuntime()
                 .invalidateLayout()
                 .thenApply(serverContext::saveManagementLayout)
                 //check if this node can handle failures (if the node is in the cluster)
                 .thenCompose(ourLayout -> {
-                    String localEndpoint = serverContext.getLocalEndpoint();
                     FailureDetectorHelper helper = new FailureDetectorHelper(ourLayout, localEndpoint);
 
                     return helper.handleReconfigurationsAsync();
@@ -271,7 +271,7 @@ public class RemoteMonitoringService implements ManagementService {
                                 return pollReport;
                             })
                             //Execute failure detector task using failureDetectorWorker executor
-                            .thenCompose(pollReport -> fdService.runFailureDetectorTask(pollReport, ourLayout));
+                            .thenCompose(pollReport -> fdService.runFailureDetectorTask(pollReport, ourLayout, localEndpoint));
                 }).thenApply(task -> {
                     Issue issue = Issue.createIssue(Component.FAILURE_DETECTOR,
                             SOME_NODES_ARE_UNRESPONSIVE,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
@@ -109,8 +109,7 @@ public class RemoteMonitoringService implements ManagementService {
         this.failureDetector = failureDetector;
         this.localMonitoringService = localMonitoringService;
         ClusterAdvisor advisor = ClusterAdvisorFactory.createForStrategy(
-                ClusterType.COMPLETE_GRAPH,
-                serverContext.getLocalEndpoint()
+                ClusterType.COMPLETE_GRAPH
         );
         this.detectionTasksScheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder()

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterAdvisor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterAdvisor.java
@@ -49,7 +49,7 @@ public interface ClusterAdvisor {
      * @return a server considered to have been healed according to the underlying
      * {@link ClusterType}.
      */
-    Optional<NodeRank> healedServer(ClusterState clusterState);
+    Optional<NodeRank> healedServer(ClusterState clusterState, String localEndpoint);
 
     /**
      * Provides a cluster graph generated from the {@link ClusterState}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterAdvisorFactory.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterAdvisorFactory.java
@@ -23,10 +23,10 @@ public class ClusterAdvisorFactory {
      * @return a concrete instance of {@link ClusterAdvisor} specific to the
      * provided strategy.
      */
-    public static ClusterAdvisor createForStrategy(ClusterType strategy, String localEndpoint) {
+    public static ClusterAdvisor createForStrategy(ClusterType strategy) {
         switch (strategy) {
             case COMPLETE_GRAPH:
-                return new CompleteGraphAdvisor(localEndpoint);
+                return new CompleteGraphAdvisor();
             case STAR_GRAPH:
                 throw new UnsupportedOperationException(strategy.name());
             default:

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
@@ -1,9 +1,7 @@
 package org.corfudb.infrastructure.management;
 
 import com.google.common.collect.ImmutableList;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.management.failuredetector.ClusterGraph;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.failuredetector.NodeRank;
@@ -24,10 +22,6 @@ import java.util.Set;
 public class CompleteGraphAdvisor implements ClusterAdvisor {
 
     private static final ClusterType CLUSTER_TYPE = ClusterType.COMPLETE_GRAPH;
-
-    public CompleteGraphAdvisor() {
-
-    }
 
     @Override
     public ClusterType getType() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.management;
 import com.google.common.collect.ImmutableList;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.management.failuredetector.ClusterGraph;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.failuredetector.NodeRank;
@@ -24,10 +25,8 @@ public class CompleteGraphAdvisor implements ClusterAdvisor {
 
     private static final ClusterType CLUSTER_TYPE = ClusterType.COMPLETE_GRAPH;
 
-    private final String localEndpoint;
+    public CompleteGraphAdvisor() {
 
-    public CompleteGraphAdvisor(@NonNull String localEndpoint) {
-        this.localEndpoint = localEndpoint;
     }
 
     @Override
@@ -95,7 +94,7 @@ public class CompleteGraphAdvisor implements ClusterAdvisor {
      * {@link ClusterType}.
      */
     @Override
-    public Optional<NodeRank> healedServer(ClusterState clusterState) {
+    public Optional<NodeRank> healedServer(ClusterState clusterState, String localEndpoint) {
 
         log.trace("Detecting the healed nodes for: ClusterState: {}", clusterState);
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/FailuresAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/FailuresAgent.java
@@ -31,9 +31,6 @@ public class FailuresAgent {
     private final FileSystemAdvisor fsAdvisor;
 
     @NonNull
-    private final String localEndpoint;
-
-    @NonNull
     private final FailureDetectorDataStore fdDataStore;
 
     @NonNull
@@ -49,7 +46,7 @@ public class FailuresAgent {
      * @param pollReport Poll report obtained from failure detection policy.
      * @return boolean result if failure was handled. False if there is no failure
      */
-    public DetectorTask detectAndHandleFailure(PollReport pollReport, Layout layout) {
+    public DetectorTask detectAndHandleFailure(PollReport pollReport, Layout layout, String localEndpoint) {
         log.trace("Handle failures for the report: {}", pollReport);
 
         try {
@@ -81,7 +78,7 @@ public class FailuresAgent {
 
                 Set<String> failedNodes = new HashSet<>();
                 failedNodes.add(failedNode.getEndpoint());
-                return handleFailure(layout, failedNodes, pollReport).join();
+                return handleFailure(layout, failedNodes, pollReport, localEndpoint).join();
             }
 
             Optional<NodeRank> maybeFailedNode = advisor.failedServer(clusterState);
@@ -109,7 +106,7 @@ public class FailuresAgent {
 
                 Set<String> failedNodes = new HashSet<>();
                 failedNodes.add(failedNode.getEndpoint());
-                return handleFailure(layout, failedNodes, pollReport).join();
+                return handleFailure(layout, failedNodes, pollReport, localEndpoint).join();
             }
         } catch (Exception e) {
             log.error("Exception invoking failure handler", e);
@@ -125,7 +122,7 @@ public class FailuresAgent {
      * @param pollReport  poll report
      */
     public CompletableFuture<DetectorTask> handleFailure(
-            Layout layout, Set<String> failedNodes, PollReport pollReport) {
+            Layout layout, Set<String> failedNodes, PollReport pollReport, String localEndpoint) {
 
         ClusterGraph graph = advisor.getGraph(pollReport.getClusterState());
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/CompleteGraphAdvisorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/CompleteGraphAdvisorTest.java
@@ -1,20 +1,12 @@
 package org.corfudb.infrastructure.management;
 
 import com.google.common.collect.ImmutableList;
-import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.log.statetransfer.StateTransferManager;
-import org.corfudb.infrastructure.log.statetransfer.transferprocessor.BasicTransferProcessor;
-import org.corfudb.infrastructure.log.statetransfer.transferprocessor.ParallelTransferProcessor;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.protocols.wireprotocol.failuredetector.NodeRank;
-import org.corfudb.runtime.clients.LogUnitClient;
 import org.junit.Test;
-import org.mockito.Mock;
 
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.LongStream;
 
 import static org.corfudb.infrastructure.management.NodeStateTestUtil.A;
 import static org.corfudb.infrastructure.management.NodeStateTestUtil.B;
@@ -26,9 +18,6 @@ import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivit
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 public class CompleteGraphAdvisorTest {
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/CompleteGraphAdvisorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/CompleteGraphAdvisorTest.java
@@ -34,19 +34,6 @@ public class CompleteGraphAdvisorTest {
 
     private final long epoch = 1;
 
-    @Mock
-    private Map<String, Object> map;
-
-    private ServerContext getDefaultInstance(String localEndpoint) {
-        final ServerContext spy = spy(new ServerContext(map));
-        doReturn(localEndpoint)
-                .when(spy).getLocalEndpoint();
-        return spy;
-    }
-
-    private CompleteGraphAdvisor getGraphAdvisor(String localEndpoint) {
-        return new CompleteGraphAdvisor(getDefaultInstance(localEndpoint));
-    }
     /**
      * By definition, a fully connected node can not be added to the unresponsive list.
      * Failed connection(s) between unresponsive and fully connected node(s)
@@ -55,8 +42,7 @@ public class CompleteGraphAdvisorTest {
     @Test
     public void testUnresponsiveAndFullyConnectedNode() {
         final String localEndpoint = A;
-        ServerContext
-        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor(localEndpoint);
+        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor();
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
@@ -73,7 +59,7 @@ public class CompleteGraphAdvisorTest {
     @Test
     public void testFailedServer_disconnected_c() {
         final String localEndpoint = A;
-        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor(localEndpoint);
+        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor();
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
@@ -91,7 +77,7 @@ public class CompleteGraphAdvisorTest {
     @Test
     public void testFailedServer_asymmetricFailureBetween_b_c() {
         final String localEndpoint = A;
-        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor(localEndpoint);
+        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor();
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
@@ -113,7 +99,7 @@ public class CompleteGraphAdvisorTest {
     @Test
     public void testFailedServer_allDisconnected_from_b_perspective() {
         final String localEndpoint = B;
-        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor(localEndpoint);
+        CompleteGraphAdvisor advisor = new CompleteGraphAdvisor();
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
@@ -136,9 +122,9 @@ public class CompleteGraphAdvisorTest {
      */
     @Test
     public void testFailureDetectionForThreeNodes_asymmetricPartition_b_c_disconnectedFromEachOther() {
-        CompleteGraphAdvisor nodeAAdvisor = new CompleteGraphAdvisor(A);
-        CompleteGraphAdvisor nodeBAdvisor = new CompleteGraphAdvisor(B);
-        CompleteGraphAdvisor nodeCAdvisor = new CompleteGraphAdvisor(C);
+        CompleteGraphAdvisor nodeAAdvisor = new CompleteGraphAdvisor();
+        CompleteGraphAdvisor nodeBAdvisor = new CompleteGraphAdvisor();
+        CompleteGraphAdvisor nodeCAdvisor = new CompleteGraphAdvisor();
 
         ClusterState nodeAClusterState = buildClusterState(
                 A,

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/DecisionMakerAgentTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/DecisionMakerAgentTest.java
@@ -40,7 +40,7 @@ class DecisionMakerAgentTest {
                 nodeState(NodeNames.C, epoch, Optional.of(readOnlyFsStats), OK, OK, OK)
         );
 
-        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor(localEndpoint);
+        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor();
         DecisionMakerAgent decisionMakerAgent = new DecisionMakerAgent(cluster, clusterAdvisor);
 
         Set<String> healthyNodes = decisionMakerAgent.healthyNodes();
@@ -65,7 +65,7 @@ class DecisionMakerAgentTest {
                 nodeState(NodeNames.C, epoch, Optional.of(writableFsStats), OK, OK, OK)
         );
 
-        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor(localEndpoint);
+        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor();
         DecisionMakerAgent decisionMakerAgent = new DecisionMakerAgent(cluster, clusterAdvisor);
         Optional<String> decisionMaker = decisionMakerAgent.findDecisionMaker();
 
@@ -89,7 +89,7 @@ class DecisionMakerAgentTest {
                 nodeState(NodeNames.C, epoch, Optional.of(writableFsStats), OK, OK, OK)
         );
 
-        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor(localEndpoint);
+        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor();
         DecisionMakerAgent decisionMakerAgent = new DecisionMakerAgent(cluster, clusterAdvisor);
         Optional<String> decisionMaker = decisionMakerAgent.findDecisionMaker();
 
@@ -112,7 +112,7 @@ class DecisionMakerAgentTest {
                 nodeState(NodeNames.C, epoch, Optional.of(writableFsStats), OK, OK, OK)
         );
 
-        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor(localEndpoint);
+        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor();
         DecisionMakerAgent decisionMakerAgent = new DecisionMakerAgent(cluster, clusterAdvisor);
         Optional<String> decisionMaker = decisionMakerAgent.findDecisionMaker();
 
@@ -137,7 +137,7 @@ class DecisionMakerAgentTest {
                 nodeState(NodeNames.C, epoch, Optional.of(readOnlyFsStats), OK, OK, OK)
         );
 
-        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor(localEndpoint);
+        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor();
         DecisionMakerAgent decisionMakerAgent = new DecisionMakerAgent(cluster, clusterAdvisor);
         Optional<String> decisionMaker = decisionMakerAgent.findDecisionMaker();
 
@@ -161,7 +161,7 @@ class DecisionMakerAgentTest {
                 nodeState(NodeNames.C, epoch, Optional.of(bpErrorStats), OK, OK, OK)
         );
 
-        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor(localEndpoint);
+        ClusterAdvisor clusterAdvisor = new CompleteGraphAdvisor();
         DecisionMakerAgent decisionMakerAgent = new DecisionMakerAgent(cluster, clusterAdvisor);
         Optional<String> decisionMaker = decisionMakerAgent.findDecisionMaker();
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorServiceTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorServiceTest.java
@@ -39,9 +39,9 @@ class FailureDetectorServiceTest {
 
         Layout layoutMock = mock(Layout.class);
 
-        String endpointMock = mock(String.class);
+        String endpoint = "localhost";
 
-        fdService.runFailureDetectorTask(pollReportMock, layoutMock, endpointMock).whenComplete((result, ex) -> {
+        fdService.runFailureDetectorTask(pollReportMock, layoutMock, endpoint).whenComplete((result, ex) -> {
             assertEquals("Wrong epoch. [expected=123]", ex.getMessage());
         });
     }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorServiceTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorServiceTest.java
@@ -39,7 +39,9 @@ class FailureDetectorServiceTest {
 
         Layout layoutMock = mock(Layout.class);
 
-        fdService.runFailureDetectorTask(pollReportMock, layoutMock).whenComplete((result, ex) -> {
+        String endpointMock = mock(String.class);
+
+        fdService.runFailureDetectorTask(pollReportMock, layoutMock, endpointMock).whenComplete((result, ex) -> {
             assertEquals("Wrong epoch. [expected=123]", ex.getMessage());
         });
     }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorTestContext.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorTestContext.java
@@ -57,7 +57,7 @@ public class FailureDetectorTestContext {
                 .localEndpoint(localEndpoint)
                 .dataStore(mock(DataStore.class));
 
-        advisor = new CompleteGraphAdvisor(localEndpoint);
+        advisor = new CompleteGraphAdvisor();
         fsAdvisor = new FileSystemAdvisor();
 
         FailureDetectorDataStore fdDatastore = fdDataStoreBuilder.build();
@@ -67,14 +67,12 @@ public class FailureDetectorTestContext {
                 .advisor(advisor)
                 .fsAdvisor(fsAdvisor)
                 .failureDetectorWorker(fdWorkerMock)
-                .localEndpoint(localEndpoint)
                 .runtimeSingleton(runtimeMock);
 
         failuresAgent = FailuresAgent.builder()
                 .fdDataStore(fdDatastore)
                 .advisor(advisor)
                 .fsAdvisor(fsAdvisor)
-                .localEndpoint(localEndpoint)
                 .runtimeSingleton(runtimeMock);
 
         clusterStateContext = new ClusterStateTestContext(localEndpoint);

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailuresAgentTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailuresAgentTest.java
@@ -59,12 +59,12 @@ class FailuresAgentTest {
 
         doReturn(handle)
                 .when(failuresAgent)
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), same(localEndpoint));
 
         DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock, localEndpoint);
 
         verify(failuresAgent, times(1))
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), same(localEndpoint));
 
         assertEquals(DetectorTask.COMPLETED, result);
     }
@@ -100,12 +100,12 @@ class FailuresAgentTest {
 
         doReturn(handle)
                 .when(failuresAgent)
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), same(localEndpoint));
 
         DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock, localEndpoint);
 
         verify(failuresAgent, times(1))
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), same(localEndpoint));
 
         assertEquals(DetectorTask.COMPLETED, result);
     }
@@ -141,12 +141,12 @@ class FailuresAgentTest {
 
         doReturn(handle)
                 .when(failuresAgent)
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), same(localEndpoint));
 
         DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock, localEndpoint);
 
         verify(failuresAgent, times(1))
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), same(localEndpoint));
 
         assertEquals(DetectorTask.COMPLETED, result);
     }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailuresAgentTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailuresAgentTest.java
@@ -59,12 +59,12 @@ class FailuresAgentTest {
 
         doReturn(handle)
                 .when(failuresAgent)
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock));
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
 
-        DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock);
+        DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock, localEndpoint);
 
         verify(failuresAgent, times(1))
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock));
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
 
         assertEquals(DetectorTask.COMPLETED, result);
     }
@@ -100,12 +100,12 @@ class FailuresAgentTest {
 
         doReturn(handle)
                 .when(failuresAgent)
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock));
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
 
-        DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock);
+        DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock, localEndpoint);
 
         verify(failuresAgent, times(1))
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock));
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
 
         assertEquals(DetectorTask.COMPLETED, result);
     }
@@ -141,12 +141,12 @@ class FailuresAgentTest {
 
         doReturn(handle)
                 .when(failuresAgent)
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock));
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
 
-        DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock);
+        DetectorTask result = failuresAgent.detectAndHandleFailure(pollReportMock, layoutMock, localEndpoint);
 
         verify(failuresAgent, times(1))
-                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock));
+                .handleFailure(same(layoutMock), eq(expectedFailedNodes), same(pollReportMock), localEndpoint);
 
         assertEquals(DetectorTask.COMPLETED, result);
     }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/HealingAgentTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/HealingAgentTest.java
@@ -58,12 +58,12 @@ public class HealingAgentTest {
 
         doReturn(handle)
                 .when(agentSpy)
-                .handleHealing(same(pollReportMock), same(layoutMock), anySet());
+                .handleHealing(same(pollReportMock), same(layoutMock), anySet(), same(localEndpoint));
 
-        CompletableFuture<DetectorTask> healingFailed = agentSpy.detectAndHandleHealing(pollReportMock, layoutMock);
+        CompletableFuture<DetectorTask> healingFailed = agentSpy.detectAndHandleHealing(pollReportMock, layoutMock, localEndpoint);
 
         verify(agentSpy, times(1))
-                .handleHealing(same(pollReportMock), same(layoutMock), anySet());
+                .handleHealing(same(pollReportMock), same(layoutMock), anySet(), same(localEndpoint));
 
         assertEquals(DetectorTask.NOT_COMPLETED, healingFailed.join());
     }
@@ -82,9 +82,9 @@ public class HealingAgentTest {
         CompletableFuture<Boolean> handle = CompletableFuture.completedFuture(true);
         doReturn(handle)
                 .when(agentSpy)
-                .handleHealing(same(pollReportMock), same(layoutMock), anySet());
+                .handleHealing(same(pollReportMock), same(layoutMock), anySet(), same(localEndpoint));
 
-        CompletableFuture<DetectorTask> healingFailed = agentSpy.detectAndHandleHealing(pollReportMock, layoutMock);
+        CompletableFuture<DetectorTask> healingFailed = agentSpy.detectAndHandleHealing(pollReportMock, layoutMock, localEndpoint);
 
         assertEquals(DetectorTask.SKIPPED, healingFailed.join());
     }
@@ -106,12 +106,12 @@ public class HealingAgentTest {
         CompletableFuture<Boolean> handle = CompletableFuture.completedFuture(true);
         doReturn(handle)
                 .when(agentSpy)
-                .handleHealing(same(pollReportMock), same(layoutMock), anySet());
+                .handleHealing(same(pollReportMock), same(layoutMock), anySet(), same(localEndpoint));
 
-        CompletableFuture<DetectorTask> healingFailed = agentSpy.detectAndHandleHealing(pollReportMock, layoutMock);
+        CompletableFuture<DetectorTask> healingFailed = agentSpy.detectAndHandleHealing(pollReportMock, layoutMock, localEndpoint);
 
         verify(agentSpy, times(1))
-                .handleHealing(same(pollReportMock), same(layoutMock), anySet());
+                .handleHealing(same(pollReportMock), same(layoutMock), anySet(), same(localEndpoint));
 
         assertEquals(DetectorTask.COMPLETED, healingFailed.join());
     }

--- a/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
@@ -31,10 +31,6 @@ public class HandOfGodIT extends GenericIntegrationTest {
     @Test(timeout = 300000)
     public void handOfGodTest() {
         workflow(wf -> {
-            wf.setupDocker(fixture -> {
-                fixture.getLogging().enabled(true);
-                fixture.getServer().logLevel(Level.TRACE);
-            });
             wf.deploy();
 
             ClientParams clientFixture = ClientParams.builder().build();
@@ -71,21 +67,17 @@ public class HandOfGodIT extends GenericIntegrationTest {
                     clientFixture.getTimeout(),
                     clientFixture.getPollPeriod()
             );
-            System.out.println("Invalidate layout");
             // Verify layout contains only the node that is up
             corfuClient.invalidateLayout();
             Layout layout = corfuClient.getLayout();
-            System.out.println("Assert one node");
             assertThat(layout.getAllActiveServers()).containsExactly(server0.getEndpoint());
 
-            System.out.println("Get cluster status and assert");
             // Verify cluster status is STABLE
             ClusterStatusReport clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
             assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatus.STABLE);
 
             ScenarioUtils.waitUninterruptibly(Duration.ofSeconds(30));
 
-            System.out.println("Verify data path");
             // Verify data path working
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 assertThat(table.get(String.valueOf(i))).isEqualTo(String.valueOf(i));

--- a/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
@@ -10,7 +10,6 @@ import org.corfudb.universe.node.client.ClientParams;
 import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.junit.Test;
-import org.slf4j.event.Level;
 
 import java.time.Duration;
 

--- a/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
@@ -10,6 +10,7 @@ import org.corfudb.universe.node.client.ClientParams;
 import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.junit.Test;
+import org.slf4j.event.Level;
 
 import java.time.Duration;
 
@@ -30,6 +31,10 @@ public class HandOfGodIT extends GenericIntegrationTest {
     @Test(timeout = 300000)
     public void handOfGodTest() {
         workflow(wf -> {
+            wf.setupDocker(fixture -> {
+                fixture.getLogging().enabled(true);
+                fixture.getServer().logLevel(Level.TRACE);
+            });
             wf.deploy();
 
             ClientParams clientFixture = ClientParams.builder().build();
@@ -66,18 +71,21 @@ public class HandOfGodIT extends GenericIntegrationTest {
                     clientFixture.getTimeout(),
                     clientFixture.getPollPeriod()
             );
-
+            System.out.println("Invalidate layout");
             // Verify layout contains only the node that is up
             corfuClient.invalidateLayout();
             Layout layout = corfuClient.getLayout();
+            System.out.println("Assert one node");
             assertThat(layout.getAllActiveServers()).containsExactly(server0.getEndpoint());
 
+            System.out.println("Get cluster status and assert");
             // Verify cluster status is STABLE
             ClusterStatusReport clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
             assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatus.STABLE);
 
             ScenarioUtils.waitUninterruptibly(Duration.ofSeconds(30));
 
+            System.out.println("Verify data path");
             // Verify data path working
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 assertThat(table.get(String.valueOf(i))).isEqualTo(String.valueOf(i));


### PR DESCRIPTION
Fix nodes not healing when local endpoint IP address changes dynamically when multiple addresses are present.

cc: @xnull , @PavelZaytsev 
## Overview

Description:

Due to the changes in the IPV6, the serverContext local endpoint can change from IPV6 to IPV4. This causes issues in FD. We refresh the local endpoint on every FD iteration to account for this.

