### PR TITLE
Increase AddNode pingRetries to 10 to avoid failing too fast

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
@@ -28,7 +28,7 @@ public class AddNode extends WorkflowRequest {
     /**
      * Number of retries to ping a base server before selecting an orchestrator.
      */
-    private final int pingRetries = 3;
+    private final int pingRetries = 10;
     /**
      * Duration between the pings.
      */


### PR DESCRIPTION
Existing pingRetries and pingInterval in AddNode give a 20-30s window. This windows is too short for a corfu server restart. Increase the pingRetries from 3 to 10 to allow ~60s timeout window.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
