### PR TITLE
Fix Flaky Tests in NettyCommTest, CompileProxyTest, DeltaStreamTest

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -394,9 +394,10 @@ public class NettyCommTest extends AbstractCorfuTest {
 
         clientRouter.getConnectionFuture().join();
         assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
-        clientRouter.stop();
+        clientRouter.close();
 
         serverData.shutdownServer();
+        serverData.serverContext.close();
     }
 
     @Test
@@ -432,9 +433,10 @@ public class NettyCommTest extends AbstractCorfuTest {
 
         clientRouter.getConnectionFuture().join();
         assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
-        clientRouter.stop();
+        clientRouter.close();
 
         serverData.shutdownServer();
+        serverData.serverContext.close();
     }
 
     /**
@@ -444,15 +446,30 @@ public class NettyCommTest extends AbstractCorfuTest {
      * @throws Exception Any Exception thrown during the test
      */
     @Test
-    public void testTlsCipherRSA() throws Exception {
+    public void testTlsCipherRsaKeyStoreRsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.name(), KeyStoreType.RSA,
                 true, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
+    }
+    @Test
+    public void testTlsCipherRsaKeyStoreEcdsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.name(), KeyStoreType.ECDSA,
                 false, null);
+    }
+
+    @Test
+    public void testTlsCipherRsaKeyStoreRsaEcdsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.name(), KeyStoreType.RSA_ECDSA,
                 true, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
+    }
+
+    @Test
+    public void testTlsCipherRsaKeyStoreRsaRsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.name(), KeyStoreType.RSA_RSA,
                 true, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
+    }
+
+    @Test
+    public void testTlsCipherRsaKeyStoreEcdsaEcdsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.name(), KeyStoreType.ECDSA_ECDSA,
                 false, null);
     }
@@ -464,12 +481,19 @@ public class NettyCommTest extends AbstractCorfuTest {
      * @throws Exception Any Exception thrown during the test
      */
     @Test
-    public void testTlsCipherEcdsa() throws Exception {
+    public void testTlsCipherEcdsaKeyStoreRsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.name(), KeyStoreType.RSA,
                 false, null);
+    }
+
+    @Test
+    public void testTlsCipherEcdsaKeyStoreEcdsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.name(), KeyStoreType.ECDSA,
                 true, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
+    }
 
+    @Test
+    public void testTlsCipherEcdsaKeyStoreRsaEcdsa() throws Exception {
         // When OpenSsl is the SSL provider
         // TLS fails sometimes, depending on the environment to find a Cipher when both RSA and ECDSA are in the trust store
         // javax.net.ssl.SSLHandshakeException: error:1417A0C1:SSL routines:tls_post_process_client_hello:no shared cipher
@@ -485,10 +509,16 @@ public class NettyCommTest extends AbstractCorfuTest {
             tlsCipherTestHelper(TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.name(), KeyStoreType.RSA_ECDSA,
                     true, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
         }
+    }
 
+    @Test
+    public void testTlsCipherEcdsaKeyStoreRsaRsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.name(), KeyStoreType.RSA_RSA,
                 false, null);
+    }
 
