### PR TITLE
Fix for Dockerfile smell DL3025

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -44,10 +44,10 @@ ENV JAVA_OPTS -verbose:gc \
     -XX:+PrintGCApplicationConcurrentTime \
     -Djava.io.tmpdir=/image/corfu-server/temp
 
-CMD java -cp *.jar \
-    ${JAVA_OPTS} \
-    -Dlogback.configurationFile=/usr/share/corfu/conf/logback.prod.xml \
-    org.corfudb.infrastructure.CorfuServer \
-    --compactor-script /usr/share/corfu/scripts/compactor_runner.py \
-    --compactor-config=/usr/share/corfu/conf/corfu-compactor-config.yml \
-    --compaction-trigger-freq-ms=900000
+CMD ["java", "-cp", "*.jar", "${JAVA_OPTS}", "-Dlogback.configurationFile=/usr/share/corfu/conf/logback.prod.xml", "org.corfudb.infrastructure.CorfuServer", "--compactor-script", "/usr/share/corfu/scripts/compactor_runner.py", "--compactor-config=/usr/share/corfu/conf/corfu-compactor-config.yml", "--compaction-trigger-freq-ms=900000"]
+
+
+
+
+
+


### PR DESCRIPTION
## Overview

Description:

Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3025](https://github.com/hadolint/hadolint/wiki/DL3025) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3025 occurs if the JSON notation is not used for the arguments of CMD and ENTRYPOINT instructions.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the command arguments are refactored in the JSON notation format.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance


Related issue(s) (if applicable): None


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
