### PR TITLE
Remove disableLogUnitServerCache arg

### DIFF
--- a/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
@@ -58,20 +58,19 @@ public class CompactorServiceIT extends AbstractIT {
         shutdownCorfuServer(corfuServer);
     }
 
-    private Process runSinglePersistentServer(String host, int port, boolean disableLogUnitServerCache) throws IOException {
+    private Process runSinglePersistentServer(String host, int port) throws IOException {
         return new AbstractIT.CorfuServerRunner()
                 .setHost(host)
                 .setPort(port)
                 .setLogPath(getCorfuServerLogPath(host, port))
                 .setSingle(true)
-                .setDisableLogUnitServerCache(disableLogUnitServerCache)
                 .runServer();
     }
 
     private void createCompactorService() throws Exception {
         // Start Corfu Server
         corfuServer = runServer(DEFAULT_PORT, true);
-        corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
+        corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
 
         ServerContext sc = spy(new ServerContextBuilder()
                 .setSingle(true)


### PR DESCRIPTION
Remove disableLogUnitServerCache arg to resolve build errors.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
