### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>
-        <guava.version>28.0-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <mockito.version>1.10.19</mockito.version>
         <assertj.version>3.19.0</assertj.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 28.0-jre
- [CVE-2020-8908](https://www.oscs1024.com/hd/CVE-2020-8908)


### What did I do？
Upgrade com.google.guava:guava from 28.0-jre to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS