### PR TITLE
Migrate LR schemas from old types to new types

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -360,7 +360,8 @@ public class CorfuInterClusterReplicationServer implements Runnable {
     private boolean isUpgradeInProgress(LogReplicationUpgradeManager upgradeManager, CorfuStore corfuStore) {
         boolean isUpgraded = true;
         try (TxnContext txnContext = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            isUpgraded = upgradeManager.getLrRollingUpgradeHandler().isLRUpgradeInProgress(txnContext);
+            isUpgraded = upgradeManager.getLrRollingUpgradeHandler()
+                    .isLRUpgradeInProgress(txnContext);
             txnContext.commit();
         } catch (TransactionAbortedException e) {
             // TODO V2: This exception needs to be caught to handle concurrent writes to the Replication Event table

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LRRollingUpgradeHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LRRollingUpgradeHandler.java
@@ -5,6 +5,9 @@ import com.google.protobuf.Timestamp;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.ILogReplicationVersionAdapter;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
@@ -57,21 +60,22 @@ public class LRRollingUpgradeHandler {
     private volatile boolean isClusterAllAtV2 = false;
     ILogReplicationVersionAdapter versionAdapter;
 
+    CorfuStore corfuStore;
+
     public LRRollingUpgradeHandler(ILogReplicationVersionAdapter versionAdapter, CorfuStore corfuStore) {
         this.versionAdapter = versionAdapter;
+        this.corfuStore = corfuStore;
 
+        // Handle legacy types first.
+        LogReplicationMetadataManager.addLegacyTypesToSerializer(corfuStore);
+        LogReplicationMetadataManager.tryOpenTable(corfuStore, NAMESPACE,
+                LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME,
+                LogReplication.LogReplicationSession.class,
+                LogReplication.ReplicationStatus.class, null);
         // Open the event table, which is used to log the intent for triggering a forced snapshot sync upon upgrade
         // completion
-        try {
-            corfuStore.openTable(NAMESPACE, REPLICATION_EVENT_TABLE_NAME,
-                LogReplicationMetadata.ReplicationEventInfoKey.class,
-                LogReplicationMetadata.ReplicationEvent.class,
-                null,
-                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationEvent.class));
-        } catch (Exception e) {
-            log.error("Failed to open the Event Table", e);
-            throw new IllegalStateException(e);
-        }
+        LogReplicationMetadataManager.tryOpenTable(corfuStore, NAMESPACE, REPLICATION_EVENT_TABLE_NAME,
+                LogReplicationMetadata.ReplicationEventInfoKey.class, LogReplicationMetadata.ReplicationEvent.class, null);
     }
 
     public boolean isLRUpgradeInProgress(TxnContext txnContext) {
@@ -125,7 +129,8 @@ public class LRRollingUpgradeHandler {
      * @param txnContext All of the above must execute in the same transaction passed in.
      */
     public void migrateData(TxnContext txnContext) {
-        // Data migration to be added here.
+        // Currently only the LogReplicationMetadataManager needs data-migration
+        LogReplicationMetadataManager.migrateData(txnContext);
         addSnapshotSyncEventOnUpgradeCompletion(txnContext);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -71,6 +71,10 @@ public final class LogReplicationEventListener implements StreamListener {
             // service event queue.
             for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {
                 for (CorfuStreamEntry entry : entryList) {
+                    if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
+                        log.warn("LREventListener ignoring a CLEAR operation");
+                        continue;
+                    }
                     ReplicationEventInfoKey key = (ReplicationEventInfoKey) entry.getKey();
                     ReplicationEvent event = (ReplicationEvent) entry.getPayload();
                     log.info("Received event :: id={}, type={}, session={}, ts={}", event.getEventId(), event.getType(),

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -742,88 +742,97 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
                     .findFirst()
                     .map(corfuStreamEntries -> corfuStreamEntries.get(0))
                     .orElse(null);
-            if (entry != null && entry.getOperation().equals(CorfuStreamEntry.OperationType.UPDATE)) {
-                log.info("onNext :: key={}, payload={}, metadata={}", entry.getKey(), entry.getPayload(), entry.getMetadata());
-                if (entry.getKey().equals(OP_SWITCH)) {
-                    clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithRoleSwitch());
-                } else if (entry.getKey().equals(OP_TWO_SOURCE)) {
-                    clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllSource());
-                } else if (entry.getKey().equals(OP_ALL_SINK)) {
-                    clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllSink());
-                } else if (entry.getKey().equals(OP_INVALID)) {
-                    clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithInvalid());
-                } else if (entry.getKey().equals(OP_RESUME)) {
-                    clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateSingleSourceSinkTopolgy());
-                } else if (entry.getKey().equals(OP_ENFORCE_SNAPSHOT_FULL_SYNC)) {
-                    try {
-                        ClusterDescriptor localCluster = clusterManager.findLocalCluster();
-                        if (DefaultClusterConfig.getSinkClusterIds().contains(localCluster.getClusterId())) {
-                            return;
-                        }
-                        // Enforce snapshot sync on the 1st sink cluster
-                        TopologyDescriptor currentTopology = clusterManager.topologyConfig;
-                        String sinkClusterId = currentTopology.getRemoteSinkClusters().keySet().stream()
-                                .filter(clusterId -> clusterId.equals(DefaultClusterConfig.getSinkClusterIds().get(0)))
-                                .findFirst().get();
-
-                        String sourceClusterId = localCluster.getClusterId();
-
-                        LogReplicationSession session = LogReplicationSession.newBuilder()
-                                .setSinkClusterId(sinkClusterId)
-                                .setSourceClusterId(sourceClusterId)
-                                .setSubscriber(LogReplicationConfigManager.getDefaultSubscriber())
-                                .build();
-                        clusterManager.forceSnapshotSync(session);
-                    } catch (LogReplicationDiscoveryServiceException e) {
-                        log.warn("Caught a RuntimeException ", e);
-                        String clusterId = clusterManager.topologyConfig.getLocalClusterDescriptor().getClusterId();
-                        if (DefaultClusterConfig.getSourceClusterIds().contains(clusterId)) {
-                            log.error("The current cluster role is SOURCE but forcedSnapshot Sync failed with an " +
-                                    "exception", e);
-                            throw new RuntimeException(e);
-                        }
-                    }
-                } else if (entry.getKey().equals(OP_BACKUP)) {
-                    clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithBackup());
-                } else if (entry.getKey().equals(OP_TWO_SINK_MIXED)) {
-                    clusterManager.isSinkConnectionStarter = true;
-                    clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateTwoSinkMixedModelTopology());
-                } else if (entry.getKey().equals(TP_SINGLE_SOURCE_SINK)) {
-                    clusterManager.initSingleSourceSinkTopology();
-                } else if (entry.getKey().equals(TP_MULTI_SINK)) {
-                    clusterManager.createSingleSourceMultiSinkTopology();
-                } else if (entry.getKey().equals(TP_MULTI_SOURCE)) {
-                    clusterManager.createMultiSourceSingleSinkTopology();
-                } else if (entry.getKey().equals(TP_MIXED_MODEL_THREE_SINK)) {
-                    clusterManager.isSinkConnectionStarter = true;
-                    clusterManager.createThreeSinkMixedModelTopology();
-                } else if (entry.getKey().equals(TP_MULTI_SINK_REV_CONNECTION)) {
-                    clusterManager.isSinkConnectionStarter = true;
-                    clusterManager.createSingleSourceMultiSinkTopology();
-                } else if (entry.getKey().equals(TP_MULTI_SOURCE_REV_CONNECTION)) {
-                    clusterManager.isSinkConnectionStarter = true;
-                    clusterManager.createMultiSourceSingleSinkTopology();
-                } else if (entry.getKey().equals(TP_SINGLE_SOURCE_SINK_REV_CONNECTION)) {
-                    clusterManager.isSinkConnectionStarter = true;
-                    clusterManager.initSingleSourceSinkTopology();
-                }
-            } else {
-                log.info("onNext :: operation={}, key={}, payload={}, metadata={}", entry.getOperation().name(),
-                        entry.getKey(), entry.getPayload(), entry.getMetadata());
+            if (entry == null) {
+                log.warn("configManager:onNext() did not find any entries");
+                return;
             }
-        }
+            if (!entry.getOperation().equals(CorfuStreamEntry.OperationType.UPDATE)) {
+                if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
+                    log.warn("Config listener ignoring a clear operation");
+                } else {
+                    log.info("onNext :: operation={}, key={}, payload={}, metadata={}", entry.getOperation().name(),
+                            entry.getKey(), entry.getPayload(), entry.getMetadata());
+                }
+                return;
+            }
 
-        @Override
-        public void onError(Throwable throwable) {
-            // Ignore
-        }
+            log.info("onNext :: key={}, payload={}, metadata={}", entry.getKey(), entry.getPayload(), entry.getMetadata());
+            if (entry.getKey().equals(OP_SWITCH)) {
+                clusterManager.getClusterManagerCallback()
+                        .applyNewTopologyConfig(clusterManager.generateConfigWithRoleSwitch());
+            } else if (entry.getKey().equals(OP_TWO_SOURCE)) {
+                clusterManager.getClusterManagerCallback()
+                        .applyNewTopologyConfig(clusterManager.generateConfigWithAllSource());
+            } else if (entry.getKey().equals(OP_ALL_SINK)) {
+                clusterManager.getClusterManagerCallback()
+                        .applyNewTopologyConfig(clusterManager.generateConfigWithAllSink());
+            } else if (entry.getKey().equals(OP_INVALID)) {
+                clusterManager.getClusterManagerCallback()
+                        .applyNewTopologyConfig(clusterManager.generateConfigWithInvalid());
+            } else if (entry.getKey().equals(OP_RESUME)) {
+                clusterManager.getClusterManagerCallback()
+                        .applyNewTopologyConfig(clusterManager.generateSingleSourceSinkTopolgy());
+            } else if (entry.getKey().equals(OP_ENFORCE_SNAPSHOT_FULL_SYNC)) {
+                try {
+                    ClusterDescriptor localCluster = clusterManager.findLocalCluster();
+                    if (DefaultClusterConfig.getSinkClusterIds().contains(localCluster.getClusterId())) {
+                        return;
+                    }
+                    // Enforce snapshot sync on the 1st sink cluster
+                    TopologyDescriptor currentTopology = clusterManager.topologyConfig;
+                    String sinkClusterId = currentTopology.getRemoteSinkClusters().keySet().stream()
+                            .filter(clusterId -> clusterId.equals(DefaultClusterConfig.getSinkClusterIds().get(0)))
+                            .findFirst().get();
+
+                    String sourceClusterId = localCluster.getClusterId();
+
+                    LogReplicationSession session = LogReplicationSession.newBuilder()
+                            .setSinkClusterId(sinkClusterId)
+                            .setSourceClusterId(sourceClusterId)
+                            .setSubscriber(LogReplicationConfigManager.getDefaultSubscriber())
+                            .build();
+                    clusterManager.forceSnapshotSync(session);
+                } catch (LogReplicationDiscoveryServiceException e) {
+                    log.warn("Caught a RuntimeException ", e);
+                    String clusterId = clusterManager.topologyConfig.getLocalClusterDescriptor().getClusterId();
+                    if (DefaultClusterConfig.getSourceClusterIds().contains(clusterId)) {
+                        log.error("The current cluster role is SOURCE but forcedSnapshot Sync failed with an " +
+                                "exception", e);
+                        throw new RuntimeException(e);
+                    }
+                }
+            } else if (entry.getKey().equals(OP_BACKUP)) {
+                clusterManager.getClusterManagerCallback()
+                        .applyNewTopologyConfig(clusterManager.generateConfigWithBackup());
+            } else if (entry.getKey().equals(OP_TWO_SINK_MIXED)) {
+                clusterManager.isSinkConnectionStarter = true;
+                clusterManager.getClusterManagerCallback()
+                        .applyNewTopologyConfig(clusterManager.generateTwoSinkMixedModelTopology());
+            } else if (entry.getKey().equals(TP_SINGLE_SOURCE_SINK)) {
+                clusterManager.initSingleSourceSinkTopology();
+            } else if (entry.getKey().equals(TP_MULTI_SINK)) {
+                clusterManager.createSingleSourceMultiSinkTopology();
+            } else if (entry.getKey().equals(TP_MULTI_SOURCE)) {
+                clusterManager.createMultiSourceSingleSinkTopology();
+            } else if (entry.getKey().equals(TP_MIXED_MODEL_THREE_SINK)) {
+                clusterManager.isSinkConnectionStarter = true;
+                clusterManager.createThreeSinkMixedModelTopology();
+            } else if (entry.getKey().equals(TP_MULTI_SINK_REV_CONNECTION)) {
+                clusterManager.isSinkConnectionStarter = true;
+                clusterManager.createSingleSourceMultiSinkTopology();
+            } else if (entry.getKey().equals(TP_MULTI_SOURCE_REV_CONNECTION)) {
+                clusterManager.isSinkConnectionStarter = true;
+                clusterManager.createMultiSourceSingleSinkTopology();
+            } else if (entry.getKey().equals(TP_SINGLE_SOURCE_SINK_REV_CONNECTION)) {
+                clusterManager.isSinkConnectionStarter = true;
+                clusterManager.initSingleSourceSinkTopology();
+            }
     }
