### PR TITLE
Support for running addRecord on null-metadata tables in corfu editor

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -421,7 +421,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
         DynamicMessage newValueMsg =
             dynamicProtobufSerializer.createDynamicMessageFromJson(defaultValueAny,
                 newValue);
-        DynamicMessage newMetadataMsg =
+        DynamicMessage newMetadataMsg = defaultMetadataAny.getTypeUrl().isEmpty() ? null :
             dynamicProtobufSerializer.createDynamicMessageFromJson(defaultMetadataAny,
                 newMetadata);
 

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
@@ -1016,6 +1016,69 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         Assert.assertEquals(2, browser.printTable(NAMESPACE, TABLE_NAME));
     }
 
+    @Test
+    public void addRecordToATableWithoutMetadata() throws IOException,
+            InvocationTargetException, NoSuchMethodException,
+            IllegalAccessException {
+        runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
+
+        // Start a Corfu runtime
+        runtime = createRuntime(singleNodeEndpoint);
+
+        CorfuStore store = new CorfuStore(runtime);
+
+        final Table<SampleSchema.Uuid, SampleSchema.Uuid, SampleSchema.Uuid> table1 = store.openTable(
+                NAMESPACE,
+                TABLE_NAME,
+                SampleSchema.Uuid.class,
+                SampleSchema.Uuid.class,
+                null,
+                TableOptions.fromProtoSchema(SampleSchema.Uuid.class));
+
+        final long keyUuid = 1L;
+        final long valueUuid = 3L;
+
+        SampleSchema.Uuid uuidKey = SampleSchema.Uuid.newBuilder()
+                .setMsb(keyUuid)
+                .setLsb(keyUuid)
+                .build();
+        SampleSchema.Uuid uuidVal = SampleSchema.Uuid.newBuilder()
+                .setMsb(valueUuid)
+                .setLsb(valueUuid)
+                .build();
+        TxnContext tx = store.txn(NAMESPACE);
+        tx.putRecord(table1, uuidKey, uuidVal, null);
+        tx.commit();
+        runtime.shutdown();
+
+        runtime = createRuntime(singleNodeEndpoint);
+        CorfuStoreBrowserEditor browser = new CorfuStoreBrowserEditor(runtime);
+
+        // Add a new record with empty metadata and verify it can be added
+        final String newKeyString1 = "{\"msb\": \"4\", \"lsb\": \"4\"}";
+        final String newValString1 = "{\"msb\": \"4\", \"lsb\": \"4\"}";
+        final String newMetadataString1 = "";
+
+        CorfuDynamicRecord addedRecord = browser.addRecord(NAMESPACE,
+                TABLE_NAME, newKeyString1, newValString1, newMetadataString1);
+        Assert.assertNotNull(addedRecord);
+
+        // Verify
+        final long newVal = 4L;
+        SampleSchema.Uuid newValUuid = SampleSchema.Uuid.newBuilder()
+                .setMsb(newVal)
+                .setLsb(newVal)
+                .build();
+        CorfuDynamicRecord expectedRecord = new CorfuDynamicRecord(
+                Any.pack(SampleSchema.Uuid.getDefaultInstance()).getTypeUrl(),
+                DynamicMessage.newBuilder(newValUuid).build(),
+                "",
+                null);
+
+        Assert.assertEquals(expectedRecord, addedRecord);
+        Assert.assertEquals(2, browser.printTable(NAMESPACE, TABLE_NAME));
+    }
+
     /**
      * Verify that addRecord fails on a non-existent table.
      */


### PR DESCRIPTION
## Overview

Description:
CorfuStore allows users to define a table with null metadata type. 
Corfu editor should be consistent with this and do not fail if there 
is no metadata passed to addRecord.

Why should this be merged: 
Users request to run addRecord on a table with null metadata type


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
