### PR TITLE
Add metrics server

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.5.5</version>
+            <version>1.10.5</version>
         </dependency>
         <dependency>
             <groupId>net.jpountz.lz4</groupId>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -167,6 +167,13 @@
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+
         <!-- External Dependencies-->
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -102,7 +102,7 @@ public class CorfuServer {
     }
 
     public static void configureHealthMonitor(Map<String, Object> opts) {
-        if (opts.get("--health-port") != null) {
+        if (opts.get(CorfuServerCmdLine.HEALTH_PORT_PARAM) != null) {
             log.info("Starting health monitor");
             HealthMonitor.init();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerCmdLine.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerCmdLine.java
@@ -4,6 +4,9 @@ import org.corfudb.common.config.ConfigParamsHelper;
 
 public class CorfuServerCmdLine {
 
+    public static final String METRICS_PORT_PARAM = "--metrics-port";
+    public static final String HEALTH_PORT_PARAM = "--health-port";
+
     private CorfuServerCmdLine() {
         // prevent class initialization
     }
@@ -39,7 +42,8 @@ public class CorfuServerCmdLine {
                     + "[-H <seconds>] [-I <cluster-id>] [-x <ciphers>] [-z <tls-protocols>]] "
                     + "[--disable-cert-expiry-check-file=<file_path>]"
                     + "[--metrics]"
-                    + "[--health-port=<health_port>]"
+                    + "[" + METRICS_PORT_PARAM + "=<metrics_port>]"
+                    + "[" + HEALTH_PORT_PARAM + "=<health_port>]"
                     + "[--snapshot-batch=<batch-size>] [--lock-lease=<lease-duration>]"
                     + "[--max-snapshot-entries-applied=<max-snapshot-entries-applied>]"
                     + "[-P <prefix>] [-R <retention>] <port>"
@@ -172,8 +176,10 @@ public class CorfuServerCmdLine {
                     + "              Number of threads dedicated for the logunit server [default: 4].\n"
                     + " --metrics                                                                "
                     + "              Enable metrics provider.\n                                  "
-                    + " --health-port=<health_port>                                              "
+                    + " " + HEALTH_PORT_PARAM + "=<health_port>                                              "
                     + "              Enable health api and bind to this port.\n                  "
+                    + " " + METRICS_PORT_PARAM + "=<metrics_port>                                              "
+                    + "              Enable metrics api and bind to this port.\n                  "
                     + " --snapshot-batch=<batch-size>                                            "
                     + "              Snapshot (Full) Sync batch size (number of entries)\n       "
                     + " --lrCacheSize=<cache-num-entries>"

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -1,6 +1,8 @@
 package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableMap;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -13,10 +15,13 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.prometheus.client.exporter.HTTPServer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.corfudb.common.config.ConfigParamNames;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
+import org.corfudb.common.metrics.micrometer.MeterRegistryProvider.MeterRegistryInitializer;
 import org.corfudb.infrastructure.ManagementServer.ManagementServerInitializer;
 import org.corfudb.infrastructure.health.HealthMonitor;
 import org.corfudb.infrastructure.health.HttpServerInitializer;
@@ -33,6 +38,7 @@ import org.corfudb.util.GitRepositoryState;
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,6 +51,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import static org.corfudb.common.util.URLUtils.getVersionFormattedHostAddress;
+import static org.corfudb.infrastructure.CorfuServerCmdLine.HEALTH_PORT_PARAM;
+import static org.corfudb.infrastructure.CorfuServerCmdLine.METRICS_PORT_PARAM;
 
 
 /**
@@ -68,6 +76,8 @@ public class CorfuServerNode implements AutoCloseable {
     private ChannelFuture bindFuture;
 
     private ChannelFuture httpServerFuture;
+
+    private HTTPServer metricsServer;
 
     /**
      * Corfu Server initialization.
@@ -115,22 +125,54 @@ public class CorfuServerNode implements AutoCloseable {
      */
     public ChannelFuture start() {
         final int corfuPort = Integer.parseInt((String) serverContext.getServerConfig().get("<port>"));
-        bindFuture = bindServer(serverContext.getWorkerGroup(),
+        bindFuture = bindServer(
+                serverContext.getWorkerGroup(),
                 this::configureBootstrapOptions,
                 serverContext,
                 router,
                 (String) serverContext.getServerConfig().get("--address"),
-                corfuPort);
-        String healthReportFlag = "--health-port";
-        if (serverContext.getServerConfig().get(healthReportFlag) != null) {
-            final int healthApiPort = Integer.parseInt((String) serverContext.getServerConfig().get(healthReportFlag));
-            if (healthApiPort != corfuPort) {
-                httpServerFuture = bindHttpServer(serverContext.getWorkerGroup(), this::configureBootstrapOptions, serverContext,
-                        healthApiPort);
-            } else {
+                corfuPort
+        );
+
+        Optional<Integer> maybeHealthPort = Optional
+                .ofNullable(serverContext.getServerConfig().get(HEALTH_PORT_PARAM))
+                .map(healthApiPort -> Integer.parseInt(healthApiPort.toString()));
+
+        maybeHealthPort.ifPresent(healthApiPort -> {
+            if (healthApiPort == corfuPort) {
                 log.warn("Port unification is not currently supported. Health server will not be started.");
+            } else {
+                httpServerFuture = bindHttpServer(
+                        serverContext.getWorkerGroup(),
+                        this::configureBootstrapOptions,
+                        serverContext,
+                        healthApiPort
+                );
             }
-        }
+        });
+
+        Optional<Integer> maybeMetricsPort = Optional
+                .ofNullable(serverContext.getServerConfig().get(METRICS_PORT_PARAM))
+                .map(metricsApiPort -> Integer.parseInt(metricsApiPort.toString()));
+
+        maybeMetricsPort.ifPresent(metricsApiPort -> {
+            if (metricsApiPort == corfuPort) {
+                log.warn("Port unification is not currently supported. Metrics server will not be started.");
+            } else {
+                PrometheusMeterRegistry prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+                MeterRegistryInitializer.getMeterRegistry().add(prometheusRegistry);
+
+                try {
+                    metricsServer = new HTTPServer.Builder()
+                            .withPort(metricsApiPort)
+                            .withRegistry(prometheusRegistry.getPrometheusRegistry())
+                            .build();
+                    log.info("Metrics server run on: " + metricsServer.getPort() + " port");
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        });
 
         return bindFuture.syncUninterruptibly();
     }
@@ -193,6 +235,7 @@ public class CorfuServerNode implements AutoCloseable {
             }
         });
         HealthMonitor.shutdown();
+        IOUtils.closeQuietly(metricsServer, ex -> {});
         log.info("close: Server shutdown and resources released");
     }
 

--- a/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.CorfuServerCmdLine;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.universe.logging.LoggingParams;
 import org.corfudb.universe.node.client.LocalCorfuClient;
@@ -56,7 +57,7 @@ public abstract class AbstractCorfuServer<T extends CorfuServerParams, U extends
         }
 
         int healthPort = params.getHealthPort();
-        cmd.append(" --health-port=").append(healthPort);
+        cmd.append(" ").append(CorfuServerCmdLine.HEALTH_PORT_PARAM).append("=").append(healthPort);
 
         cmd.append(" --log-size-quota-percentage=").append(params.getLogSizeQuotaPercentage()).append(" ");
 


### PR DESCRIPTION
## Overview

Description:
Add the metrics server that can be activated via command line and will provide metrics in a Prometheus format

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
