### PR TITLE
Reset object state on exceptions during sync

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
@@ -202,6 +202,12 @@ public class MultiVersionObject<T extends ICorfuSMR<T>> {
                     if (!te.isRetriable() || x == (trimRetry - 1)) {
                         throw te;
                     }
+                } catch (Exception ex) {
+                    log.warn("SnapshotProxy[{}] encountered an exception during sync to {} on attempt {} of {}",
+                            Utils.toReadableId(getID()), timestamp, x + 1, trimRetry, ex);
+
+                    resetUnsafe();
+                    throw ex;
                 }
             }
 

--- a/test/src/test/java/org/corfudb/integration/ObjectsViewIT.java
+++ b/test/src/test/java/org/corfudb/integration/ObjectsViewIT.java
@@ -98,8 +98,8 @@ public class ObjectsViewIT extends AbstractIT {
         writeTx(table2rt2, rt2, key, singleWrite, multiWrite);
 
         // Perform a read on table1 with rt1. Since globalTail = 21 > resolvedUpTo = 13, we will trigger a sync.
-        // However, when applying the updates from the object, 11 will not be >= 13, so an IllegalStateException
-        // will be thrown. The object layer should detect this and reset the object in order to provide a correct view.
+        // However, when applying the updates from the object, 11 will not be >= 13, so a TrimmedException will
+        // be thrown. The object layer should detect this and reset the object in order to provide a correct view.
         rt1.getObjectsView().TXBegin();
         assertThat(table1.get(key)).isEqualTo(key + multiWrite);
         rt1.getObjectsView().TXEnd();


### PR DESCRIPTION
This patch fixes a bug where clients can observe stale or incomplete data when an exception occurs on some code paths during a sync. By resetting the state of the object and its SMR stream, subsequent reads will be served from an accurate view of the object.

## Overview

Description:

Why should this be merged:  Bug fix during certain edge cases.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
