### PR TITLE
Stronger consistency guarantee for LR logical group client APIs & Sink data removal

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationLogicalGroupConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationLogicalGroupConfig.java
@@ -30,6 +30,7 @@ public class LogReplicationLogicalGroupConfig extends LogReplicationConfig {
     @Setter
     private Map<String, Set<String>> logicalGroupToStreams;
 
+
     public LogReplicationLogicalGroupConfig(@NonNull LogReplicationSession session,
                                             @NonNull Set<String> streamsToReplicate,
                                             @NonNull Map<UUID, List<UUID>> dataStreamToTagsMap,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/exceptions/GroupDestinationChangeException.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/exceptions/GroupDestinationChangeException.java
@@ -1,0 +1,16 @@
+package org.corfudb.infrastructure.logreplication.exceptions;
+
+
+/**
+ * Dedicated for LOGICAL_GROUP replication model. During log entry sync if group destination change is detected,
+ * the ongoing log entry sync should be canceled and a forced snapshot sync for that session should be triggered.
+ */
+public class GroupDestinationChangeException extends RuntimeException {
+    public GroupDestinationChangeException() {
+        super("Group destination change detected.");
+    }
+
+    public GroupDestinationChangeException(String msg) {
+        super(msg);
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/exceptions/MessageSizeExceededException.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/exceptions/MessageSizeExceededException.java
@@ -1,16 +1,17 @@
-package org.corfudb.infrastructure.logreplication.replication.send.logreader;
+package org.corfudb.infrastructure.logreplication.exceptions;
 
-import lombok.NoArgsConstructor;
 
 /**
  * An exception that is thrown when the message size exceeds the predefined limit
  *
  * Created by Anny on 12/5/22.
  */
-@NoArgsConstructor
 public class MessageSizeExceededException extends RuntimeException {
+    public MessageSizeExceededException() {
+        super("Message size has exceeded the limit set.");
+    }
 
     public MessageSizeExceededException(String msg) {
-        super("Message size has exceeded the limit set. " + msg);
+        super(msg);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
@@ -24,7 +24,6 @@ import static org.corfudb.util.serializer.ProtobufSerializer.PROTOBUF_SERIALIZER
 public class LogReplicationContext {
 
     @Getter
-    @Setter
     private final LogReplicationConfigManager configManager;
 
     @Getter
@@ -35,7 +34,6 @@ public class LogReplicationContext {
     private long topologyConfigId;
 
     @Getter
-    @Setter
     private final AtomicBoolean isLeader;
 
     @Getter
@@ -68,13 +66,14 @@ public class LogReplicationContext {
     }
 
     /**
-     * This method will be invoked when it is needed to check if registry has new entries, to get the up-to-date
-     * LogReplicationConfig, which mainly includes streams to replicate and data streams to tags map. Please note
-     * that this method is synchronized because LogReplicationContext is shared across sessions so each session
-     * will have its own threads to access it.
+     * This method will be invoked when it is needed to get the up-to-date LogReplicationConfig by checking registry
+     * table or other config related tables.
+     *
+     * @param session LogReplicationSession to refresh the config.
+     * @param updateGroupDestinationConfig True if group destination config needs to be updated.
      */
-    public synchronized void refresh() {
-        this.configManager.getUpdatedConfig();
+    public void refreshConfig(LogReplicationSession session, boolean updateGroupDestinationConfig) {
+        this.configManager.getUpdatedConfig(session, updateGroupDestinationConfig);
     }
 
     /**
@@ -96,5 +95,4 @@ public class LogReplicationContext {
     public ISerializer getProtobufSerializer() {
         return configManager.getRuntime().getSerializers().getSerializer(PROTOBUF_SERIALIZER_CODE);
     }
-
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -60,7 +60,7 @@ public class SessionManager {
 
     private final LogReplicationConfigManager configManager;
 
-    private final LogReplicationClientConfigListener clientConfigListener;
+    private final LogReplicationClientRegisterListener clientConfigListener;
 
     @Getter
     private final Set<LogReplicationSession> sessions = ConcurrentHashMap.newKeySet();
@@ -103,7 +103,7 @@ public class SessionManager {
 
         this.configManager = new LogReplicationConfigManager(runtime, serverContext,
                 topology.getLocalClusterDescriptor().getClusterId());
-        this.clientConfigListener = new LogReplicationClientConfigListener(this,
+        this.clientConfigListener = new LogReplicationClientRegisterListener(this,
                 configManager, corfuStore);
         this.replicationContext = new LogReplicationContext(configManager, topology.getTopologyConfigId(),
                 localCorfuEndpoint, pluginConfig);
@@ -140,7 +140,7 @@ public class SessionManager {
             .build();
         this.localCorfuEndpoint = lrNodeLocator.toEndpointUrl();
         this.configManager = new LogReplicationConfigManager(runtime, topology.getLocalClusterDescriptor().getClusterId());
-        this.clientConfigListener = new LogReplicationClientConfigListener(this, configManager, corfuStore);
+        this.clientConfigListener = new LogReplicationClientRegisterListener(this, configManager, corfuStore);
         this.replicationContext = new LogReplicationContext(configManager, topology.getTopologyConfigId(),
                 localCorfuEndpoint, pluginConfig);
         this.metadataManager = new LogReplicationMetadataManager(corfuRuntime, replicationContext);
@@ -329,7 +329,7 @@ public class SessionManager {
         log.info("Total of {} outgoing sessions created with subscriber {}, sessions={}", sessionsToAdd.size(),
                 subscriber, sessionsToAdd);
 
-        configManager.generateConfig(sessionsToAdd);
+        configManager.generateConfig(sessionsToAdd, true);
     }
 
     private void createIncomingSessionsBySubscriber(ReplicationSubscriber subscriber) {
@@ -370,7 +370,7 @@ public class SessionManager {
         log.info("Total of {} incoming sessions created with subscriber {}, sessions={}", sessionsToAdd.size(),
                 subscriber, sessionsToAdd);
 
-        configManager.generateConfig(sessionsToAdd);
+        configManager.generateConfig(sessionsToAdd, true);
     }
 
     private void logNewlyAddedSessionInfo() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -78,7 +78,7 @@ public class LogEntryWriter extends SinkWriter {
         // Log entry sync could have slow writes. That is, there could be a relatively long duration between last
         // snapshot/log entry sync and the current log entry sync, during which Sink side could have new tables opened.
         // So the config needs to be synced here to capture those updates.
-        replicationContext.refresh();
+        replicationContext.refreshConfig(session, true);
 
         // Boolean value that indicate if the config should sync with registry table or not. Note that primitive boolean
         // value cannot be used here as its value needs to be changed in the lambda function below.
@@ -172,7 +172,7 @@ public class LogEntryWriter extends SinkWriter {
                             // an abort if concurrent updates to the registry occur. We are currently not implementing
                             // this, as (1) it incurs in additional RPC calls for all updates and (2) LR will filter out
                             // these streams on the next batch.
-                            replicationContext.refresh();
+                            replicationContext.refreshConfig(session, true);
                             registryTableUpdated.set(false);
                         }
                     } catch (TransactionAbortedException tae) {
@@ -243,7 +243,7 @@ public class LogEntryWriter extends SinkWriter {
     public void reset(long snapshot, long ackTimestamp) {
         // Sync with registry table when LogEntryWriter is reset, which will happen when Snapshot sync is completed, and
         // when LogReplicationSinkManager is initialized and reset.
-        replicationContext.refresh();
+        replicationContext.refreshConfig(session, true);
         srcGlobalSnapshot = snapshot;
         lastMsgTs = ackTimestamp;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -497,7 +497,7 @@ public class LogReplicationSinkManager implements DataReceiver {
 
         // Sync with registry after transfer phase to capture local updates, as transfer phase could
         // take a relatively long time.
-        replicationContext.refresh();
+        replicationContext.refreshConfig(session, true);
         snapshotWriter.clearLocalStreams();
         snapshotWriter.startSnapshotSyncApply();
         completeSnapshotApply(entry);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -141,7 +141,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         snapshotSyncStartMarker = Optional.empty();
         replicatedStreamIds.clear();
         // Sync with registry table to capture local updates on Sink side
-        replicationContext.refresh();
+        replicationContext.refreshConfig(session, true);
     }
 
     /**
@@ -255,8 +255,8 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
     }
 
     private void clearStream(UUID streamId, TxnContext txnContext) {
-        SMREntry entry = new SMREntry(CLEAR_SMR_METHOD, new Array[0], Serializers.PRIMITIVE);
-        txnContext.logUpdate(streamId, entry, replicationContext.getConfig(session).getDataStreamToTagsMap().get(streamId));
+        txnContext.logUpdate(streamId, CLEAR_ENTRY, replicationContext.getConfig(session)
+                .getDataStreamToTagsMap().get(streamId));
     }
 
     @Override
@@ -392,7 +392,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         applyShadowStream(REGISTRY_TABLE_ID, snapshot);
 
         // Sync the config with registry table after applying its entries
-        replicationContext.refresh();
+        replicationContext.refreshConfig(session, true);
 
         for (String stream : replicationContext.getConfig(session).getStreamsToReplicate()) {
             UUID regularStreamId = CorfuRuntime.getStreamID(stream);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
@@ -172,7 +172,6 @@ public class LogReplicationAckReader {
      */
     private long getMaxReplicatedStreamsTail(Map<UUID, Long> tailMap) {
         long maxTail = Address.NON_ADDRESS;
-        replicationContext.refresh();
         Set<String> streamsToReplicate = replicationContext.getConfig(session).getStreamsToReplicate();
         for (String streamName : streamsToReplicate) {
             UUID streamUuid = CorfuRuntime.getStreamID(streamName);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationError.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationError.java
@@ -9,7 +9,8 @@ public enum LogReplicationError {
     LOG_ENTRY_ACK_TIMEOUT(2, "log Entry Sync ack has timed out."),
     LOG_ENTRY_MESSAGE_SIZE_EXCEEDED(3, "log Replication Entry Message exceeds max allowed size." +
             "Log Replication is TERMINATED."),
-    UNKNOWN (4, "unknown exception caused sync cancel.");
+    GROUP_DESTINATION_CHANGE(4, "group destination changed during log entry sync"),
+    UNKNOWN(5, "unknown exception caused sync cancel.");
 
     private final int code;
     private final String description;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 import com.google.protobuf.TextFormat;
 import io.micrometer.core.instrument.DistributionSummary;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.common.util.Memory;
@@ -56,7 +57,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     private OpaqueEntry lastEntry = null;
 
     @Getter
-    private ObservableValue<Integer> observeBiggerMsg = new ObservableValue(0);
+    private final ObservableValue<Integer> observeBiggerMsg = new ObservableValue(0);
 
     protected final LogReplication.LogReplicationSession session;
     protected final LogReplicationContext replicationContext;
@@ -131,7 +132,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     }
 
     /**
-     * Read log data from the current stream until the sum of all SMR entries's sizeInBytes reaches the maxDataSizePerMsg.
+     * Read log data from the current stream until the sum of all SMR entries sizeInBytes reaches the maxDataSizePerMsg.
      * @param stream
      * @return
      */
@@ -210,7 +211,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
      * @return
      */
     @Override
-    public SnapshotReadMessage read(UUID syncRequestId) {
+    public @NonNull SnapshotReadMessage read(UUID syncRequestId) {
         List<LogReplication.LogReplicationEntryMsg> messages = new ArrayList<>();
 
         boolean endSnapshotSync = false;
@@ -265,7 +266,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     public void reset(long ts) {
         // As the config should reflect the latest configuration read from registry table, it will be synced with the
         // latest registry table content instead of the given ts, while the streams to replicate will be read up to ts.
-        replicationContext.refresh();
+        replicationContext.refreshConfig(session, true);
         streams = replicationContext.getConfig(session).getStreamsToReplicate();
         streamsToSend = new PriorityQueue<>(streams);
         preMsgTs = Address.NON_ADDRESS;
@@ -282,7 +283,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     public static class OpaqueStreamIterator {
         private String name;
         private UUID uuid;
-        private Iterator iterator;
+        private final Iterator iterator;
         private long maxVersion; // the max address of the log entries processed for this stream.
 
         OpaqueStreamIterator(String name, CorfuRuntime rt, long snapshot) {
@@ -313,10 +314,10 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
 
         // The total sizeInBytes of smrEntries in bytes.
         @Getter
-        private int sizeInBytes;
+        private final int sizeInBytes;
 
         @Getter
-        private List<SMREntry> smrEntries;
+        private final List<SMREntry> smrEntries;
 
         public SMREntryList(int size, List<SMREntry> smrEntries) {
             this.sizeInBytes = size;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupLogEntryReader.java
@@ -1,8 +1,32 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import com.google.protobuf.Message;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.config.LogReplicationLogicalGroupConfig;
+import org.corfudb.infrastructure.logreplication.exceptions.GroupDestinationChangeException;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.protocols.logprotocol.OpaqueEntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication.ClientDestinationInfoKey;
+import org.corfudb.runtime.LogReplication.DestinationInfoVal;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.CorfuStreamEntry.OperationType;
+import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.util.serializer.ISerializer;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_MODEL_METADATA_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 
 /**
@@ -12,10 +36,102 @@ import org.corfudb.runtime.LogReplication.LogReplicationSession;
  * with the exception that it will read from a different transactional stream for log entry sync (one that is
  * specific for this model).
  */
+@Slf4j
 public class LogicalGroupLogEntryReader extends BaseLogEntryReader {
+
+    public static final UUID CLIENT_CONFIG_TABLE_ID = CorfuRuntime.getStreamID(
+            TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, LR_MODEL_METADATA_TABLE_NAME));
+
+    private final ISerializer protobufSerializer;
+
 
     public LogicalGroupLogEntryReader(CorfuRuntime runtime, LogReplicationSession session,
                                       LogReplicationContext replicationContext) {
         super(runtime, session, replicationContext);
+        protobufSerializer = replicationContext.getProtobufSerializer();
+    }
+
+    /**
+     * Verify the transaction entry is valid. For LOGICAL_GROUP case, it will check:
+     * (1) If current session is impacted by group destinations change
+     * (2) If the opaque entry contains newly opened streams to replicate
+     * <p>
+     * Notice that a transaction stream entry can be fully or partially replicated,
+     * i.e., if only a subset of streams in the transaction entry are part of the streams
+     * to replicate, the transaction entry will be partially replicated,
+     * avoiding replication of the other streams present in the transaction.
+     *
+     * @param entry transaction stream opaque entry
+     * @return true, if the transaction entry has any valid stream to replicate.
+     * false, otherwise.
+     */
+    @Override
+    boolean isValidTransactionEntry(@NonNull OpaqueEntry entry) {
+        Set<UUID> txEntryStreamIds = new HashSet<>(entry.getEntries().keySet());
+
+        if (txEntryStreamIds.contains(CLIENT_CONFIG_TABLE_ID) &&
+                isCurrentSessionImpacted(entry.getEntries().get(CLIENT_CONFIG_TABLE_ID))) {
+            log.info("Group destination change detected, log entry sync will be stopped and a new snapshot sync " +
+                    "will be triggered！");
+            throw new GroupDestinationChangeException();
+        }
+
+        return super.isValidTransactionEntry(entry);
+    }
+
+    /**
+     * Helper method for checking if the smr entries present in the opaque stream (that current session's log entry
+     * reader is tracking) contain any group destination change with respect to current session. The opaque entries
+     * will be deserialized to verify if the Sink cluster of current session is among the target destinations.
+     *
+     * @param groupConfigTableEntries SMREntries of LogReplicationModelMetadataTable.
+     * @return True if current session is impacted by group destination config change, false otherwise.
+     */
+    private boolean isCurrentSessionImpacted(List<SMREntry> groupConfigTableEntries) {
+        Set<String> groups = ((LogReplicationLogicalGroupConfig) replicationContext.getConfig(session))
+                .getLogicalGroupToStreams().keySet();
+
+        for (SMREntry smrEntry : groupConfigTableEntries) {
+            // Get serialized form of arguments for registry table. They were sent in OpaqueEntry and
+            // need to be deserialized using ProtobufSerializer
+            Object[] objs = smrEntry.getSMRArguments();
+            ByteBuf keyBuf = Unpooled.wrappedBuffer((byte[]) objs[0]);
+            ClientDestinationInfoKey clientInfoKey = (ClientDestinationInfoKey) protobufSerializer
+                    .deserialize(keyBuf, null);
+
+            if (clientInfoKey.getModel() != session.getSubscriber().getModel() ||
+                    !clientInfoKey.getClientName().equals(session.getSubscriber().getClientName())) {
+                // SMREntry for other clients
+                continue;
+            } else if (CorfuStreamEntry.getOperationType(smrEntry).equals(OperationType.DELETE) &&
+                    groups.contains(clientInfoKey.getGroupName())) {
+                    log.info("Group {} has no destinations now and is removed from client metadata table.",
+                            clientInfoKey.getGroupName());
+                    return true;
+            }
+
+            ByteBuf valueBuf = Unpooled.wrappedBuffer((byte[]) objs[1]);
+            CorfuRecord<DestinationInfoVal, Message> destinations =
+                    (CorfuRecord<DestinationInfoVal, Message>) protobufSerializer.deserialize(valueBuf, null);
+
+            // From a session's point of view, there are 2 ways it could be impacted:
+            // (1) a group is added to have current session's Sink as its destination
+            // (2) an existing group (already in config) no longer has current session's Sink as its destination
+            boolean isGroupAdded = !groups.contains(clientInfoKey.getGroupName()) &&
+                    destinations.getPayload().getDestinationIdsList().contains(session.getSinkClusterId());
+            boolean isGroupRemoved = groups.contains(clientInfoKey.getGroupName()) &&
+                    !destinations.getPayload().getDestinationIdsList().contains(session.getSinkClusterId());
+
+
+            if (isGroupAdded || isGroupRemoved) {
+                String groupChangeMessage = isGroupAdded ? "New group added for the Sink of current session. " :
+                        "Group removed from the Sink of current session. ";
+                log.info(groupChangeMessage + "Group=[{}], Sinks=[{}], current Sessions' Sink=[{}]",
+                        clientInfoKey.getGroupName(), destinations.getPayload().getDestinationIdsList(),
+                        session.getSinkClusterId());
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupSnapshotReader.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
@@ -7,6 +8,7 @@ import org.corfudb.runtime.LogReplication.LogReplicationSession;
 /**
  * Snapshot reader implementation for Logical Grouping Replication Model.
  */
+@Slf4j
 public class LogicalGroupSnapshotReader extends BaseSnapshotReader {
 
     public LogicalGroupSnapshotReader(CorfuRuntime runtime, LogReplicationSession session,

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
@@ -16,6 +16,8 @@ import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.util.retry.ExponentialBackoffRetry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.RetryNeededException;
@@ -191,7 +193,10 @@ public class LogReplicationLogicalGroupClient {
                                 .addAllDestinationIds(finalRemoteDestinations)
                                 .build();
                     }
-
+                    // Manually add stream tag to the write set of this txn, such that relevant LogEntryReaders could
+                    // be able to track the corresponding opaque stream.
+                    TransactionalContext.getRootContext().getWriteSetInfo().getStreamTags()
+                            .add(ObjectsView.getLogicalGroupStreamTagInfo(clientName).getStreamId());
                     txn.putRecord(sourceMetadataTable, clientInfoKey, clientDestinations, null);
                     txn.commit();
                     return null;
@@ -250,7 +255,10 @@ public class LogReplicationLogicalGroupClient {
                                 .build();
                         txn.putRecord(sourceMetadataTable, clientInfoKey, clientDestinations, null);
                     }
-
+                    // Manually add stream tag to the write set of this txn, such that relevant LogEntryReaders could
+                    // be able to track the corresponding opaque stream.
+                    TransactionalContext.getRootContext().getWriteSetInfo().getStreamTags()
+                            .add(ObjectsView.getLogicalGroupStreamTagInfo(clientName).getStreamId());
                     txn.commit();
                     return null;
                 } catch (TransactionAbortedException tae) {
@@ -322,6 +330,10 @@ public class LogReplicationLogicalGroupClient {
                                 clientName, logicalGroup));
                     }
 
+                    // Manually add stream tag to the write set of this txn, such that relevant LogEntryReaders could
+                    // be able to track the corresponding opaque stream.
+                    TransactionalContext.getRootContext().getWriteSetInfo().getStreamTags()
+                            .add(ObjectsView.getLogicalGroupStreamTagInfo(clientName).getStreamId());
                     txn.commit();
                     return null;
                 } catch (TransactionAbortedException tae) {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntry.java
@@ -85,7 +85,7 @@ public class CorfuStreamEntry<K extends Message, V extends Message, M extends Me
         return new CorfuStreamEntry<>(key, payload, metadata, operationType);
     }
 
-    private static OperationType getOperationType(@Nonnull SMREntry entry) {
+    public static OperationType getOperationType(@Nonnull SMREntry entry) {
         OperationType operationType;
         switch (entry.getSMRMethod()) {
             case "put":

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
@@ -134,7 +134,7 @@ public class LogReplicationConfigManagerTest extends AbstractViewTest {
                 .setSinkClusterId(REMOTE_SINK_CLUSTER_ID)
                 .setSubscriber(LogReplicationConfigManager.getDefaultSubscriber())
                 .build();
-        configManager.generateConfig(Collections.singleton(sampleSession));
+        configManager.generateConfig(Collections.singleton(sampleSession), true);
         verifyExpectedConfigGenerated((LogReplicationFullTableConfig) configManager.getSessionToConfigMap()
                 .get(sampleSession));
     }
@@ -147,15 +147,15 @@ public class LogReplicationConfigManagerTest extends AbstractViewTest {
                 .setSinkClusterId(REMOTE_SINK_CLUSTER_ID)
                 .setSubscriber(LogReplicationConfigManager.getDefaultSubscriber())
                 .build();
-        configManager.generateConfig(Collections.singleton(sampleSession));
+        configManager.generateConfig(Collections.singleton(sampleSession), true);
         verifyExpectedConfigGenerated((LogReplicationFullTableConfig) configManager.getSessionToConfigMap()
                 .get(sampleSession));
 
         // Open new tables and update the expected streams to replicate map, streams to drop and stream tags
         setupStreamsToReplicateAndTagsMap(Collections.singleton(TABLE5), SampleSchema.ValueFieldTagOne.class);
         setupStreamsToDrop(Collections.singleton(TABLE6), SampleSchema.Uuid.class);
-        configManager.getUpdatedConfig();
-        configManager.generateConfig(Collections.singleton(sampleSession));
+        configManager.getUpdatedConfig(sampleSession, true);
+        configManager.generateConfig(Collections.singleton(sampleSession), true);
         verifyExpectedConfigGenerated((LogReplicationFullTableConfig) configManager.getSessionToConfigMap()
                 .get(sampleSession));
     }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -830,7 +830,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(runtime, LOCAL_SOURCE_CLUSTER_ID);
         LogReplicationPluginConfig pluginConfig = new LogReplicationPluginConfig(pluginConfigFilePath);
         LogReplicationSession session = DefaultClusterConfig.getSessions().get(0);
-        configManager.generateConfig(Collections.singleton(session));
+        configManager.generateConfig(Collections.singleton(session), false);
 
         switch(readerImpl) {
             case EMPTY:

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1240,7 +1240,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(srcTestRuntime, LOCAL_SOURCE_CLUSTER_ID);
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT, pluginConfig);
 
-        configManager.generateConfig(Collections.singleton(session));
+        configManager.generateConfig(Collections.singleton(session), false);
 
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used

--- a/test/src/test/java/org/corfudb/integration/LogReplicationLogicalGroupIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationLogicalGroupIT.java
@@ -633,8 +633,6 @@ public class LogReplicationLogicalGroupIT extends CorfuReplicationMultiSourceSin
         // Remove groupB from Sink3 and verify groupB tables' data no longer replicated to Sink3
         logicalGroupClient.removeDestinations(GROUP_B,
                 Collections.singletonList(DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
-        // Pause the test thread for a while to let the destination removal and new config take effect.
-        TimeUnit.SECONDS.sleep(SLEEP_INTERVAL);
 
         for (int i = targetWrites; i < targetWrites + NUM_WRITES; i++) {
             StringKey key = StringKey.newBuilder().setKey(String.valueOf(i)).build();
@@ -652,7 +650,234 @@ public class LogReplicationLogicalGroupIT extends CorfuReplicationMultiSourceSin
         verifyGroupBTableData(sinkCorfuStores.get(SINK2_INDEX),
                 targetWrites + NUM_WRITES, sinkTablesGroupBOnSink2);
 
+        // After removing groupB from Sink3, the data from groupB tables on Sink3 should be cleared.
+        verifyGroupBTableData(sinkCorfuStores.get(SINK3_INDEX), 0, sinkTablesGroupB);
+    }
+
+    /**
+     * This test verifies that continuous group removal will make Sink side clear related tables without
+     * missing any group removal.
+     * (1) Bring up the 1-Source & 3-Sink topology
+     * (2) Register the logical group client and setup initial group destination mapping as
+     *     {GROUP_A: [SINK2, SINK3]; GROUP_B: [SINK2, SINK3]}
+     * (3) Open tables for replication on both Source and Sink side, and write data to Source side
+     * (4) Start replication servers and verify snapshot sync succeeded.
+     * (5) Remove all groups from SINK3, so now the mapping is {GROUP_A: [SINK2]; GROUP_B: [SINK2]}
+     * (6) Verify forced snapshot sync with Sink3 is triggered because of group removal
+     * (8) Write more data to GROUP_A and GROUP_B tables on Source side, and verify new data is only replicated to
+     *     Sink2 and related tables are cleared from Sink3.
+     */
+    @Test
+    public void testGroupContinuousRemoval() throws Exception {
+        // Register client and add group destinations
+        CorfuRuntime clientRuntime = getClientRuntime();
+        LogReplicationLogicalGroupClient logicalGroupClient =
+                new LogReplicationLogicalGroupClient(clientRuntime, SAMPLE_CLIENT_NAME);
+        logicalGroupClient.setDestinations(GROUP_A,
+                Arrays.asList(
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK2_INDEX),
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
+        logicalGroupClient.setDestinations(GROUP_B,
+                Arrays.asList(
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK2_INDEX),
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
+
+        // Subscribe snapshot plugin listener on each Sink cluster, Sink1 will only have 1 snapshot sync while Sink2
+        // and Sink3 will have 2 snapshot sync for each, where 1 snapshot sync will update the listener twice.
+        CountDownLatch latchSink1 = new CountDownLatch(PLUGIN_UPDATES_PER_SNAPSHOT_SYNC);
+        SnapshotSyncPluginListener snapshotSyncPluginListenerSink1 = new SnapshotSyncPluginListener(latchSink1);
+        subscribeToSnapshotSyncPluginTable(sinkCorfuStores.get(SINK1_INDEX), snapshotSyncPluginListenerSink1);
+
+        CountDownLatch latchSink2 = new CountDownLatch(PLUGIN_UPDATES_PER_SNAPSHOT_SYNC);
+        SnapshotSyncPluginListener snapshotSyncPluginListenerSink2 = new SnapshotSyncPluginListener(latchSink2);
+        subscribeToSnapshotSyncPluginTable(sinkCorfuStores.get(SINK2_INDEX), snapshotSyncPluginListenerSink2);
+
+        CountDownLatch latchSink3 = new CountDownLatch(2 * PLUGIN_UPDATES_PER_SNAPSHOT_SYNC);
+        SnapshotSyncPluginListener snapshotSyncPluginListenerSink3 = new SnapshotSyncPluginListener(latchSink3);
+        subscribeToSnapshotSyncPluginTable(sinkCorfuStores.get(SINK3_INDEX), snapshotSyncPluginListenerSink3);
+
+        // Open tables for replication on both side
+        int numTables = 3;
+        // Source
+        openFederatedTable(numTables, sourceCorfuStores.get(SOURCE_INDEX), srcFederatedTables);
+        openGroupATable(numTables, sourceCorfuStores.get(SOURCE_INDEX), srcTablesGroupA);
+        openGroupBTable(numTables, sourceCorfuStores.get(SOURCE_INDEX), srcTablesGroupB);
+        // Sink
+        openFederatedTable(numTables, sinkCorfuStores.get(SINK1_INDEX), sinkFederatedTables);
+        openGroupATable(numTables, sinkCorfuStores.get(SINK2_INDEX), sinkTablesGroupA);
+        openGroupBTable(numTables, sinkCorfuStores.get(SINK3_INDEX), sinkTablesGroupB);
+
+        // Write data to Source side tables
+        writeDataOnSource(0, NUM_WRITES);
+
+        // Start log replication for all sessions
+        startReplicationServers();
+
+        // Verify all the sessions' snapshot sync completed
+        verifySessionInLogEntrySyncState(SINK1_INDEX, LogReplicationConfigManager.getDefaultSubscriber());
+        // TODO: should be replaced by real client name after Sink session creation workflow is introduced
+        verifySessionInLogEntrySyncState(SINK2_INDEX, LogReplicationConfigManager.getDefaultLogicalGroupSubscriber());
+        verifySessionInLogEntrySyncState(SINK3_INDEX, LogReplicationConfigManager.getDefaultLogicalGroupSubscriber());
+
+        List<Table<StringKey, SampleGroupMsgA, Message>> sinkTablesGroupAOnSink3 = new ArrayList<>();
+        openGroupATable(numTables, sinkCorfuStores.get(SINK3_INDEX), sinkTablesGroupAOnSink3);
+        List<Table<StringKey, SampleGroupMsgB, Message>> sinkTablesGroupBOnSink2 = new ArrayList<>();
+        openGroupBTable(numTables, sinkCorfuStores.get(SINK2_INDEX), sinkTablesGroupBOnSink2);
+
+        // Verify tables' content on Sink side
+        verifyFederatedTableData(sinkCorfuStores.get(SINK1_INDEX), NUM_WRITES, sinkFederatedTables);
+        verifyGroupATableData(sinkCorfuStores.get(SINK2_INDEX), NUM_WRITES, sinkTablesGroupA);
+        verifyGroupATableData(sinkCorfuStores.get(SINK3_INDEX), NUM_WRITES, sinkTablesGroupAOnSink3);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK2_INDEX), NUM_WRITES, sinkTablesGroupBOnSink2);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK3_INDEX), NUM_WRITES, sinkTablesGroupB);
+
+        // Remove GROUP_A and GROUP_B from Sink3
+        logicalGroupClient.removeDestinations(GROUP_A,
+                Collections.singletonList(DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
+        logicalGroupClient.removeDestinations(GROUP_B,
+                Collections.singletonList(DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
+
+        int targetWrites = 2 * NUM_WRITES;
+        for (int i = NUM_WRITES; i < targetWrites; i++) {
+            StringKey key = StringKey.newBuilder().setKey(String.valueOf(i)).build();
+            SampleGroupMsgA groupATablePayload = SampleGroupMsgA.newBuilder().setPayload(String.valueOf(i)).build();
+            SampleGroupMsgB groupBTablePayload = SampleGroupMsgB.newBuilder().setPayload(String.valueOf(i)).build();
+
+            try (TxnContext txn = sourceCorfuStores.get(SOURCE_INDEX).txn(NAMESPACE)) {
+                for (Table<StringKey, SampleGroupMsgA, Message> table : srcTablesGroupA) {
+                    txn.putRecord(table, key, groupATablePayload, null);
+                }
+                for (Table<StringKey, SampleGroupMsgB, Message> table : srcTablesGroupB) {
+                    txn.putRecord(table, key, groupBTablePayload, null);
+                }
+                txn.commit();
+            }
+        }
+
+        verifyGroupATableData(sinkCorfuStores.get(SINK2_INDEX), targetWrites, sinkTablesGroupA);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK2_INDEX), targetWrites, sinkTablesGroupBOnSink2);
+        // After removing group from Sink, the tables for those groups should be cleared from related Sinks.
+        verifyGroupATableData(sinkCorfuStores.get(SINK3_INDEX), 0, sinkTablesGroupAOnSink3);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK3_INDEX), 0, sinkTablesGroupB);
+
+        // Check Sink clusters snapshot plugin listeners received expected updates.
+        latchSink1.await();
+        latchSink2.await();
+        latchSink3.await();
+    }
+
+    /**
+     * This test verifies that group deletion from client metadata table could be properly captured from log entry
+     * readers and trigger a snapshot sync.
+     * (1) Bring up the 1-Source & 3-Sink topology
+     * (2) Register the logical group client and setup initial group destination mapping as
+     *     {GROUP_A: [SINK2, SINK3]; GROUP_B: [SINK2, SINK3]}
+     * (3) Open tables for replication on both Source and Sink side, and write data to Source side
+     * (4) Start replication servers and verify snapshot sync succeeded.
+     * (5) Remove all Sinks from groupA, so now the mapping is {GROUP_A: []; GROUP_B: [SINK2, SINK3]}
+     * (6) Verify snapshot sync with Sink2 and Sink3 is triggered because of group removal
+     * (8) Write more data to GROUP_A and GROUP_B tables on Source side, and verify new data is only replicated to
+     *     GROUP_B tables on Sink side, and GROUP_A tables are cleared from both Sink2 and Sink3
+     */
+    @Test
+    public void testGroupDeletion() throws Exception {
+        // Register client and add group destinations
+        CorfuRuntime clientRuntime = getClientRuntime();
+        LogReplicationLogicalGroupClient logicalGroupClient =
+                new LogReplicationLogicalGroupClient(clientRuntime, SAMPLE_CLIENT_NAME);
+        logicalGroupClient.setDestinations(GROUP_A,
+                Arrays.asList(
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK2_INDEX),
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
+        logicalGroupClient.setDestinations(GROUP_B,
+                Arrays.asList(
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK2_INDEX),
+                        DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
+
+        // Subscribe snapshot plugin listener on each Sink cluster, Sink1 will only have 1 snapshot sync while Sink2
+        // and Sink3 will have 2 snapshot sync for each, where 1 snapshot sync will update the listener twice.
+        CountDownLatch latchSink1 = new CountDownLatch(PLUGIN_UPDATES_PER_SNAPSHOT_SYNC);
+        SnapshotSyncPluginListener snapshotSyncPluginListenerSink1 = new SnapshotSyncPluginListener(latchSink1);
+        subscribeToSnapshotSyncPluginTable(sinkCorfuStores.get(SINK1_INDEX), snapshotSyncPluginListenerSink1);
+
+        CountDownLatch latchSink2 = new CountDownLatch(2 * PLUGIN_UPDATES_PER_SNAPSHOT_SYNC);
+        SnapshotSyncPluginListener snapshotSyncPluginListenerSink2 = new SnapshotSyncPluginListener(latchSink2);
+        subscribeToSnapshotSyncPluginTable(sinkCorfuStores.get(SINK2_INDEX), snapshotSyncPluginListenerSink2);
+
+        CountDownLatch latchSink3 = new CountDownLatch(2 * PLUGIN_UPDATES_PER_SNAPSHOT_SYNC);
+        SnapshotSyncPluginListener snapshotSyncPluginListenerSink3 = new SnapshotSyncPluginListener(latchSink3);
+        subscribeToSnapshotSyncPluginTable(sinkCorfuStores.get(SINK3_INDEX), snapshotSyncPluginListenerSink3);
+
+        // Open tables for replication on both side
+        int numTables = 3;
+        // Source
+        openFederatedTable(numTables, sourceCorfuStores.get(SOURCE_INDEX), srcFederatedTables);
+        openGroupATable(numTables, sourceCorfuStores.get(SOURCE_INDEX), srcTablesGroupA);
+        openGroupBTable(numTables, sourceCorfuStores.get(SOURCE_INDEX), srcTablesGroupB);
+        // Sink
+        openFederatedTable(numTables, sinkCorfuStores.get(SINK1_INDEX), sinkFederatedTables);
+        openGroupATable(numTables, sinkCorfuStores.get(SINK2_INDEX), sinkTablesGroupA);
+        openGroupBTable(numTables, sinkCorfuStores.get(SINK3_INDEX), sinkTablesGroupB);
+
+        // Write data to Source side tables
+        writeDataOnSource(0, NUM_WRITES);
+
+        // Start log replication for all sessions
+        startReplicationServers();
+
+        // Verify all the sessions' snapshot sync completed
+        verifySessionInLogEntrySyncState(SINK1_INDEX, LogReplicationConfigManager.getDefaultSubscriber());
+        // TODO: should be replaced by real client name after Sink session creation workflow is introduced
+        verifySessionInLogEntrySyncState(SINK2_INDEX, LogReplicationConfigManager.getDefaultLogicalGroupSubscriber());
+        verifySessionInLogEntrySyncState(SINK3_INDEX, LogReplicationConfigManager.getDefaultLogicalGroupSubscriber());
+
+        List<Table<StringKey, SampleGroupMsgA, Message>> sinkTablesGroupAOnSink3 = new ArrayList<>();
+        openGroupATable(numTables, sinkCorfuStores.get(SINK3_INDEX), sinkTablesGroupAOnSink3);
+        List<Table<StringKey, SampleGroupMsgB, Message>> sinkTablesGroupBOnSink2 = new ArrayList<>();
+        openGroupBTable(numTables, sinkCorfuStores.get(SINK2_INDEX), sinkTablesGroupBOnSink2);
+
+        // Verify tables' content on Sink side
+        verifyFederatedTableData(sinkCorfuStores.get(SINK1_INDEX), NUM_WRITES, sinkFederatedTables);
+        verifyGroupATableData(sinkCorfuStores.get(SINK2_INDEX), NUM_WRITES, sinkTablesGroupA);
+        verifyGroupATableData(sinkCorfuStores.get(SINK3_INDEX), NUM_WRITES, sinkTablesGroupAOnSink3);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK2_INDEX), NUM_WRITES, sinkTablesGroupBOnSink2);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK3_INDEX), NUM_WRITES, sinkTablesGroupB);
+
+        // Remove GROUP_A from Sink3 and GROUP_B from Sink2
+        logicalGroupClient.removeDestinations(GROUP_A,
+                Collections.singletonList(DefaultClusterConfig.getSinkClusterIds().get(SINK2_INDEX)));
+        logicalGroupClient.removeDestinations(GROUP_A,
+                Collections.singletonList(DefaultClusterConfig.getSinkClusterIds().get(SINK3_INDEX)));
+
+        assertThat(logicalGroupClient.getDestinations(GROUP_A)).isEqualTo(null);
+
+        int targetWrites = 2 * NUM_WRITES;
+        for (int i = NUM_WRITES; i < targetWrites; i++) {
+            StringKey key = StringKey.newBuilder().setKey(String.valueOf(i)).build();
+            SampleGroupMsgA groupATablePayload = SampleGroupMsgA.newBuilder().setPayload(String.valueOf(i)).build();
+            SampleGroupMsgB groupBTablePayload = SampleGroupMsgB.newBuilder().setPayload(String.valueOf(i)).build();
+
+            try (TxnContext txn = sourceCorfuStores.get(SOURCE_INDEX).txn(NAMESPACE)) {
+                for (Table<StringKey, SampleGroupMsgA, Message> table : srcTablesGroupA) {
+                    txn.putRecord(table, key, groupATablePayload, null);
+                }
+                for (Table<StringKey, SampleGroupMsgB, Message> table : srcTablesGroupB) {
+                    txn.putRecord(table, key, groupBTablePayload, null);
+                }
+                txn.commit();
+            }
+        }
+
         verifyGroupBTableData(sinkCorfuStores.get(SINK3_INDEX), targetWrites, sinkTablesGroupB);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK2_INDEX), targetWrites, sinkTablesGroupBOnSink2);
+        // After removing group from Sink, the tables for those groups should be cleared from related Sinks.
+        verifyGroupATableData(sinkCorfuStores.get(SINK2_INDEX), 0, sinkTablesGroupA);
+        verifyGroupATableData(sinkCorfuStores.get(SINK3_INDEX), 0, sinkTablesGroupAOnSink3);
+
+        // Check Sink clusters snapshot plugin listeners received expected updates.
+        latchSink1.await();
+        latchSink2.await();
+        latchSink3.await();
     }
 
     /**
@@ -742,9 +967,6 @@ public class LogReplicationLogicalGroupIT extends CorfuReplicationMultiSourceSin
         logicalGroupClient.removeDestinations(GROUP_B,
                 Collections.singletonList(DefaultClusterConfig.getSinkClusterIds().get(SINK2_INDEX)));
 
-        // Pause the test thread for a while to let the destination removal and new config take effect.
-        TimeUnit.SECONDS.sleep(SLEEP_INTERVAL);
-
         int targetWrites = 2 * NUM_WRITES;
         for (int i = NUM_WRITES; i < targetWrites; i++) {
             StringKey key = StringKey.newBuilder().setKey(String.valueOf(i)).build();
@@ -764,8 +986,9 @@ public class LogReplicationLogicalGroupIT extends CorfuReplicationMultiSourceSin
 
         verifyGroupATableData(sinkCorfuStores.get(SINK2_INDEX), targetWrites, sinkTablesGroupA);
         verifyGroupBTableData(sinkCorfuStores.get(SINK3_INDEX), targetWrites, sinkTablesGroupB);
-        verifyGroupATableData(sinkCorfuStores.get(SINK3_INDEX), NUM_WRITES, sinkTablesGroupAOnSink3);
-        verifyGroupBTableData(sinkCorfuStores.get(SINK2_INDEX), NUM_WRITES, sinkTablesGroupBOnSink2);
+        // After removing group from Sink, the tables for those groups should be cleared from related Sinks.
+        verifyGroupATableData(sinkCorfuStores.get(SINK3_INDEX), 0, sinkTablesGroupAOnSink3);
+        verifyGroupBTableData(sinkCorfuStores.get(SINK2_INDEX), 0, sinkTablesGroupBOnSink2);
 
         // Add GROUP_A and GROUP_B back and verify new data is replicated to Sink2 and Sink3
         logicalGroupClient.addDestinations(GROUP_A,

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -230,7 +230,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public static void readSnapshotMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt, boolean blockOnSem) {
         int cnt = 0;
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SOURCE_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()));
+        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
                 Mockito.mock(LogReplicationPluginConfig.class));
 
@@ -264,7 +264,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public void writeSnapshotMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SINK_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()));
+        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
 
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
                 getReplicationContext(configManager, 0, "test", true));
@@ -303,7 +303,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
                                         boolean blockOnce) throws TrimmedException {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SOURCE_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()));
+        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
 
         StreamsLogEntryReader reader = new StreamsLogEntryReader(rt, getDefaultSession(),
                 new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
@@ -338,7 +338,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     private void writeLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SINK_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()));
+        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
 
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
                 getReplicationContext(configManager, 0, "test", true));


### PR DESCRIPTION
## Overview

Description:

Stream listener based logical group config updating could have race condition with the threads sending log entry data, which could break the happens-before relationship of the APIs exposed by LR logical group client.

typical example:
client.remove(group1, sink1)
client.writeData(group1) <- Current implementation could still replicate some data from this write. Although it could achieve eventual consistency by clearing the table at Sink side in next forced snapshot sync, the intermediate state is still undesired.

This PR will fix that issue and stop replicating any log entry data after the removal.


Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
