### PR TITLE
Upgrade rocksdb to 8.1.1.1

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
 
-        <rocksdb.version>7.9.2</rocksdb.version>
+        <rocksdb.version>8.1.1.1</rocksdb.version>
         <kryo.version>4.0.0</kryo.version>
         <kryo.serializers.version>0.41</kryo.serializers.version>
         <plexus.version>3.0.24</plexus.version>


### PR DESCRIPTION
Upgrade rocksdb to 8.1.1.1 to fix its zlib dependency vulnerabilities.
- https://nvd.nist.gov/vuln/detail/CVE-2018-25032
- https://nvd.nist.gov/vuln/detail/CVE-2022-37434

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
