### PR TITLE
Create new runtime for CompactorService

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
@@ -25,11 +25,13 @@ public class CompactorBaseConfig {
     public static final int DEFAULT_CP_MAX_WRITE_SIZE = 25 << 20;
     public static final int SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT = 100;  // Corfu default is 20
     public static final int CORFU_LOG_CHECKPOINT_ERROR = 3;
+    private static final int SYSTEM_EXIT_ERROR_CODE = -3;
     public static final String USAGE = "Usage: compactor-runner";
     public static final String OPTIONS = "Options:\n";
 
     private final Runnable defaultSystemDownHandler = () -> {
-        throw new UnreachableClusterException("Cluster is unavailable");
+        log.error("Exiting since the SystemDownHandler is invoked after " + SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT + " retries.");
+        System.exit(SYSTEM_EXIT_ERROR_CODE);
     };
 
     private Map<String, Object> opts;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -63,7 +63,7 @@ public class CompactorLeaderServices {
         this.nodeEndpoint = nodeEndpoint;
         this.corfuStore = corfuStore;
         this.livenessValidator = livenessValidator;
-        this.trimLog = new TrimLog(corfuRuntime, corfuStore);
+        this.trimLog = new TrimLog();
         this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
@@ -268,7 +268,7 @@ public class CompactorLeaderServices {
                     txn.delete(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM);
                     txn.commit();
                     log.info("Invoking trimlog() due to InstantTrigger with trim found");
-                    trimLog.invokePrefixTrim();
+                    trimLog.invokePrefixTrim(corfuRuntime, corfuStore);
                     return;
                 }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -232,7 +232,7 @@ public class CompactorService implements ManagementService {
         } catch (Exception ex) {
           log.error("Exception in runOrchestrator(): ", ex);
         } catch (Throwable t) {
-            log.error("Encountered unexpected exception in runOrchestrator(): ", t);
+            log.error("Unexpected throwable encountered in runOrchestrator(): ", t);
             getCorfuRuntime().getParameters().getSystemDownHandler().run();
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -155,7 +155,7 @@ public class ManagementAgent {
             HealthMonitor.reportIssue(Issue.createInitIssue(Component.COMPACTOR));
         }
 
-        this.compactorService = new CompactorService(serverContext, runtimeSingletonResource,
+        this.compactorService = new CompactorService(serverContext, TRIGGER_INTERVAL,
                 new InvokeCheckpointingJvm(serverContext), new DynamicTriggerPolicy());
 
         // Creating the initialization task thread.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
@@ -16,17 +16,13 @@ import java.util.concurrent.TimeUnit;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 public class TrimLog {
-    private final CorfuRuntime corfuRuntime;
-    private final CorfuStore corfuStore;
     private final Logger log;
 
-    TrimLog(CorfuRuntime corfuRuntime, CorfuStore corfuStore) {
-        this.corfuStore = corfuStore;
-        this.corfuRuntime = corfuRuntime;
+    TrimLog() {
         this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
-    private Optional<Long> getTrimAddress() {
+    private Optional<Long> getTrimAddress(CorfuStore corfuStore) {
         Optional<Long> trimAddress = Optional.empty();
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
@@ -49,8 +45,8 @@ public class TrimLog {
     /**
      * Perform log-trimming on CorfuDB
      */
-    public void invokePrefixTrim() {
-        Optional<Long> trimAddress = getTrimAddress();
+    public void invokePrefixTrim(CorfuRuntime corfuRuntime, CorfuStore corfuStore) {
+        Optional<Long> trimAddress = getTrimAddress(corfuStore);
         if (!trimAddress.isPresent()) {
             return;
         }

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointLivenessUpdater.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointLivenessUpdater.java
@@ -57,7 +57,7 @@ public class CheckpointLivenessUpdater implements LivenessUpdater {
     @Override
     public void start() {
         executorService.scheduleWithFixedDelay(
-                () -> LambdaUtils.runSansThrow(this::updateHeartbeat),
+                this::updateHeartbeat,
                 UPDATE_INTERVAL.toMillis() / 2,
                 UPDATE_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
     }
@@ -86,6 +86,8 @@ public class CheckpointLivenessUpdater implements LivenessUpdater {
             }
         } catch (Exception e) {
             log.warn("Unable to update liveness for table: {} due to exception: {}", table, e.getStackTrace());
+        } catch (Throwable t) {
+            corfuStore.getRuntime().getParameters().getSystemDownHandler().run();
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ChannelOption;
@@ -1139,7 +1140,8 @@ public class CorfuRuntime {
      * @param layout The layout to check.
      * @throws WrongClusterException If the layout belongs to the wrong cluster.
      */
-    private void checkClusterId(@Nonnull Layout layout) {
+    @VisibleForTesting
+    public void checkClusterId(@Nonnull Layout layout) {
         // We haven't adopted a clusterId yet.
         if (clusterId == null) {
             clusterId = layout.getClusterId();

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -98,7 +98,7 @@ public class CompactorServiceTest extends AbstractViewTest {
      * @return The generated layout.
      */
     private Layout setup3NodeCluster(Double logSizeLimitPercentage) {
-        sc0 = new ServerContextBuilder()
+        sc0 = spy(new ServerContextBuilder()
                 .setSingle(false)
                 .setServerRouter(new TestServerRouter(SERVERS.PORT_0))
                 .setPort(SERVERS.PORT_0)
@@ -106,8 +106,8 @@ public class CompactorServiceTest extends AbstractViewTest {
                 .setCacheSizeHeapRatio(CACHE_SIZE_HEAP_RATIO)
                 .setLogPath(com.google.common.io.Files.createTempDir().getAbsolutePath())
                 .setLogSizeLimitPercentage(Double.toString(logSizeLimitPercentage))
-                .build();
-        sc1 = new ServerContextBuilder()
+                .build());
+        sc1 = spy(new ServerContextBuilder()
                 .setSingle(false)
                 .setServerRouter(new TestServerRouter(SERVERS.PORT_1))
                 .setPort(SERVERS.PORT_1)
@@ -115,8 +115,8 @@ public class CompactorServiceTest extends AbstractViewTest {
                 .setCacheSizeHeapRatio(CACHE_SIZE_HEAP_RATIO)
                 .setLogPath(com.google.common.io.Files.createTempDir().getAbsolutePath())
                 .setLogSizeLimitPercentage(Double.toString(logSizeLimitPercentage))
-                .build();
-        sc2 = new ServerContextBuilder()
+                .build());
+        sc2 = spy(new ServerContextBuilder()
                 .setSingle(false)
                 .setServerRouter(new TestServerRouter(SERVERS.PORT_2))
                 .setPort(SERVERS.PORT_2)
@@ -124,7 +124,7 @@ public class CompactorServiceTest extends AbstractViewTest {
                 .setCacheSizeHeapRatio(CACHE_SIZE_HEAP_RATIO)
                 .setLogPath(com.google.common.io.Files.createTempDir().getAbsolutePath())
                 .setLogSizeLimitPercentage(Double.toString(logSizeLimitPercentage))
-                .build();
+                .build());
 
         addServer(SERVERS.PORT_0, sc0);
         addServer(SERVERS.PORT_1, sc1);
@@ -183,6 +183,11 @@ public class CompactorServiceTest extends AbstractViewTest {
         } catch (Exception e) {
             log.warn("Caught exception while opening MetadataTables: ", e);
         }
+
+        doReturn(runtime0.getParameters()).when(sc0).getManagementRuntimeParameters();
+        doReturn(runtime1.getParameters()).when(sc1).getManagementRuntimeParameters();
+        doReturn(runtime2.getParameters()).when(sc2).getManagementRuntimeParameters();
+
         distributedCheckpointer0 = new ServerTriggeredCheckpointer(CheckpointerBuilder.builder()
                 .corfuRuntime(runtime0).cpRuntime(Optional.of(cpRuntime0)).persistedCacheRoot(Optional.empty())
                 .isClient(false).build(), corfuStore, compactorMetadataTables);

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -21,7 +21,6 @@ import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.Layout;
-import org.corfudb.util.concurrent.SingletonResource;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -41,9 +40,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 @Slf4j
 public class CompactorServiceTest extends AbstractViewTest {
@@ -88,7 +89,6 @@ public class CompactorServiceTest extends AbstractViewTest {
     private final InvokeCheckpointingJvm mockInvokeJvm0 = mock(InvokeCheckpointingJvm.class);
     private final InvokeCheckpointingJvm mockInvokeJvm1 = mock(InvokeCheckpointingJvm.class);
     private final InvokeCheckpointingJvm mockInvokeJvm2 = mock(InvokeCheckpointingJvm.class);
-
     private final DynamicTriggerPolicy dynamicTriggerPolicy0 = mock(DynamicTriggerPolicy.class);
 
     /**
@@ -373,11 +373,11 @@ public class CompactorServiceTest extends AbstractViewTest {
     @Test
     public void singleServerTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
 
-        CompactorService compactorService1 = new CompactorService(sc0, runtimeSingletonResource1, mockInvokeJvm0, dynamicTriggerPolicy0);
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
-        compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
+        compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
             while (!pollForFinishCheckpointing()) {
@@ -396,17 +396,16 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void multipleServerTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
 
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource2 = SingletonResource.withInitial(() -> runtime1);
-
-        CompactorService compactorService1 = new CompactorService(sc0, runtimeSingletonResource1, mockInvokeJvm0, dynamicTriggerPolicy0);
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
-        compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
+        compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         DynamicTriggerPolicy dynamicTriggerPolicy1 = mock(DynamicTriggerPolicy.class);
-        CompactorService compactorService2 = new CompactorService(sc1, runtimeSingletonResource2, mockInvokeJvm1, dynamicTriggerPolicy1);
+        CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, dynamicTriggerPolicy1));
+        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
         when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
-        compactorService2.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
+        compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
             while (!pollForFinishCheckpointing()) {
@@ -425,16 +424,16 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void leaderFailureTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
 
-        SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
-        CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource0, mockInvokeJvm0, dynamicTriggerPolicy0);
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy1 = mock(DynamicTriggerPolicy.class);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime1);
-        CompactorService compactorService1 = new CompactorService(sc1, runtimeSingletonResource1, mockInvokeJvm1, dynamicTriggerPolicy1);
+        CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, dynamicTriggerPolicy1));
+        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy2 = mock(DynamicTriggerPolicy.class);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource2 = SingletonResource.withInitial(() -> runtime2);
-        CompactorService compactorService2 = new CompactorService(sc2, runtimeSingletonResource2, mockInvokeJvm2, dynamicTriggerPolicy2);
+        CompactorService compactorService2 = spy(new CompactorService(sc2, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm2, dynamicTriggerPolicy2));
+        doReturn(runtime2).when(compactorService2).getCorfuRuntime();
 
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
@@ -448,7 +447,6 @@ public class CompactorServiceTest extends AbstractViewTest {
         try {
             TimeUnit.MILLISECONDS.sleep(WAIT_TO_KILL);
             shutdownServer(SERVERS.PORT_0);
-            compactorService0.shutdown();
 
             while (!pollForFinishCheckpointing()) {
                 TimeUnit.MILLISECONDS.sleep(COMPACTOR_SERVICE_INTERVAL);
@@ -466,16 +464,16 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void nonLeaderFailureTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
 
-        SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
-        CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource0, mockInvokeJvm0, dynamicTriggerPolicy0);
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy1 = mock(DynamicTriggerPolicy.class);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime1);
-        CompactorService compactorService1 = new CompactorService(sc1, runtimeSingletonResource1, mockInvokeJvm1, dynamicTriggerPolicy1);
+        CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, dynamicTriggerPolicy1));
+        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy2 = mock(DynamicTriggerPolicy.class);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource2 = SingletonResource.withInitial(() -> runtime2);
-        CompactorService compactorService2 = new CompactorService(sc2, runtimeSingletonResource2, mockInvokeJvm2, dynamicTriggerPolicy2);
+        CompactorService compactorService2 = spy(new CompactorService(sc2, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm2, dynamicTriggerPolicy2));
+        doReturn(runtime2).when(compactorService2).getCorfuRuntime();
 
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
@@ -506,11 +504,11 @@ public class CompactorServiceTest extends AbstractViewTest {
     @Test
     public void checkpointFailureTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
 
-        CompactorService compactorService1 = new CompactorService(sc0, runtimeSingletonResource1, mockInvokeJvm0, dynamicTriggerPolicy0);
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
-        compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
+        compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable = openCompactionControlsTable();
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
@@ -553,8 +551,8 @@ public class CompactorServiceTest extends AbstractViewTest {
     @Test
     public void runOrchestratorLeaderInitManagerStatusTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
-        CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource0, mockInvokeJvm0, new DynamicTriggerPolicy());
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, new DynamicTriggerPolicy()));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
@@ -570,8 +568,8 @@ public class CompactorServiceTest extends AbstractViewTest {
     @Test
     public void runOrchestratorNonLeaderInitManagerStatusTest() {
         testSetup(logSizeLimitPercentageFull);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime1);
-        CompactorService compactorService1 = new CompactorService(sc1, runtimeSingletonResource1, mockInvokeJvm1, new DynamicTriggerPolicy());
+        CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, new DynamicTriggerPolicy()));
+        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
@@ -586,8 +584,8 @@ public class CompactorServiceTest extends AbstractViewTest {
     @Test
     public void quotaExceededTest() throws Exception {
         testSetup(logSizeLimitPercentageLow);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
-        CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource1, mockInvokeJvm0, dynamicTriggerPolicy0);
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
@@ -612,12 +610,12 @@ public class CompactorServiceTest extends AbstractViewTest {
     @Test
     public void instantTriggerUpgradeTest() {
         testSetup(logSizeLimitPercentageFull);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
-        CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource0, mockInvokeJvm0, new DynamicTriggerPolicy());
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, new DynamicTriggerPolicy()));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime1);
-        CompactorService compactorService1 = new CompactorService(sc1, runtimeSingletonResource1, mockInvokeJvm1, new DynamicTriggerPolicy());
+        CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, new DynamicTriggerPolicy()));
+        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable = openCompactionControlsTable();
@@ -643,14 +641,14 @@ public class CompactorServiceTest extends AbstractViewTest {
         assert verifyCheckpointStatusTable(StatusType.COMPLETED, 0);
         assert trimSequence > 0;
         assert verifyCompactionControlsTable(CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM) == 0;
-        assert runtimeSingletonResource0.get().getAddressSpaceView().getTrimMark().getSequence() == trimSequence + 1;
+        assert runtime0.getAddressSpaceView().getTrimMark().getSequence() == trimSequence + 1;
     }
 
     @Test
     public void freezeAndDisableTokenTest() {
         testSetup(logSizeLimitPercentageFull);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
-        CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource0, mockInvokeJvm0, new DynamicTriggerPolicy());
+        CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, new DynamicTriggerPolicy()));
+        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         Table<StringKey, RpcCommon.TokenMsg, Message> compactionControlsTable = openCompactionControlsTable();
@@ -693,9 +691,9 @@ public class CompactorServiceTest extends AbstractViewTest {
     @Test
     public void disableTokenAfterStartedTest() {
         testSetup(logSizeLimitPercentageFull);
-        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
 
-        CompactorService compactorService1 = new CompactorService(sc0, runtimeSingletonResource1, mockInvokeJvm0, dynamicTriggerPolicy0);
+        CompactorService compactorService1 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
         doNothing().when(mockInvokeJvm0).invokeCheckpointing();
         Table<StringKey, CheckpointingStatus, Message> compactionManagerTable = openCompactionManagerTable(corfuStore);
         Table<TableName, CheckpointingStatus, Message> checkpointStatusTable = openCheckpointStatusTable();

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -375,7 +375,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
@@ -397,13 +397,13 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         DynamicTriggerPolicy dynamicTriggerPolicy1 = mock(DynamicTriggerPolicy.class);
         CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, dynamicTriggerPolicy1));
-        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
+        doReturn(runtime1).when(compactorService1).getNewCorfuRuntime();
         when(dynamicTriggerPolicy1.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
@@ -425,15 +425,15 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy1 = mock(DynamicTriggerPolicy.class);
         CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, dynamicTriggerPolicy1));
-        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
+        doReturn(runtime1).when(compactorService1).getNewCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy2 = mock(DynamicTriggerPolicy.class);
         CompactorService compactorService2 = spy(new CompactorService(sc2, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm2, dynamicTriggerPolicy2));
-        doReturn(runtime2).when(compactorService2).getCorfuRuntime();
+        doReturn(runtime2).when(compactorService2).getNewCorfuRuntime();
 
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
@@ -465,15 +465,15 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy1 = mock(DynamicTriggerPolicy.class);
         CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, dynamicTriggerPolicy1));
-        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
+        doReturn(runtime1).when(compactorService1).getNewCorfuRuntime();
 
         DynamicTriggerPolicy dynamicTriggerPolicy2 = mock(DynamicTriggerPolicy.class);
         CompactorService compactorService2 = spy(new CompactorService(sc2, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm2, dynamicTriggerPolicy2));
-        doReturn(runtime2).when(compactorService2).getCorfuRuntime();
+        doReturn(runtime2).when(compactorService2).getNewCorfuRuntime();
 
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
@@ -506,7 +506,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
@@ -552,7 +552,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void runOrchestratorLeaderInitManagerStatusTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, new DynamicTriggerPolicy()));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
@@ -569,7 +569,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void runOrchestratorNonLeaderInitManagerStatusTest() {
         testSetup(logSizeLimitPercentageFull);
         CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, new DynamicTriggerPolicy()));
-        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
+        doReturn(runtime1).when(compactorService1).getNewCorfuRuntime();
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         try {
@@ -585,7 +585,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void quotaExceededTest() throws Exception {
         testSetup(logSizeLimitPercentageLow);
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
@@ -611,11 +611,11 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void instantTriggerUpgradeTest() {
         testSetup(logSizeLimitPercentageFull);
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, new DynamicTriggerPolicy()));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         CompactorService compactorService1 = spy(new CompactorService(sc1, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm1, new DynamicTriggerPolicy()));
-        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
+        doReturn(runtime1).when(compactorService1).getNewCorfuRuntime();
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable = openCompactionControlsTable();
@@ -648,7 +648,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     public void freezeAndDisableTokenTest() {
         testSetup(logSizeLimitPercentageFull);
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, new DynamicTriggerPolicy()));
-        doReturn(runtime0).when(compactorService0).getCorfuRuntime();
+        doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
         Table<StringKey, RpcCommon.TokenMsg, Message> compactionControlsTable = openCompactionControlsTable();
@@ -693,7 +693,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService1 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
-        doReturn(runtime1).when(compactorService1).getCorfuRuntime();
+        doReturn(runtime1).when(compactorService1).getNewCorfuRuntime();
         doNothing().when(mockInvokeJvm0).invokeCheckpointing();
         Table<StringKey, CheckpointingStatus, Message> compactionManagerTable = openCompactionManagerTable(corfuStore);
         Table<TableName, CheckpointingStatus, Message> checkpointStatusTable = openCheckpointStatusTable();

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
@@ -25,7 +25,8 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 import static org.mockito.Matchers.any;
@@ -80,7 +81,7 @@ public class CompactorServiceUnitTest {
 
         compactorServiceSpy = spy(new CompactorService(serverContext,
                 Duration.ofSeconds(SCHEDULER_INTERVAL), invokeCheckpointingJvm, dynamicTriggerPolicy));
-        doReturn(corfuRuntime).when(compactorServiceSpy).getCorfuRuntime();
+        doReturn(corfuRuntime).when(compactorServiceSpy).getNewCorfuRuntime();
         doReturn(leaderServices).when(compactorServiceSpy).getCompactorLeaderServices();
         doReturn(corfuStore).when(compactorServiceSpy).getCorfuStore();
         //Compaction enabled

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
@@ -64,14 +64,16 @@ public class CompactorServiceUnitTest {
     @Before
     public void setup() throws Exception {
 
-        Map<String, Object> map = new HashMap<>();
-        map.put("<port>", "port");
-        when(serverContext.getLocalEndpoint()).thenReturn(NODE_ENDPOINT);
-        when(serverContext.getServerConfig()).thenReturn(map);
-
         CorfuRuntime.CorfuRuntimeParameters mockParams = mock(CorfuRuntime.CorfuRuntimeParameters.class);
         when(corfuRuntime.getParameters()).thenReturn(mockParams);
         when(mockParams.getCheckpointTriggerFreqMillis()).thenReturn(1L);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("<port>", "port");
+        when(serverContext.getManagementRuntimeParameters()).thenReturn(mockParams);
+        when(serverContext.getLocalEndpoint()).thenReturn(NODE_ENDPOINT);
+        when(serverContext.getServerConfig()).thenReturn(map);
+
 
         when(corfuStore.txn(CORFU_SYSTEM_NAMESPACE)).thenReturn(txn);
         when(txn.getRecord(CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME, CompactorMetadataTables.COMPACTION_MANAGER_KEY)).thenReturn(corfuStoreCompactionManagerEntry);

--- a/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
@@ -1,0 +1,102 @@
+package org.corfudb.integration;
+
+import org.corfudb.infrastructure.*;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.WrongClusterException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.view.AddressSpaceView;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+public class CompactorServiceIT extends AbstractIT {
+    private static String corfuSingleNodeHost;
+    private static int corfuStringNodePort;
+    private static String singleNodeEndpoint ;
+    private CompactorService compactorServiceSpy;
+    private Process corfuServer;
+    private final InvokeCheckpointing invokeCheckpointing = mock(InvokeCheckpointing.class);
+
+    private static final Duration SCHEDULER_INTERVAL = Duration.ofSeconds(1);
+    private static final Duration VERIFY_TIMEOUT = Duration.ofSeconds(20);
+
+    @Before
+    public void loadProperties() {
+        corfuSingleNodeHost = PROPERTIES.getProperty("corfuSingleNodeHost");
+        corfuStringNodePort = Integer.valueOf(PROPERTIES.getProperty("corfuSingleNodePort"));
+        singleNodeEndpoint = String.format("%s:%d",
+                corfuSingleNodeHost,
+                corfuStringNodePort);
+    }
+
+    private Process runSinglePersistentServer(String host, int port, boolean disableLogUnitServerCache) throws IOException {
+        return new AbstractIT.CorfuServerRunner()
+                .setHost(host)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(host, port))
+                .setSingle(true)
+                .setDisableLogUnitServerCache(disableLogUnitServerCache)
+                .runServer();
+    }
+
+    private void createCompactorService() throws Exception {
+        // Start Corfu Server
+        corfuServer = runServer(DEFAULT_PORT, true);
+        corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
+
+        ServerContext sc = new ServerContextBuilder()
+                .setSingle(true)
+                .setAddress(corfuSingleNodeHost)
+                .setPort(DEFAULT_PORT)
+                .setLogPath(com.google.common.io.Files.createTempDir().getAbsolutePath())
+                .build();
+        compactorServiceSpy = spy(new CompactorService(sc, SCHEDULER_INTERVAL, invokeCheckpointing, new DynamicTriggerPolicy()));
+        CorfuRuntime.CorfuRuntimeParameters.CorfuRuntimeParametersBuilder paramsBuilder = CorfuRuntime.CorfuRuntimeParameters
+                .builder()
+                .systemDownHandler(() -> {
+                    compactorServiceSpy.shutdown();
+                    compactorServiceSpy.start(SCHEDULER_INTERVAL);
+                })
+                .checkpointTriggerFreqMillis(1);
+        runtime = spy(createRuntime(singleNodeEndpoint, paramsBuilder));
+        doReturn(runtime).when(compactorServiceSpy).getCorfuRuntime();
+    }
+
+    @Test
+    public void throwUnrecoverableCorfuErrorTest() throws Exception {
+        createCompactorService();
+        AddressSpaceView mockAddressSpaceView = spy(new AddressSpaceView(runtime));
+        Long address = 7L;
+        doReturn(mockAddressSpaceView).when(runtime).getAddressSpaceView();
+        doThrow(new UnrecoverableCorfuError(new InterruptedException("Thread interrupted"))).when(mockAddressSpaceView).read(eq(address), any(), any());
+        compactorServiceSpy.start(SCHEDULER_INTERVAL);
+
+        verify(compactorServiceSpy, timeout(VERIFY_TIMEOUT.toMillis()).atLeast(2)).start(any());
+        verify(compactorServiceSpy, atLeastOnce()).shutdown();
+    }
+
+    @Test
+    public void invokeSystemDownHandlerTest() throws Exception {
+        createCompactorService();
+        doCallRealMethod().doCallRealMethod().doCallRealMethod()
+                .doThrow(new WrongClusterException(UUID.randomUUID(), UUID.randomUUID())).when(runtime).checkClusterId(any());
+        compactorServiceSpy.start(SCHEDULER_INTERVAL);
+
+        verify(compactorServiceSpy, timeout(VERIFY_TIMEOUT.toMillis()).atLeast(2)).start(any());
+        verify(compactorServiceSpy, atLeastOnce()).shutdown();
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
@@ -6,6 +6,9 @@ import org.corfudb.infrastructure.InvokeCheckpointing;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStoreEntry;
+import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.WrongClusterException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.view.AddressSpaceView;
@@ -17,6 +20,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
@@ -94,7 +98,7 @@ public class CompactorServiceIT extends AbstractIT {
     public void throwUnrecoverableCorfuErrorTest() throws Exception {
         createCompactorService();
         AddressSpaceView mockAddressSpaceView = spy(new AddressSpaceView(runtime));
-        Long address = 7L;
+        final Long address = 1L;
         doReturn(mockAddressSpaceView).when(runtime).getAddressSpaceView();
         doThrow(new UnrecoverableCorfuError(new InterruptedException("Thread interrupted"))).when(mockAddressSpaceView).read(eq(address), any(), any());
         compactorServiceSpy.start(SCHEDULER_INTERVAL);
@@ -119,18 +123,22 @@ public class CompactorServiceIT extends AbstractIT {
     public void invokeConcurrentSystemDownHandlerTest() throws Exception {
         createCompactorService();
 
+        CorfuStore corfuStore = mock(CorfuStore.class);
+        TxnContext txn = mock(TxnContext.class);
+        CorfuStoreEntry record = mock(CorfuStoreEntry.class);
+        doReturn(txn).when(corfuStore).txn(any());
+        doReturn(record).when(txn).getRecord(anyString(), any());
+        doReturn(null).when(record).getPayload();
+        doReturn(corfuStore).when(compactorServiceSpy).getCorfuStore();
+
         //return runtime2 when systemHandler is invoked the 2nd time
         doReturn(runtime).doReturn(runtime2).when(compactorServiceSpy).getNewCorfuRuntime();
         compactorServiceSpy.start(SCHEDULER_INTERVAL);
 
-        verify(compactorServiceSpy, timeout(VERIFY_TIMEOUT.toMillis()).atLeastOnce()).getNewCorfuRuntime();
+        verify(compactorServiceSpy, timeout(VERIFY_TIMEOUT.toMillis()).times(1)).getNewCorfuRuntime();
 
         Runnable invokeConcurrentSystemDownHandler = () -> {
-            try {
-                runtime.getParameters().getSystemDownHandler().run();
-            } catch (Exception e) {
-                System.out.println("Caught exception from down handler: " + e);
-            }
+            runtime.getParameters().getSystemDownHandler().run();
         };
 
         Thread t1 = new Thread(invokeConcurrentSystemDownHandler);
@@ -140,8 +148,10 @@ public class CompactorServiceIT extends AbstractIT {
         t1.join();
         t2.join();
 
+        final int invokeStartTimes = 3;
+        verify(compactorServiceSpy, timeout(VERIFY_TIMEOUT.toMillis())).getCompactorLeaderServices();
         verify(compactorServiceSpy, times(2)).getSystemDownHandlerForCompactor(any());
-        verify(compactorServiceSpy, times(3)).start(any());
+        verify(compactorServiceSpy, times(invokeStartTimes)).start(any());
         verify(compactorServiceSpy, times(2)).shutdown();
     }
 }


### PR DESCRIPTION
The CompactorService needs to register a systemDownHandler where the runtime is reinitialized on an unrecoverable exception. Since the CompactorService uses the same runtime as the other services part of the management server, we need an independent runtime for CompactorService.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
