### PR TITLE
Avoid opening compactor metadata tables on every shouldTrigger call

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactionTriggerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactionTriggerPolicy.java
@@ -1,9 +1,10 @@
 package org.corfudb.infrastructure;
 
+import org.corfudb.runtime.DistributedCheckpointerHelper;
 import org.corfudb.runtime.collections.CorfuStore;
 
 public interface CompactionTriggerPolicy {
-    boolean shouldTrigger(long interval, CorfuStore corfuStore) throws Exception;
+    boolean shouldTrigger(long interval, CorfuStore corfuStore, DistributedCheckpointerHelper distributedCheckpointerHelper) throws Exception;
 
     void markCompactionCycleStart();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -215,7 +215,7 @@ public class CompactorService implements ManagementService {
                         compactorLeaderServices.validateLiveness();
                     }
                 } else if (compactionTriggerPolicy.shouldTrigger(
-                        this.corfuRuntimeParameters.getCheckpointTriggerFreqMillis(), getCorfuStore())) {
+                        this.corfuRuntimeParameters.getCheckpointTriggerFreqMillis(), getCorfuStore(), getDistributedCheckpointerHelper())) {
                     trimLog.invokePrefixTrim(getCorfuRuntime(), getCorfuStore());
                     compactionTriggerPolicy.markCompactionCycleStart();
                     compactorLeaderServices.initCompactionCycle();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
@@ -52,8 +52,7 @@ public class DynamicTriggerPolicy implements CompactionTriggerPolicy {
      * @return true if compaction cycle should run, false otherwise
      */
     @Override
-    public boolean shouldTrigger(long interval, CorfuStore corfuStore) throws Exception {
-        DistributedCheckpointerHelper distributedCheckpointerHelper = new DistributedCheckpointerHelper(corfuStore);
+    public boolean shouldTrigger(long interval, CorfuStore corfuStore, DistributedCheckpointerHelper distributedCheckpointerHelper) {
 
         if (distributedCheckpointerHelper.isCompactionDisabled()) {
             log.warn("Compaction has been disabled");

--- a/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
@@ -44,7 +44,7 @@ public class ServerTriggeredCheckpointer extends DistributedCheckpointer {
         for (TableName tableName : tableNames) {
             boolean isSuccess = tryCheckpointTable(tableName, t -> getCheckpointWriter(t, keyDynamicProtobufSerializer));
             if (!isSuccess) {
-                log.warn("Stop checkpointing after failure in {}${}", tableName.getNamespace(), tableName.getTableName());
+                log.warn("Stop checkpointing after failure");
                 break;
             }
         }

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -381,7 +381,7 @@ public class CompactorServiceTest extends AbstractViewTest {
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
         doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
-        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
@@ -403,13 +403,13 @@ public class CompactorServiceTest extends AbstractViewTest {
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
         doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
-        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         DynamicTriggerPolicy dynamicTriggerPolicy1 = mock(DynamicTriggerPolicy.class);
         CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, dynamicTriggerPolicy1));
         doReturn(runtime1).when(compactorService1).getNewCorfuRuntime();
-        when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
+        when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(false);
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
@@ -440,13 +440,13 @@ public class CompactorServiceTest extends AbstractViewTest {
         CompactorService compactorService2 = spy(new CompactorService(sc2, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm2, dynamicTriggerPolicy2));
         doReturn(runtime2).when(compactorService2).getNewCorfuRuntime();
 
-        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
-        when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
+        when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(false);
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
-        when(dynamicTriggerPolicy2.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
+        when(dynamicTriggerPolicy2.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(false);
         compactorService2.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
@@ -480,13 +480,13 @@ public class CompactorServiceTest extends AbstractViewTest {
         CompactorService compactorService2 = spy(new CompactorService(sc2, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm2, dynamicTriggerPolicy2));
         doReturn(runtime2).when(compactorService2).getNewCorfuRuntime();
 
-        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
-        when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
+        when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(false);
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
-        when(dynamicTriggerPolicy2.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
+        when(dynamicTriggerPolicy2.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(false);
         compactorService2.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
@@ -512,7 +512,7 @@ public class CompactorServiceTest extends AbstractViewTest {
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
         doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
-        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable = openCompactionControlsTable();
@@ -558,7 +558,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, new DynamicTriggerPolicy()));
         doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
-        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
@@ -591,7 +591,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageLow);
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
         doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
-        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         // Write entries to the stream until the quota has been exhausted.

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
@@ -9,6 +9,7 @@ import org.corfudb.runtime.CorfuCompactorManagement.CheckpointingStatus;
 import org.corfudb.runtime.CorfuCompactorManagement.CheckpointingStatus.StatusType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.DistributedCheckpointerHelper;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.TxnContext;
@@ -19,7 +20,6 @@ import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.runtime.view.Layout;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.after;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -140,7 +141,7 @@ public class CompactorServiceUnitTest {
         when((CheckpointingStatus) corfuStoreCompactionManagerEntry.getPayload())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.FAILED).build())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build());
-        when(dynamicTriggerPolicy.shouldTrigger(Matchers.anyLong(), Matchers.any(CorfuStore.class))).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy.shouldTrigger(anyLong(), any(CorfuStore.class), any(DistributedCheckpointerHelper.class))).thenReturn(true).thenReturn(false);
         doNothing().when(leaderServices).validateLiveness();
         doReturn(CompactorLeaderServices.LeaderInitStatus.SUCCESS).when(leaderServices).initCompactionCycle();
         when(invokeCheckpointingJvm.isRunning()).thenReturn(false).thenReturn(true);
@@ -164,7 +165,7 @@ public class CompactorServiceUnitTest {
         when(txn.commit()).thenThrow(new TransactionAbortedException(
                         new TxResolutionInfo(UUID.randomUUID(), new Token(0, 0)),
                         AbortCause.CONFLICT, new Throwable(), null));
-        when(dynamicTriggerPolicy.shouldTrigger(Matchers.anyLong(), Matchers.any(CorfuStore.class))).thenReturn(true);
+        when(dynamicTriggerPolicy.shouldTrigger(anyLong(), any(CorfuStore.class), any(DistributedCheckpointerHelper.class))).thenReturn(true);
         doReturn(CompactorLeaderServices.LeaderInitStatus.SUCCESS).when(leaderServices).initCompactionCycle();
 
         compactorServiceSpy.start(Duration.ofSeconds(SCHEDULER_INTERVAL));
@@ -185,7 +186,7 @@ public class CompactorServiceUnitTest {
         when((CheckpointingStatus) corfuStoreCompactionManagerEntry.getPayload())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.FAILED).build())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build());
-        when(dynamicTriggerPolicy.shouldTrigger(Matchers.anyLong(), Matchers.any(CorfuStore.class))).thenReturn(true).thenReturn(false);
+        when(dynamicTriggerPolicy.shouldTrigger(anyLong(), any(CorfuStore.class), any(DistributedCheckpointerHelper.class))).thenReturn(true).thenReturn(false);
         doNothing().when(leaderServices).validateLiveness();
         doReturn(CompactorLeaderServices.LeaderInitStatus.SUCCESS).when(leaderServices).initCompactionCycle();
         when(invokeCheckpointingJvm.isRunning())


### PR DESCRIPTION
When shouldTrigger initializes DistributedCheckpointerHelper on every call, it opens all the compactor metadata tables leading to excessive openTable logs. So init distributedCheckpointerHelper only if it's not done already

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
