### PR TITLE
Add resetTrimmedTable to Corfu BrowserEditor Tool

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuBrowserEditorCommands.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuBrowserEditorCommands.java
@@ -173,4 +173,6 @@ public interface CorfuBrowserEditorCommands {
      * @return table names with given 'streamTag'
      */
     List<CorfuStoreMetadata.TableName> listTablesForTag(@Nonnull String streamTag);
+
+    void resetTrimmedTable(String namespace, String table);
 }

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuOfflineBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuOfflineBrowserEditor.java
@@ -385,6 +385,9 @@ public class CorfuOfflineBrowserEditor implements CorfuBrowserEditorCommands {
         return null;
     }
 
+    @Override
+    public void resetTrimmedTable(String namespace, String table) {}
+
     class CorfuTableDescriptor {
         @Getter
         private final UUID streamID;

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -39,6 +39,7 @@ import org.corfudb.runtime.CorfuStoreMetadata.TableName;
 import org.corfudb.runtime.ExampleSchemas.ExampleTableName;
 import org.corfudb.runtime.ExampleSchemas.ManagedMetadata;
 import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreShim;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.CorfuTable;
@@ -886,5 +887,14 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
         formatMapping = formatMapping.substring(0, formatMapping.length() - 2);
         System.out.println("Tag: " + tag + " --- Total Tables: " + tables.size()
             + " TableNames: " + formatMapping);
+    }
+
+    @Override
+    public void resetTrimmedTable(String namespace, String tableName) {
+        System.out.println("\n======================\n");
+        CorfuStore corfuStore = new CorfuStore(runtime);
+        corfuStore.resetTrimmedTable(namespace, tableName);
+        System.out.println("Successfully reset trimmed table!");
+        System.out.println("\n======================\n");
     }
 }

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
@@ -41,7 +41,8 @@ public class CorfuStoreBrowserEditorMain {
         listTagsForTable,
         listTagsMap,
         printMetadataMap,
-        addRecord
+        addRecord,
+        resetTrimmedTable
     }
 
     private static final String USAGE = "Usage: corfu-browser "+
@@ -66,7 +67,7 @@ public class CorfuStoreBrowserEditorMain {
         + "--port=<port>   Port\n"
         + "--operation=<listTables|infoTable|showTable|clearTable"
         + "|editTable|deleteRecord|loadTable|listenOnTable|listTags|listTagsMap"
-        + "|listTablesForTag|listTagsForTable|listAllProtos> Operation\n"
+        + "|listTablesForTag|listTagsForTable|listAllProtos|resetTrimmedTable> Operation\n"
         + "--namespace=<namespace>   Namespace\n"
         + "--tablename=<tablename>   Table Name\n"
         + "--tag=<tag>  Stream tag of interest\n"
@@ -208,8 +209,7 @@ public class CorfuStoreBrowserEditorMain {
             browser = null;
         }
         final String namespace = Optional.ofNullable(opts.get("--namespace"))
-                .map(Object::toString)
-                .orElse(null);
+                .map(Object::toString).filter(s -> !"NULL".equals(s)).orElse(null);
         final String tableName = Optional.ofNullable(opts.get("--tablename"))
                 .map(Object::toString)
                 .orElse(null);
@@ -218,24 +218,16 @@ public class CorfuStoreBrowserEditorMain {
 
         switch (Enum.valueOf(OperationType.class, operation)) {
             case listTables:
-                Preconditions.checkArgument(isValid(namespace),
-                        "Namespace is null or empty.");
                 return browser.listTables(namespace);
             case infoTable:
-                Preconditions.checkArgument(isValid(namespace),
-                        "Namespace is null or empty.");
                 Preconditions.checkArgument(isValid(tableName),
                         "Table name is null or empty.");
                 return browser.printTableInfo(namespace, tableName);
             case clearTable:
-                Preconditions.checkArgument(isValid(namespace),
-                        "Namespace is null or empty.");
                 Preconditions.checkArgument(isValid(tableName),
                         "Table name is null or empty.");
                 return browser.clearTable(namespace, tableName);
             case showTable:
-                Preconditions.checkArgument(isValid(namespace),
-                        "Namespace is null or empty.");
                 Preconditions.checkArgument(isValid(tableName),
                         "Table name is null or empty.");
                 return browser.printTable(namespace, tableName);
@@ -378,6 +370,10 @@ public class CorfuStoreBrowserEditorMain {
                 } else {
                     log.error("Print metadata map for a specific address. Specify using tag --address");
                 }
+            case resetTrimmedTable:
+                Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
+                browser.resetTrimmedTable(namespace, tableName);
             default:
                 break;
         }

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -216,7 +216,7 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
         return tags;
     }
 
-    private Token forceNoOpEntry() {
+    public Token forceNoOpEntry() {
         Set<UUID> streamsToAdvance = new HashSet<>();
         if (serializer instanceof DynamicProtobufSerializer) {
             // One of the use-cases of a no-op entry written by the checkpointer is to always - even for empty streams -

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -461,6 +461,9 @@ public class TableRegistry {
      * @return Fully qualified table name.
      */
     public static String getFullyQualifiedTableName(String namespace, String tableName) {
+        if (namespace == null || namespace.isEmpty()) {
+            return tableName;
+        }
         return namespace + "$" + tableName;
     }
 

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -523,6 +523,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private boolean disableHost = false;
         private String networkInterface = null;
         private NetworkInterfaceVersion networkInterfaceVersion = null;
+        private boolean disableLogUnitServerCache = false;
 
 
         /**
@@ -534,8 +535,12 @@ public class AbstractIT extends AbstractCorfuTest {
         public String getOptionsString() {
             StringBuilder command = new StringBuilder();
 
+            if (disableLogUnitServerCache) {
+                command.append("-c ").append(0);
+            }
+
             if (!disableHost) {
-                command.append("-a ").append(host);
+                command.append(" -a ").append(host);
             }
 
             if (logPath != null) {


### PR DESCRIPTION
## Overview

Description:
Reset a trimmed table by appending an empty checkpoint to the table. This allows for subsequent reopening and accessing the trimmed table for a limited time window (before the next trim happens).

Why should this be merged: 
Reopening trimmed table is required in rollback and upgrade scenarios.

Related issue(s) (if applicable): #3251 


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