+
+    @Override
+    public void onError(Throwable throwable) {
+        // Ignore
+    }
+}
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationEvent;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationEventInfoKey;
@@ -46,6 +47,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -97,25 +100,76 @@ public class LogReplicationMetadataManager {
         this.runtime = runtime;
         this.corfuStore = new CorfuStore(runtime);
         this.replicationContext = replicationContext;
+        this.metadataTable = (Table<LogReplicationSession, ReplicationMetadata, Message>)
+                tryOpenTable(this.corfuStore, NAMESPACE, METADATA_TABLE_NAME,
+                        LogReplicationSession.class, ReplicationMetadata.class, null);
+        this.statusTable = (Table<LogReplicationSession, ReplicationStatus, Message>)
+                tryOpenTable(this.corfuStore, NAMESPACE, LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME,
+                        LogReplicationSession.class, ReplicationStatus.class, null);
+        this.replicationEventTable = (Table<ReplicationEventInfoKey, ReplicationEvent, Message>)
+                tryOpenTable(corfuStore, NAMESPACE, REPLICATION_EVENT_TABLE_NAME,
+                        ReplicationEventInfoKey.class, ReplicationEvent.class, null);
+    }
 
+    /**
+     * A generic way to try open a table and handle any exceptions encountered
+     * @param corfuStore - instance of the corfuStore
+     * @param namespace - just the namespace part of the full table name
+     * @param tableName - just the tablename part of the full table name
+     * @param keyClass - Protobuf key class that extends Message
+     * @param valueClass - Protobuf generated Value or Payload class that extends Message
+     * @param metadataClass - Protobuf generated Metadata class (can be null)
+     * @return - a generic table type.
+     */
+    public static Table tryOpenTable(CorfuStore corfuStore, String namespace, String tableName,
+                                     Class keyClass, Class valueClass, Class metadataClass) {
+        Table table = null;
         try {
-            this.metadataTable = this.corfuStore.openTable(NAMESPACE, METADATA_TABLE_NAME,
-                    LogReplicationSession.class, ReplicationMetadata.class, null,
-                    TableOptions.fromProtoSchema(ReplicationMetadata.class));
-
-            this.statusTable = this.corfuStore.openTable(NAMESPACE, LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME,
-                    LogReplicationSession.class, ReplicationStatus.class, null,
-                    TableOptions.fromProtoSchema(ReplicationStatus.class));
-
-            this.replicationEventTable = this.corfuStore.openTable(NAMESPACE, REPLICATION_EVENT_TABLE_NAME,
-                    ReplicationEventInfoKey.class,
-                    ReplicationEvent.class,
-                    null,
-                    TableOptions.fromProtoSchema(ReplicationEvent.class));
-        } catch (Exception e) {
-            log.error("Caught an exception while opening metadata tables", e);
-            throw new ReplicationWriterException(e);
+            table = corfuStore.openTable(namespace, tableName,
+                    keyClass, valueClass, metadataClass,
+                    TableOptions.fromProtoSchema(valueClass));
+        } catch (Exception ee) {
+            log.error("Caught an exception while opening "+namespace+"$"+tableName, ee);
+            throw new ReplicationWriterException(ee);
         }
+        return table;
+    }
+
+    /**
+     * The following tables need to move from old type to new type
+     * 1. CORFU-REPLICATION-WRITER-UUID-OF-CLUSTER -> LogReplicationMetadataTable
+     * Type: Schema change AND name change
+     *    (LogReplicationMetadataKey, LogReplicationMetadataVal) ->
+     *     (LogReplicationSession, ReplicationMetadata)
+     * Action: Open the old table with old types and Clear the old table
+     *         Not used in new code. Optional as failure to clear won't cause issues.
+     *         TODO: consider scanning registry for signature and wipe out contents.
+     *
+     * 2. LogReplicationStatus
+     * Type: Schema change for key AND value types with NO table name change
+     * (ReplicationStatusKey, ReplicationStatusVal) ->
+     * (LogReplicationSession.class, ReplicationMetadata.class)
+     * Action: Make serializer aware of old types, open table with new type, clear it
+     *
+     * 3. LogReplicationEventTable
+     * Type: Schema change for Key type only
+     * (ReplicationEventKey, ReplicationEvent) ->
+     * (ReplicationEventInfoKey, ReplicationEvent)
+     * Action: Make serializer aware of old key type, open table with new type, clear it
+     * @param corfuStore - the same runtime used by LogReplicationMetadataManager
+     */
+    public static void addLegacyTypesToSerializer(CorfuStore corfuStore) {
+        corfuStore.getRuntime().getTableRegistry()
+                .addTypeToClassMap(LogReplicationMetadata.ReplicationStatusKey.getDefaultInstance());
+        corfuStore.getRuntime().getTableRegistry()
+                .addTypeToClassMap(LogReplicationMetadata.ReplicationStatusVal.getDefaultInstance());
+        corfuStore.getRuntime().getTableRegistry()
+                .addTypeToClassMap(LogReplicationMetadata.ReplicationEventKey.getDefaultInstance());
+    }
+
+    public static void migrateData(TxnContext txnContext) {
+        txnContext.clear(txnContext.getTable(LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME));
+        txnContext.clear(txnContext.getTable(REPLICATION_EVENT_TABLE_NAME));
     }
 
     private void initializeMetadata(TxnContext txn, LogReplicationSession session, boolean incomingSession,

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -37,7 +37,8 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 public final class LogReplicationUtils {
     public static final String LR_STATUS_STREAM_TAG = "lr_status";
 
-    public static final String REPLICATION_STATUS_TABLE_NAME = "LogReplicationStatusSource";
+    // Retain the old name from LR v1 to avoid polluting the registry table with stale entries.
+    public static final String REPLICATION_STATUS_TABLE_NAME = "LogReplicationStatus";
 
     private LogReplicationUtils() { }
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
@@ -153,8 +153,14 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         verifyInitialSnapshotSyncAfterStartup(FIVE, NUM_WRITES);
 
         // Upgrade the sink site
+        CountDownLatch statusUpdateLatch = new CountDownLatch(NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE + 1);
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
         log.info(">> Upgrading the sink site ...");
         performRollingUpgrade(false);
+
+        statusUpdateLatch.await();
+        corfuStoreSink.unsubscribeListener(sinkListener);
 
         // Trigger a snapshot sync by stopping the source LR and running a CP+trim.  Verify that snapshot sync took
         // place
@@ -170,7 +176,17 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
 
         // Upgrade the sink site first
         log.info(">> Upgrading the sink site ...");
+        // TODO pankti: Add a comment here
+        CountDownLatch statusUpdateLatch = new CountDownLatch(NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE + 1);
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
+
         performRollingUpgrade(false);
+
+        log.info("Wait for the initial write");
+        statusUpdateLatch.await();
+        log.info("Initial Write received");
+        corfuStoreSink.unsubscribeListener(sinkListener);
 
         // Upgrading the source site will force a snapshot sync
         verifySnapshotSyncAfterSourceUpgrade();
@@ -241,13 +257,17 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
 
         // Upgrade the sink site
 
+        CountDownLatch statusUpdateLatch = new CountDownLatch(NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE + 1);
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
         log.info(">> Upgrading the sink site ...");
         Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {
             streamsToReplicateSink.add(TABLE_PREFIX + i);
         }
         performRollingUpgrade(false);
-
+        statusUpdateLatch.await();
+        corfuStoreSink.unsubscribeListener(sinkListener);
 
         stopSourceLogReplicator();
 
@@ -279,7 +299,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        CountDownLatch statusUpdateLatch = new CountDownLatch(NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE);
+        statusUpdateLatch = new CountDownLatch(NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE);
         sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
         corfuStoreSink.subscribeListener(sinkListener, CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
 
@@ -319,7 +339,15 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
             streamsToReplicateSink.add(TABLE_PREFIX + i);
         }
 
+        // TODO pankti: Add a comment here
+        CountDownLatch statusUpdateLatch = new CountDownLatch(NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE + 1);
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
+
         performRollingUpgrade(false);
+
+        statusUpdateLatch.await();
+        corfuStoreSink.unsubscribeListener(sinkListener);
 
         List<String> sourceOnlyStreams = streamsToReplicateSource.stream()
                 .filter(s -> !streamsToReplicateSink.contains(s))
@@ -349,17 +377,16 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         verifyDataOnSink(sourceOnlyStreams, NUM_WRITES);
         verifyDataOnSink(sinkOnlyStreams, 0);
 
-        corfuStoreSink.unsubscribeListener(sinkListener);
-        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
+/*        corfuStoreSink.unsubscribeListener(sinkListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);*/
 
         CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
         snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        CountDownLatch statusUpdateLatch = new CountDownLatch(NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE);
+        statusUpdateLatch = new CountDownLatch(NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE);
         sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
         corfuStoreSink.subscribeListener(sinkListener, CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
-
 
         // Now upgrade the source site
         openMapsAfterUpgradeSource(sourceOnlyStreams, sinkOnlyStreams);

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -467,15 +467,14 @@ public class LogReplicationAbstractIT extends AbstractIT {
         public void onNext(CorfuStreamEntries results) {
             results.getEntries().forEach((schema, entries) -> entries.forEach(e -> {
                 log.info("Operation: {}", e.getOperation());
-                ReplicationStatus status = (ReplicationStatus) e.getPayload();
-
-                log.info("Status: {}", status);
-
                 // TODO pankti:  Clean up and add a comment when this operation will be received and reason for this
                 //  condition.
                 if (e.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
                     return;
                 }
+                ReplicationStatus status = (ReplicationStatus) e.getPayload();
+
+                log.info("Status: {}", status);
                 log.info("Adding: {}", status);
                 accumulatedStatus.add(status.getSinkStatus().getDataConsistent());
                 if (this.waitSnapshotStatusComplete &&

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -466,22 +466,34 @@ public class LogReplicationAbstractIT extends AbstractIT {
         @Override
         public void onNext(CorfuStreamEntries results) {
             results.getEntries().forEach((schema, entries) -> entries.forEach(e -> {
-                    ReplicationStatus status = (ReplicationStatus)e.getPayload();
-                    accumulatedStatus.add(status.getSinkStatus().getDataConsistent());
-                    if (this.waitSnapshotStatusComplete &&
-                            status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus()
-                                .equals(SyncStatus.COMPLETED)) {
-                        countDownLatch.countDown();
-                    }
+                log.info("Operation: {}", e.getOperation());
+                ReplicationStatus status = (ReplicationStatus) e.getPayload();
+
+                log.info("Status: {}", status);
+
+                // TODO pankti:  Clean up and add a comment when this operation will be received and reason for this
+                //  condition.
+                if (e.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
+                    return;
+                }
+                log.info("Adding: {}", status);
+                accumulatedStatus.add(status.getSinkStatus().getDataConsistent());
+                if (this.waitSnapshotStatusComplete &&
+                    status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus()
+                        .equals(SyncStatus.COMPLETED)) {
+                    countDownLatch.countDown();
+                }
             }));
 
             if (!this.waitSnapshotStatusComplete) {
+                log.info("Counting Down");
                 countDownLatch.countDown();
             }
         }
 
         @Override
         public void onError(Throwable throwable) {
+            log.error("Error in Replication Status Listener: {}", throwable);
             fail("onError for ReplicationStatusListener : " + throwable.toString());
         }
     }


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
This allows new code to open old schemas without actually registering the old types.

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
