### PR TITLE
Reduce unnecessary log lines from compactor

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -3,6 +3,12 @@
 
     <property name="LOG_DIRECTORY" value="/var/log/corfu" />
 
+    <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
+        <Marker>NOT_IMPORTANT</Marker>
+        <OnMatch>DENY</OnMatch>
+        <OnMismatch>NEUTRAL</OnMismatch>
+    </turboFilter>
+
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIRECTORY}/corfu.9000.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -42,6 +42,8 @@ import org.corfudb.util.Sleep;
 import org.corfudb.util.serializer.Serializers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 
 import javax.annotation.Nonnull;
 import java.nio.file.Path;
@@ -167,6 +169,8 @@ public class CorfuRuntime {
      */
     @Getter
     private volatile boolean isShutdown = false;
+
+    public static final Marker LOG_NOT_IMPORTANT = MarkerFactory.getMarker("NOT_IMPORTANT");
 
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -102,7 +102,7 @@ public class CorfuStore {
         Table table =
                 runtime.getTableRegistry().openTable(namespace, tableName, kClass, vClass, mClass, tableOptions);
         corfuStoreMetrics.recordTableCount();
-        log.info("openTable {}${} took {}ms", namespace, tableName, (System.currentTimeMillis() - startTime));
+        log.info(CorfuRuntime.LOG_NOT_IMPORTANT, "openTable {}${} took {}ms", namespace, tableName, (System.currentTimeMillis() - startTime));
         return table;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/MVOCorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MVOCorfuCompileProxy.java
@@ -92,7 +92,7 @@ public class MVOCorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRPr
 
         // Linearize this read against a timestamp
         long timestamp = rt.getSequencerView().query(getStreamID());
-        log.debug("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
+        log.trace("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
 
         // Perform underlying access
         ICorfuSMRSnapshotProxy<T> snapshotProxy = underlyingMVO.getSnapshotProxy(timestamp);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -72,7 +72,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                                                 Object[] conflictObject) {
         long startAccessTime = System.nanoTime();
         try {
-            log.debug("Access[{},{}] conflictObj={}", this, proxy, conflictObject);
+            log.trace("Access[{},{}] conflictObj={}", this, proxy, conflictObject);
 
             // First, we add this access to the read set
             addToReadSet(proxy, conflictObject);

--- a/runtime/src/main/java/org/corfudb/runtime/view/SMRObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SMRObject.java
@@ -137,7 +137,7 @@ public class SMRObject<T extends ICorfuSMR<T>> {
             final SMRObject<T> smrObject = build();
 
             try {
-                log.info("ObjectBuilder: open Corfu stream {} id {}", smrObject.getStreamName(),
+                log.info(CorfuRuntime.LOG_NOT_IMPORTANT, "ObjectBuilder: open Corfu stream {} id {}", smrObject.getStreamName(),
                         smrObject.getStreamID());
 
                 if (smrObject.getOption() == ObjectOpenOption.NO_CACHE) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -576,7 +576,7 @@ public class TableRegistry {
                 .map(StreamTagInfo::getStreamId)
                 .collect(Collectors.toSet());
 
-        log.info("openTable: opening {}${} with stream tags {}", namespace, tableName, streamTagInfoForTable);
+        log.info(CorfuRuntime.LOG_NOT_IMPORTANT, "openTable: opening {}${} with stream tags {}", namespace, tableName, streamTagInfoForTable);
 
         // Open and return table instance.
         Table<K, V, M> table = new Table<>(


### PR DESCRIPTION
Due to many of the unnecessary log lines invoked by the compactor the corfu.9000 log file becomes too chatty and also leads to quick rolling over. This fix helps with the above issue - uses markers to mark unimportant logs and then filter them out in the logback file.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