+    @Test
+    public void testTlsCipherEcdsaKeystoreEcdsaEcdsa() throws Exception {
         tlsCipherTestHelper(TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.name(), KeyStoreType.ECDSA_ECDSA,
                 true, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
     }
@@ -500,13 +530,19 @@ public class NettyCommTest extends AbstractCorfuTest {
      * @throws Exception Any Exception thrown during the test
      */
     @Test
-    public void testTlsCipherRsaAndEcdsa() throws Exception {
+    public void testTlsCipherRsaAndEcdsaKeyStoreRsa() throws Exception {
         tlsCipherTestHelper(ConfigParamsHelper.getTlsCiphersCSV(), KeyStoreType.RSA,
                 true, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
+    }
 
+    @Test
+    public void testTlsCipherRsaAndEcdsaKeyStoreEcdsa() throws Exception {
         tlsCipherTestHelper(ConfigParamsHelper.getTlsCiphersCSV(), KeyStoreType.ECDSA,
                 true, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
+    }
 
+    @Test
+    public void testTlsCipherRsaAndEcdsaKeyStoreRsaEcdsa() throws Exception {
         if (OpenSsl.isAvailable()) {
             // when OpenSsl is the SSL provider
             // Picks RSA Cipher TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 when both are given
@@ -518,10 +554,16 @@ public class NettyCommTest extends AbstractCorfuTest {
             tlsCipherTestHelper(ConfigParamsHelper.getTlsCiphersCSV(), KeyStoreType.RSA_ECDSA,
                     true, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
         }
+    }
 
+    @Test
+    public void testTlsCipherRsaAndEcdsaKeyStoreRsaRsa() throws Exception {
         tlsCipherTestHelper(ConfigParamsHelper.getTlsCiphersCSV(), KeyStoreType.RSA_RSA,
                 true, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
+    }
 
+    @Test
+    public void testTlsCipherRsaAndEcdsaKeyStoreEcdsaEcdsa() throws Exception {
         tlsCipherTestHelper(ConfigParamsHelper.getTlsCiphersCSV(), KeyStoreType.ECDSA_ECDSA,
                 true, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
     }
@@ -607,8 +649,9 @@ public class NettyCommTest extends AbstractCorfuTest {
         } finally {
             try {
                 if (ncr != null) {
-                    ncr.stop();
+                    ncr.close();
                 }
+                d.serverContext.close();
             } catch (Exception ex) {
                 log.warn("Error shutting down client...", ex);
             }
@@ -682,6 +725,7 @@ public class NettyCommTest extends AbstractCorfuTest {
                             nsr,
                             address,
                             Integer.parseInt((String) serverContext.getServerConfig().get("<port>")));
+            f.syncUninterruptibly();
         }
 
         void shutdownServer() {

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
@@ -144,7 +144,7 @@ public class SMRMapEntrySetTest extends AbstractTransactionsTest {
             assertThat(keys.contains(0L)).isFalse();
         });
 
-        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_SHORT);
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
 
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.AbstractCorfuTest.PARAMETERS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -309,7 +310,7 @@ public class DeltaStreamTest {
 
         producer.setName("producer");
         producer.start();
-        done.await(1, TimeUnit.SECONDS);
+        done.await(PARAMETERS.TIMEOUT_NORMAL.getSeconds(), TimeUnit.SECONDS);
 
         assertThat(consumed.size()).isEqualTo(numToProduce);
         for (int x = 0; x < numToProduce; x++) {

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -164,7 +164,7 @@ public class CompileProxyTest extends AbstractViewTest {
                     if (sharedCounter.CAS(INITIAL, t) == INITIAL)
                         casSucceeded.incrementAndGet();
         });
-        executeScheduled(concurrency, PARAMETERS.TIMEOUT_SHORT);
+        executeScheduled(concurrency, PARAMETERS.TIMEOUT_NORMAL);
 
         // check that exactly one CAS succeeded
         assertThat(sharedCounter.getValue())
@@ -311,7 +311,7 @@ public class CompileProxyTest extends AbstractViewTest {
         scheduleConcurrently(concurrency, t -> {
             map.insert(Integer.toString(t), "world");
         });
-        executeScheduled(concurrency, PARAMETERS.TIMEOUT_SHORT);
+        executeScheduled(concurrency, PARAMETERS.TIMEOUT_NORMAL);
 
         // check that map contains keys with every thread index
         for (int i = 0; i < concurrency; i++)
@@ -376,7 +376,7 @@ public class CompileProxyTest extends AbstractViewTest {
         scheduleConcurrently(concurrency, t -> {
             sharedCorfuCompound.set(sharedCorfuCompound.new Inner("A"+t, "B"+t), t);
         });
-        executeScheduled(concurrency, PARAMETERS.TIMEOUT_SHORT);
+        executeScheduled(concurrency, PARAMETERS.TIMEOUT_NORMAL);
 
         // sanity checks on the final value of sharedCorfuCompound
         assertThat(sharedCorfuCompound.getID())


### PR DESCRIPTION
## Overview

Description:

- NettyCommTest: 
  - Make `bootstrapServer()` wait for the server to be up and running before checking for ping messages.
  - Move all combinations of ciphers and keystore args into separate tests to enable threads clean up after each test.

- CompileProxyTest: 
  - Increase timeout for `executeScheduled` as it takes more than 1 second to execute the scheduled task in tests.

- DeltaStreamTest:
  - In `concurrencyTest()`, increase the timeout for the `done` latch to 10 seconds to wait for the consumer to get all the updates.
   
Why should this be merged:  Fixes flakiness in the tests.

Related issue(s) (if applicable): #<number>
Issue: https://github.com/CorfuDB/CorfuDB/issues/3589
Issue: https://github.com/CorfuDB/CorfuDB/issues/3568
Issue: https://github.com/CorfuDB/CorfuDB/issues/3622
Issue: https://github.com/CorfuDB/CorfuDB/issues/2954
Issue: https://github.com/CorfuDB/CorfuDB/issues/3623

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
