### PR TITLE
Revert "Bump netty version from 4.1.77 to 4.1.89 (#3565)"

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -2,7 +2,6 @@ package org.corfudb.infrastructure.logreplication.transport.sample;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +17,6 @@ import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.util.NodeLocator;
 
 import javax.annotation.Nonnull;
-import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -79,7 +77,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
             try {
                 NodeLocator nodeLocator = NodeLocator.parseString(node.getEndpoint());
                 log.info("GRPC create connection to node{}@{}:{}", node.getNodeId(), nodeLocator.getHost(), nodeLocator.getPort());
-                ManagedChannel channel = NettyChannelBuilder.forAddress(new InetSocketAddress(nodeLocator.getHost(), nodeLocator.getPort()))
+                ManagedChannel channel = ManagedChannelBuilder.forAddress(nodeLocator.getHost(), nodeLocator.getPort())
                         .usePlaintext()
                         .build();
                 channelMap.put(node.getNodeId(), channel);
@@ -143,7 +141,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
     private void queryLeadership(String nodeId, RequestMsg request) {
         try {
             if (blockingStubMap.containsKey(nodeId)) {
-                ResponseMsg response = blockingStubMap.get(nodeId).withDeadlineAfter(10, TimeUnit.SECONDS).queryLeadership(request);
+                ResponseMsg response = blockingStubMap.get(nodeId).withWaitForReady().queryLeadership(request);
                 receive(response);
             } else {
                 log.warn("Stub not found for remote endpoint {}. Dropping message of type {}",
@@ -159,7 +157,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
     private void requestMetadata(String nodeId, RequestMsg request) {
         try {
             if (blockingStubMap.containsKey(nodeId)) {
-                ResponseMsg response = blockingStubMap.get(nodeId).withDeadlineAfter(10, TimeUnit.SECONDS).negotiate(request);
+                ResponseMsg response = blockingStubMap.get(nodeId).withWaitForReady().negotiate(request);
                 receive(response);
             } else {
                 log.warn("Stub not found for remote endpoint {}. Dropping message of type {}",

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
-        <netty.version>4.1.89.Final</netty.version>
-        <netty.tcnative.version>2.0.56.Final</netty.tcnative.version>
+        <netty.version>4.1.77.Final</netty.version>
+        <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -24,7 +24,7 @@
         <annotations.api.version>6.0.53</annotations.api.version>
         <ehcahce.sizeOf.version>0.4.0</ehcahce.sizeOf.version>
 
-        <grpc.version>1.54.0</grpc.version>
+        <grpc.version>1.46.0</grpc.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This reverts commit 4eca583d697a09743b151d1408de8927737a63ea.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
