### PR TITLE
Keep trying to generate nodeId in case of DataCorruptionException

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
@@ -179,7 +179,7 @@ public class DataStore implements KvDataStore {
     private <T> T load(Class<T> tClass, String key) {
         try {
             Path path = Paths.get(logDirPath, key + EXTENSION);
-            if (Files.notExists(path)) {
+            if (!Files.isReadable(path)) {
                 return null;
             }
             byte[] bytes = Files.readAllBytes(path);
@@ -192,7 +192,7 @@ public class DataStore implements KvDataStore {
             String json = new String(bytes, 4, bytes.length - 4);
             return JsonUtils.parser.fromJson(json, tClass);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new DataCorruptionException(e);
         }
     }
 


### PR DESCRIPTION
## Overview

Description:
When Corfu starts, it should retry creating the nodeID file in case of IOExceptions rather than exit
issue: #3577 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
