### PR TITLE
[Not for review] Test to help with reopening table after being trimmed

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -216,7 +216,7 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
         return tags;
     }
 
-    private Token forceNoOpEntry() {
+    public Token forceNoOpEntry() {
         Set<UUID> streamsToAdvance = new HashSet<>();
         if (serializer instanceof DynamicProtobufSerializer) {
             // One of the use-cases of a no-op entry written by the checkpointer is to always - even for empty streams -


### PR DESCRIPTION
Test to show appending HOLE with cp start and finish records helps with reopening table after being trimmed

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
