### PR TITLE
[Backport] Fix sequencer cache eviction policy (#3010)

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -2,15 +2,13 @@ package org.corfudb.infrastructure;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.TextFormat;
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.Tags;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.infrastructure.SequencerServerCache.ConflictTxStream;
 import org.corfudb.protocols.CorfuProtocolCommon;
@@ -39,6 +37,7 @@ import org.corfudb.util.Utils;
 
 import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -275,11 +274,33 @@ public class SequencerServer extends AbstractServer {
                     txInfo, txSnapshotTimestamp, trimMark);
             return new TxResolutionResponse(TokenType.TX_ABORT_SEQ_TRIM);
         }
+
+        // The maxConflictNewSequencer is modified whenever a server is elected
+        // as the 'new' sequencer, we immediately set its value to the max timestamp
+        // evicted from the cache at that time. If a txSnapshotTimestamp falls
+        // under this threshold we can report that the cause of abort is due to
+        // a NEW_SEQUENCER (not able to hold these in its cache).
+        long maxConflictNewSequencer = cache.getMaxConflictNewSequencer();
+        if (txSnapshotTimestamp.getSequence() < maxConflictNewSequencer) {
+            log.debug("ABORT[{}] ts[{}] WILDCARD New Sequencer ts=[{}]",
+                    txInfo, txSnapshotTimestamp, maxConflictNewSequencer);
+            return new TxResolutionResponse(TokenType.TX_ABORT_NEWSEQ);
+        }
+
+        // If the txSnapshotTimestamp did not fall under the new sequencer threshold
+        // but it does fall under the latest evicted timestamp we report the cause of
+        // abort as SEQUENCER_OVERFLOW
+        long maxConflictWildcard = cache.getMaxConflictWildcard();
+        if (txSnapshotTimestamp.getSequence() < maxConflictWildcard) {
+            log.debug("ABORT[{}] ts[{}] WILDCARD ts=[{}]",
+                    txInfo, txSnapshotTimestamp, maxConflictWildcard);
+            return new TxResolutionResponse(TokenType.TX_ABORT_SEQ_OVERFLOW);
+        }
+
         MicroMeterUtils.measure(txInfo.getConflictSet().size(), "sequencer.tx-resolution.num_streams");
         for (Map.Entry<UUID, Set<byte[]>> conflictStream : txInfo.getConflictSet().entrySet()) {
 
-            // if conflict-parameters are present, check for conflict based on conflict-parameter
-            // updates
+            // if conflict-parameters are present, check for conflict based on conflict-parameter updates
             Set<byte[]> conflictParamSet = conflictStream.getValue();
             //check for conflict based on streams updates
             if (conflictParamSet == null || conflictParamSet.isEmpty()) {
@@ -295,9 +316,7 @@ public class SequencerServer extends AbstractServer {
 
             // for each key pair, check for conflict; if not present, check against the wildcard
             for (byte[] conflictParam : conflictParamSet) {
-
-                Long keyAddress = cache.get(new ConflictTxStream(conflictStream.getKey(),
-                        conflictParam, Address.NON_ADDRESS));
+                Long keyAddress = cache.get(new ConflictTxStream(conflictStream.getKey(), conflictParam));
 
                 if (log.isTraceEnabled()){
                     log.trace("Commit-ck[{}] conflict-key[{}](ts={})",
@@ -313,28 +332,6 @@ public class SequencerServer extends AbstractServer {
                             conflictParam,
                             conflictStream.getKey()
                     );
-                }
-
-                // The maxConflictNewSequencer is modified whenever a server is elected
-                // as the 'new' sequencer, we immediately set its value to the max timestamp
-                // evicted from the cache at that time. If a txSnapshotTimestamp falls
-                // under this threshold we can report that the cause of abort is due to
-                // a NEW_SEQUENCER (not able to hold these in its cache).
-                long maxConflictNewSequencer = cache.getMaxConflictNewSequencer();
-                if (txSnapshotTimestamp.getSequence() < maxConflictNewSequencer) {
-                    log.debug("ABORT[{}] ts[{}] WILDCARD New Sequencer ts=[{}]",
-                            txInfo, txSnapshotTimestamp, maxConflictNewSequencer);
-                    return new TxResolutionResponse(TokenType.TX_ABORT_NEWSEQ);
-                }
-
-                // If the txSnapshotTimestamp did not fall under the new sequencer threshold
-                // but it does fall under the latest evicted timestamp we report the cause of
-                // abort as SEQUENCER_OVERFLOW
-                long maxConflictWildcard = cache.getMaxConflictWildcard();
-                if (txSnapshotTimestamp.getSequence() < maxConflictWildcard) {
-                    log.debug("ABORT[{}] ts[{}] WILDCARD ts=[{}]",
-                            txInfo, txSnapshotTimestamp, maxConflictWildcard);
-                    return new TxResolutionResponse(TokenType.TX_ABORT_SEQ_OVERFLOW);
                 }
             }
         }
@@ -400,7 +397,7 @@ public class SequencerServer extends AbstractServer {
         if (trimMark < req.getPayload().getSequencerTrimRequest().getTrimMark()) {
             // Advance the trim mark, if the new trim request has a higher trim mark.
             trimMark = req.getPayload().getSequencerTrimRequest().getTrimMark();
-            cache.invalidateUpTo(trimMark);
+            cache.evictUpTo(trimMark);
 
             // Remove trimmed addresses from each address map and set new trim mark
             for (StreamAddressSpace streamAddressSpace : streamsAddressMap.values()) {
@@ -487,7 +484,7 @@ public class SequencerServer extends AbstractServer {
         if (!bootstrapWithoutTailsUpdate) {
             globalLogTail = req.getPayload().getBootstrapSequencerRequest().getGlobalTail();
             cache = sequencerFactoryHelper.getSequencerServerCache(
-                    cache.getCacheSize(),
+                    cache.getCapacity(),
                     globalLogTail - 1
             );
 
@@ -710,15 +707,20 @@ public class SequencerServer extends AbstractServer {
 
         // update the cache of conflict parameters
         if (tokenRequest.hasTxnResolution()) {
-            tokenRequest.getTxnResolution().getWriteConflictParamsSetList()
-                    .forEach((item) -> {
-                        // insert an entry with the new timestamp using the
-                        // hash code based on the param and the stream id.
-                        item.getValueList().forEach(conflictParam ->
-                                cache.put(new ConflictTxStream(getUUID(item.getKey()),
-                                        conflictParam.toByteArray(), newTail - 1)));
-                    });
+            List<ConflictTxStream> conflictTxStreamList = tokenRequest.getTxnResolution()
+                    .getWriteConflictParamsSetList()
+                    .parallelStream()
+                    .flatMap(conflictKeysForStream -> {
+                        final UUID streamId = getUUID(conflictKeysForStream.getKey());
+                        return conflictKeysForStream.getValueList()
+                                .stream()
+                                .map(ByteString::toByteArray)
+                                .map(conflictParam -> new ConflictTxStream(streamId, conflictParam));
+                    }).collect(Collectors.toCollection(ArrayList::new));
+
+           cache.put(conflictTxStreamList, newTail - 1);
         }
+
         if (log.isTraceEnabled()) {
             log.trace("handleAllocation: token={} backpointers={}",
                     globalLogTail, backPointerMap.build());
@@ -744,7 +746,7 @@ public class SequencerServer extends AbstractServer {
      * The response contains the requested streams address maps and the global log tail.
      */
     @RequestHandler(type = PayloadCase.STREAMS_ADDRESS_REQUEST)
-    private void handleStreamsAddressRequest(@Nonnull RequestMsg req,
+    public void handleStreamsAddressRequest(@Nonnull RequestMsg req,
                                              @Nonnull ChannelHandlerContext ctx,
                                              @Nonnull IServerRouter r) {
         StreamsAddressRequestMsg streamsAddressRequest =

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
@@ -1,52 +1,61 @@
 package org.corfudb.infrastructure;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
-import org.corfudb.common.util.Memory;
 import org.corfudb.runtime.view.Address;
 
 import javax.annotation.concurrent.NotThreadSafe;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.PriorityQueue;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 /**
  * Sequencer server cache.
  * Contains transaction conflict-resolution data structures.
  * <p>
- * The cache map maps conflict keys (stream id + key) to versions (long), illustrated below:
+ * The conflictKeyMap maps conflict keys (stream id + key) to versions (long), illustrated below:
  * Conflict Key | ck1 | ck2 | ck3 | ck4
  * Version | v1 | v1 | v2 | v3
- * Consider the case where we need to insert a new conflict key (ck), but the cache is full,
- * we need to evict the oldest conflict keys. In the example above, we can't just evict ck1,
- * we need to evict all keys that map to v1, so we need to evict ck1 and ck2,
- * this eviction policy is FIFO on the version number. The simple FIFO approach in Caffein etc doesn't work here,
- * as it may evict ck1, but not ck2. Notice that we also can't evict ck3 before the keys for v1,
- * that's because it will create holes in the resolution window and can lead to incorrect resolutions.
+ * Consider the case where we need to insert a new conflict key (ck), but the cache is full.
+ * We need to evict the oldest conflict keys. In the example above, we can't just evict ck1,
+ * we need to evict all keys that map to v1, so we need to evict ck1 and ck2. This eviction
+ * policy is FIFO on the version number. Notice that we also can't evict ck3 before the keys
+ * for v1, that's because it will create holes in the resolution window and can lead to
+ * incorrect resolutions.
  * <p>
- * We use priority queue as a sliding window on the versions, where a version can map to multiple keys,
- * so we also need to maintain the beginning of the window which is the maxConflictWildcard variable.
+ * We use LinkedHashMap as a sliding window on the versions, since versions are added in strictly increasing
+ * order. We also maintain the beginning of the window which is the maxConflictWildcard variable.
  * <p>
- * SequencerServerCache achieves consistency by using single threaded cache. It's done by following code:
- * `.executor(Runnable::run)`
+ * SequencerServerCache achieves consistency by using single threaded cache.
  */
 @NotThreadSafe
 @Slf4j
 public class SequencerServerCache implements AutoCloseable {
-    /**
-     * TX conflict-resolution information:
-     * a cache of recent conflict keys and their latest global-log position.
-     */
 
-    // As the sequencer cache is used by a single thread, it is safe to use hashmap.
-    private final HashMap<ConflictTxStream, Long> conflictKeys;
-    private final PriorityQueue<ConflictTxStream> cacheEntries; //sorted according to address
+    /**
+     * A mapping between conflict keys and their latest global-log position.
+     * This map is backed by a LinkedHashMap in order to maintain insertion order.
+     * Since the timestamps inserted into the cache are strictly increasing, the sliding
+     * window can be maintained within this same data structure.
+     */
+    @VisibleForTesting
+    @Getter(AccessLevel.PUBLIC)
+    private final Map<ConflictTxStream, Long> conflictKeyMap;
+
+    /**
+     * The max number of entries that the SequencerServerCache may contain.
+     */
     @Getter
-    private final int cacheSize; // the max number of entries in SequencerServerCache
+    private final int capacity;
 
     /**
      * A "wildcard" representing the maximal update timestamp of
@@ -56,165 +65,152 @@ public class SequencerServerCache implements AutoCloseable {
     private long maxConflictWildcard;
 
     /**
+     * Since the LinkedHashMap does not provide easy access to the largest
+     * timestamp, this is maintained explicitly for precondition validation.
+     */
+    @Getter
+    private long maxTimestampInserted = Address.NON_ADDRESS;
+
+    /**
      * maxConflictNewSequencer represents the max update timestamp of all the conflict keys
      * which were evicted from the cache by the time this server is elected
      * the primary sequencer. This means that any snapshot timestamp below this
      * actual threshold would abort due to NEW_SEQUENCER cause.
      */
     @Getter
-    private long maxConflictNewSequencer;
+    private final long maxConflictNewSequencer;
+
+    private static final String CONFLICT_KEYS_COUNTER_NAME = "sequencer.conflict-keys.size";
 
     /**
-     * It is used to calculate the size of ServerCache. Each entry relates two pointers
-     * used by HashMap, one pointer in PriorityQueue.
+     * The Sequencers conflict key cache, limited by size.
+     * @param capacity                The max capacity of the cache.
+     * @param maxConflictNewSequencer The new max update timestamp of all conflict keys evicted
+     *                                from the cache by the time this server is elected as
+     *                                primary sequencer.
      */
-    private static final int ENTRY_OVERHEAD = 24;
+    public SequencerServerCache(int capacity, long maxConflictNewSequencer) {
+        Preconditions.checkArgument(capacity > 0, "sequencer cache capacity must be positive.");
 
-    //As calculating object size is expensive, used the value calculated by deepSize
-    private final int CONFLICTTXSTREAM_OBJ_SIZE = 80; //by calculated by deepSize
-
-    @Getter
-    private final String conflictKeysCounterName = "sequencer.conflict-keys.size";
-    @Getter
-    private final String windowSizeName = "sequencer.cache.window";
-    /**
-     * The cache limited by size.
-     * For a synchronous cache we are using a same-thread executor (Runnable::run)
-     * https://github.com/ben-manes/caffeine/issues/90
-     *
-     * @param cacheSize cache size
-     */
-
-    public SequencerServerCache(int cacheSize, long maxConflictNewSequencer) {
-        this.cacheSize = cacheSize;
-        maxConflictWildcard = maxConflictNewSequencer;
+        this.capacity = capacity;
+        this.maxConflictWildcard = maxConflictNewSequencer;
         this.maxConflictNewSequencer = maxConflictNewSequencer;
-        Supplier<PriorityQueue<ConflictTxStream>> queueSupplier = () ->
-                new PriorityQueue<>(cacheSize, Comparator.comparingLong(conflict ->
-                        conflict.txVersion));
-        cacheEntries = MicroMeterUtils.gauge(windowSizeName, queueSupplier.get(), PriorityQueue::size)
-                .orElseGet(queueSupplier);
-        conflictKeys = MicroMeterUtils
-                .gauge(conflictKeysCounterName, new HashMap<ConflictTxStream, Long>(), HashMap::size)
-                .orElseGet(HashMap::new);
+
+        this.conflictKeyMap = MicroMeterUtils
+                .gauge(CONFLICT_KEYS_COUNTER_NAME, new LinkedHashMap<ConflictTxStream, Long>(), LinkedHashMap::size)
+                .orElseGet(LinkedHashMap::new);
     }
 
     /**
-     * Returns the value associated with the {@code key} in this cache,
-     * or {@code null} if there is no cached value for the {@code key}.
-     *
-     * @param conflictKey conflict stream
-     * @return global address
+     * Returns the global address associated with the conflict key in this cache,
+     * or {@code Address.NON_ADDRESS} if there is no such cached address.
+     * @param conflictKey The conflict key.
+     * @return The global address associated with this hashed conflict key, if present.
      */
-    public Long get(ConflictTxStream conflictKey) {
-        return conflictKeys.getOrDefault(conflictKey, Address.NON_ADDRESS);
+    public long get(@NonNull ConflictTxStream conflictKey) {
+        return conflictKeyMap.getOrDefault(conflictKey, Address.NON_ADDRESS);
     }
 
     /**
-     * The first address in the priority queue.
+     * Returns the first (smallest) address in the cache.
+     * @return The smallest address currently in the cache.
      */
+    @VisibleForTesting
     public long firstAddress() {
-        if (cacheEntries.isEmpty()) {
+        if (conflictKeyMap.isEmpty()) {
             return Address.NOT_FOUND;
         }
-        return cacheEntries.peek().txVersion;
+
+        return conflictKeyMap.entrySet().iterator().next().getValue();
     }
-
-  /**
-   * Invalidate the records with the minAddress. It could be one or multiple records
-   *
-   * @return the number of entries has been invalidated and removed from the cache.
-   */
-  private int invalidateSmallestTxVersion() {
-    ConflictTxStream firstEntry = cacheEntries.peek();
-    if (cacheEntries.size() == 0) {
-      return 0;
-    }
-
-    int numEntries = 0;
-
-    while (firstAddress() == firstEntry.txVersion) {
-      if (log.isTraceEnabled()) {
-        log.trace(
-            "invalidateSmallestTxVersion: items evicted {} min address {}",
-            numEntries,
-            firstAddress());
-      }
-      ConflictTxStream entry = cacheEntries.poll();
-      conflictKeys.remove(entry);
-      numEntries++;
-    }
-
-    maxConflictWildcard = Math.max(maxConflictWildcard, firstEntry.txVersion);
-    return numEntries;
-  }
 
     /**
-     * Invalidate all records up to a trim mark (not included).
+     * Evict the records with the smallest address in the cache.
+     * It could be one or multiple records.
      *
-     * @param trimMark trim mark
+     * @return The number of entries that have been evicted from the cache.
      */
-    public void invalidateUpTo(long trimMark) {
-        log.debug("Invalidate sequencer cache. Trim mark: {}", trimMark);
-        int entries = 0;
-        int pqEntries = 0;
-        while (Address.isAddress(firstAddress()) && firstAddress() < trimMark) {
-            pqEntries += invalidateSmallestTxVersion();
-            entries++;
-        }
-        final int numPqEntries = pqEntries;
-        MicroMeterUtils.measure(numPqEntries, "sequencer.cache.evictions");
-        log.info("Invalidated entries {} addresses {}", pqEntries, entries);
+    private void evictSmallestTxVersion() {
+        evictUpTo(firstAddress() + 1);
     }
 
     /**
-     * The cache size as the number of entries
-     *
-     * @return cache size
+     * Evict all records up to the given address (not included).
+     * @param address The given address.
+     */
+    public void evictUpTo(long address) {
+        long numDeletedEntries = 0;
+        long smallestAddress;
+
+        Iterator<Map.Entry<ConflictTxStream, Long>> it = conflictKeyMap.entrySet().iterator();
+
+        while (it.hasNext()) {
+            smallestAddress = it.next().getValue();
+            if (smallestAddress >= address) {
+                break;
+            }
+
+            it.remove();
+            numDeletedEntries++;
+            maxConflictWildcard = Math.max(maxConflictWildcard, smallestAddress);
+        }
+
+        log.trace("evictUpTo[{}]: entries={}", address, numDeletedEntries);
+        MicroMeterUtils.measure(numDeletedEntries, "sequencer.cache.evictions");
+    }
+
+    /**
+     * Evict records from the cache until the number of records is
+     * equal to or less than the cache capacity. Eviction is performed
+     * by repeatedly evicting all of the records with the smallest address.
+     */
+    private void evict() {
+        while (conflictKeyMap.size() > capacity) {
+            evictSmallestTxVersion();
+        }
+    }
+
+    /**
+     * The cache size as the number of entries.
+     * @return The current cache size.
      */
     public int size() {
-        return conflictKeys.size();
+        return conflictKeyMap.size();
     }
 
     /**
-     * The memory space used by the entries and also the space used by
-     * priority queue and hashmap to store the pointers
-     * @return the memory space used in bytes:
+     * Put the provided conflict keys into the cache, and evict older
+     * entries as necessary.
+     * @param conflictKeys The conflict keys to add into the cache.
+     * @param txVersion    The timestamp associated with these conflict keys.
      */
-    public long byteSize() {
-        log.debug("the cache has {} entries,  the object size used {}, calculated by beepSize {}",
-                size(), CONFLICTTXSTREAM_OBJ_SIZE,
-                cacheEntries.isEmpty() ? 0 : Memory.sizeOf.deepSizeOf(cacheEntries.peek()));
-        return size() * (ENTRY_OVERHEAD + CONFLICTTXSTREAM_OBJ_SIZE);
-    }
+    public void put(@NonNull List<ConflictTxStream> conflictKeys, long txVersion) {
+        // Validate that the conflictKeys can all fit into the cache.
+        Preconditions.checkState(conflictKeys.size() <= capacity,
+                "too many conflict keys for the capacity=%s of the cache", capacity);
 
-    /*
-     * Put a value in the cache
-     *
-     * @param conflictStream conflict stream
-     */
-    public boolean put(ConflictTxStream conflictStream) {
+        // Validate that the timestamps are being inserted in strictly increasing order.
+        Preconditions.checkState(txVersion > maxTimestampInserted,
+                "txVersion=%s is not larger than the previous timestamp=%s inserted",
+                txVersion, maxTimestampInserted);
 
-        Long val = conflictKeys.getOrDefault(conflictStream, Address.NON_ADDRESS);
-        if (val > conflictStream.txVersion) {
-            log.error("For key {} the new entry address {} is smaller than the entry " +
-                            "address {} in cache. There is a sequencer regression.",
-                    conflictStream, conflictStream.txVersion, conflictKeys.get(conflictStream));
-            return false;
-        }
+        conflictKeys.forEach(conflictKey -> {
+            // This remove is required since inserting a duplicate conflict key into
+            // the LinkedHashMap does not update the insertion order.
+            this.conflictKeyMap.remove(conflictKey);
+            this.conflictKeyMap.put(conflictKey, txVersion);
+        });
 
-        cacheEntries.add(conflictStream);
-        conflictKeys.put(conflictStream, conflictStream.txVersion);
+        maxTimestampInserted = txVersion;
 
-        while (conflictKeys.size() > cacheSize) {
-            invalidateSmallestTxVersion();
-        }
-        return true;
+        // If applicable, evict entries until we are below the max cache capacity.
+        // Note: this can trigger the eviction of multiple conflict keys from multiple timestamps.
+        evict();
     }
 
     @Override
     public void close() {
-        MicroMeterUtils.removeGaugesWithNoTags(windowSizeName, conflictKeysCounterName);
+        MicroMeterUtils.removeGaugesWithNoTags(CONFLICT_KEYS_COUNTER_NAME);
     }
 
     /**
@@ -225,21 +221,18 @@ public class SequencerServerCache implements AutoCloseable {
 
         @Getter
         private final UUID streamId;
+
         @Getter
         private final byte[] conflictParam;
 
-        @EqualsAndHashCode.Exclude
-        public final long txVersion;
-
-        public ConflictTxStream(UUID streamId, byte[] conflictParam, long address) {
+        public ConflictTxStream(UUID streamId, byte[] conflictParam) {
             this.streamId = streamId;
             this.conflictParam = conflictParam;
-            txVersion = address;
         }
 
         @Override
         public String toString() {
-            return streamId.toString() + conflictParam;
+            return streamId.toString() + Arrays.toString(conflictParam);
         }
     }
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -564,7 +564,7 @@ public class SequencerServerTest {
         // (Note: SequencerTrimResponse will not have any body)
         assertTrue(response.getPayload().hasSequencerTrimResponse());
         // Verify that sequencerServerCache was invalidated up to the trimMark
-        verify(cache).invalidateUpTo(trimMark);
+        verify(cache).evictUpTo(trimMark);
 
         // Verify that the streamAddressSpace.trim() was called with trimMark argument.
         verify(streamAddressSpace).trim(trimMark);

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/SequencerServerCacheTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/SequencerServerCacheTest.java
@@ -1,10 +1,11 @@
 package org.corfudb.runtime.object.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.reflect.TypeToken;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.infrastructure.SequencerServerCache;
 import org.corfudb.infrastructure.SequencerServerCache.ConflictTxStream;
 import org.corfudb.protocols.wireprotocol.Token;
@@ -14,22 +15,89 @@ import org.corfudb.runtime.view.Address;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 /**
  * Created by maithem on 7/24/17.
  */
 @Slf4j
+@SuppressWarnings("checkstyle:magicnumber")
 public class SequencerServerCacheTest extends AbstractObjectTest {
-    @Test
-    public void testSequencerCacheTrim() {
 
+    public static final int entryPerAddress = 20;
+    public static final int iterations = 100;
+    public static final int cacheSize = iterations * entryPerAddress;
+    public static final int numRemains = 10;
+
+    private static final String TEST_STREAM = "test";
+
+    private void generateData(@NonNull Map<ConflictTxStream, Long> recordMap, @NonNull SequencerServerCache cache,
+                              long numEntries, long address, boolean verify) {
+        final UUID streamId = UUID.randomUUID();
+        generateData(recordMap, cache, streamId, 0, numEntries, address, verify);
+    }
+
+    private void generateData(@NonNull Map<ConflictTxStream, Long> recordMap, @NonNull SequencerServerCache cache,
+                              @NonNull UUID streamId, long numEntries, long address, boolean verify) {
+        generateData(recordMap, cache, streamId, 0, numEntries, address, verify);
+    }
+
+    /**
+     * Generate data with given address and verify that the entries with firstAddress are correctly evicted.
+     */
+    private void generateData(@NonNull Map<ConflictTxStream, Long> recordMap, @NonNull SequencerServerCache cache,
+                              @NonNull UUID streamId, int offSet, long numEntries, long address, boolean verify) {
+        final List<ConflictTxStream> entriesToAdd = new ArrayList<>();
+        final long initialSmallestAddress = cache.firstAddress();
+        final long initialSize = cache.size();
+
+        for (int i = offSet; i < offSet + numEntries; i++) {
+            entriesToAdd.add(new ConflictTxStream(streamId, intToByteArray(i)));
+        }
+
+        cache.put(entriesToAdd, address);
+
+        if (verify && cache.size() <= initialSize) {
+            // Verify that the smallest cache entry has been evicted.
+            log.debug("cache.firstAddress: " + cache.firstAddress() + " cacheSize: " + cache.size() + " address:" + address);
+            assertThat(initialSmallestAddress).isLessThan(cache.firstAddress());
+        }
+
+        // Verify that the entry is now present in the cache.
+        entriesToAdd.forEach(conflictKey -> {
+            assertThat(cache.get(conflictKey)).isNotEqualTo(Address.NON_ADDRESS);
+            recordMap.put(conflictKey, address);
+        });
+
+        // Verify that the cache size is not larger than the maximum capacity.
+        assertThat(cache.size()).isLessThanOrEqualTo(cache.getCapacity());
+    }
+
+    /**
+     * Verify cache contains all the data in recordMap and that each address >= firstAddress.
+     */
+    private void verifyData(@NonNull Map<ConflictTxStream, Long> recordMap, @NonNull SequencerServerCache cache) {
+        for (Map.Entry<ConflictTxStream, Long> entry : recordMap.entrySet()) {
+            final long expectedAddress = entry.getValue();
+            assertThat(expectedAddress).isGreaterThanOrEqualTo(cache.firstAddress());
+            log.debug("address " + cache.get(entry.getKey()) + " expected " + expectedAddress);
+            assertThat(cache.get(entry.getKey())).isEqualTo(expectedAddress);
+        }
+    }
+
+    /**
+     * Test that adding the same conflict key into the cache does not pollute
+     * it with stale entries.
+     */
+    @Test
+    public void testSequencerCacheSameKey() {
         getDefaultRuntime();
 
         Map<Integer, Integer> map = getDefaultRuntime()
@@ -37,20 +105,48 @@ public class SequencerServerCacheTest extends AbstractObjectTest {
                 .build()
                 .setTypeToken(new TypeToken<CorfuTable<Integer, Integer>>() {
                 })
-                .setStreamName("test")
+                .setStreamName(TEST_STREAM)
+                .open();
+
+        final int key = 0xBEEF;
+
+        for (int x = 0; x < cacheSize; x++) {
+            getRuntime().getObjectsView().TXBegin();
+            map.put(key, x);
+            getRuntime().getObjectsView().TXEnd();
+        }
+
+        SequencerServerCache cache = getSequencer(0).getCache();
+        assertThat(cache.size()).isEqualTo(1);
+    }
+
+    /**
+     * Test that the cache behaves correctly under trim operations.
+     */
+    @Test
+    public void testSequencerCacheTrim() {
+        getDefaultRuntime();
+
+        Map<Integer, Integer> map = getDefaultRuntime()
+                .getObjectsView()
+                .build()
+                .setTypeToken(new TypeToken<CorfuTable<Integer, Integer>>() {
+                })
+                .setStreamName(TEST_STREAM)
                 .open();
 
         final int numTxn = 500;
         final Token trimAddress = new Token(getDefaultRuntime().getLayoutView().getLayout().getEpoch(), 250);
+
         for (int x = 0; x < numTxn; x++) {
             getRuntime().getObjectsView().TXBegin();
             map.put(x, x);
             getRuntime().getObjectsView().TXEnd();
         }
 
-        SequencerServer sequencerServer = getSequencer(0);
-        SequencerServerCache cache = sequencerServer.getCache();
+        SequencerServerCache cache = getSequencer(0).getCache();
         assertThat(cache.size()).isEqualTo(numTxn);
+
         getDefaultRuntime().getAddressSpaceView().prefixTrim(trimAddress);
         // Since the addressSpace only sends a hint to the sequencer, its possible
         // that the method returns before the sequencer receives the trim request,
@@ -63,195 +159,228 @@ public class SequencerServerCacheTest extends AbstractObjectTest {
 
     /**
      * Check cache eviction algorithm (it must be atomic operation).
-     * Check cache invalidation
      */
     @Test
-    public void testCache() {
-        final AtomicBoolean criticalVariable = new AtomicBoolean();
-
+    public void testCacheBasicEvict() {
         SequencerServerCache cache = new SequencerServerCache(1, Address.NOT_FOUND);
-        final long firstValue = 1L;
-        final long secondValue = 2L;
         final int iterations = 10;
-        final ConflictTxStream firstKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{}, firstValue);
-        final ConflictTxStream secondKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{}, secondValue);
+        final ConflictTxStream firstKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{});
+        final ConflictTxStream secondKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{});
 
         for (int i = 0; i < iterations; i++) {
-            cache.put(firstKey);
-            cache.put(secondKey);
+            cache.put(Collections.singletonList(firstKey), 2*i);
+            cache.put(Collections.singletonList(secondKey), 2*i + 1);
 
             assertThat(cache.size()).isOne();
             assertThat(cache.get(firstKey)).isEqualTo(Address.NON_ADDRESS);
+            assertThat(cache.get(secondKey)).isEqualTo(2*i + 1);
         }
-    }
-
-    public static final int entryPerAddress = 20;
-    public static final int iterations = 100;
-    public static final int cacheSize = iterations * entryPerAddress;
-    public static final int numRemains = 10;
-
-    /**
-     * generate data with given address and verify that the entries with firstAddress are correctly evicted
-     */
-    void generateData(HashMap recordMap, SequencerServerCache cache, long address, boolean verifyFirst) {
-        final ConflictTxStream key = new ConflictTxStream(UUID.randomUUID(), new byte[]{}, address);
-        long firstAddress = cache.firstAddress();
-        long size = cache.size();
-
-        cache.put(key);
-
-        if (verifyFirst && cache.size() <= size) {
-            log.debug("cache.firstAddress: " + cache.firstAddress() + " cacheSize: " + cache.size() + " address:" + address);
-            assertThat(firstAddress).isLessThan(cache.firstAddress());
-        }
-
-        assertThat(cache.get(key)).isNotEqualTo(Address.NON_ADDRESS);
-        recordMap.put(key, address);
-        assertThat(cache.size()).isLessThanOrEqualTo(cacheSize);
-
     }
 
     /**
-     * Verify cache contains all the data in recordMap that address >= firstAddress.
-     * @param recordMap
-     * @param cache
+     * Check that an exception is thrown when trying to put a conflict key with version
+     * that is not currently in the cache, but is smaller than the smallest version present.
      */
-    void verifyData(HashMap<ConflictTxStream, Long> recordMap, SequencerServerCache cache) {
-        for (ConflictTxStream oldKey : recordMap.keySet()) {
-            long oldAddress = oldKey.txVersion;
-            if (oldAddress < cache.firstAddress()) {
-                continue;
-            }
-            ConflictTxStream key = new ConflictTxStream(oldKey.getStreamId(), oldKey.getConflictParam(), 0);
-            log.debug("address " + cache.get(key) + " expected " + oldAddress);
-            assertThat(cache.get(key)).isEqualTo(oldAddress);
-        }
-    }
-
     @Test
-    /*
-        Test the evication the firstAddress while the cache is full, by generating address out of order
+    public void testCachePutVersionSmallerThanSmallest() {
+        SequencerServerCache cache = new SequencerServerCache(1, Address.NOT_FOUND);
+        final ConflictTxStream firstKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{});
+        final ConflictTxStream secondKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{});
+
+        cache.put(Collections.singletonList(firstKey), 0);
+        cache.put(Collections.singletonList(secondKey), 1);
+
+        assertThat(cache.size()).isEqualTo(1);
+        assertThat(cache.get(secondKey)).isEqualTo(1);
+
+        assertThrows(IllegalStateException.class, () ->
+                cache.put(Collections.singletonList(firstKey), 0));
+
+        assertThat(cache.size()).isEqualTo(1);
+        assertThat(cache.get(secondKey)).isEqualTo(1);
+    }
+
+    /**
+     * Test that performing a put with a conflict key that is already present
+     * but having a smaller version throws an exception. The cache should also
+     * remain unmodified.
      */
-    public void testSequencerCacheEvict1() {
-        SequencerServerCache cache = new SequencerServerCache(cacheSize, Address.NOT_FOUND);
-        long address = 0;
-        HashMap<ConflictTxStream, Long> recordMap = new HashMap<>();
+    @Test
+    public void testSequencerPutWithRegression() {
+        final UUID streamId = UUID.randomUUID();
+        final int capacity = 10;
 
-        // put entries to the cache with duplicate address not in order
-        while (cache.size() < cacheSize) {
-            address = 0;
-            for (int i = 0; i < cacheSize / entryPerAddress; i++) {
-                generateData(recordMap, cache, address++, false);
-            }
-        }
-
-        assertThat(cache.size()).isEqualTo(cacheSize);
-        verifyData(recordMap, cache);
-
-        address = cacheSize;
-        // Each put should evict all streams with the same address
-        for (int i = 0; i < iterations; i++, address++) {
-            generateData(recordMap, cache, address, true);
+        SequencerServerCache cache = new SequencerServerCache(capacity, Address.NOT_FOUND);
+        Map<ConflictTxStream, Long> recordMap = new HashMap<>();
+        for (int i = 0; i < capacity; i++) {
+            generateData(recordMap, cache, 1, i, false);
         }
 
         verifyData(recordMap, cache);
 
-        cache.invalidateUpTo(address - 1);
-        assertThat(cache.size()).isOne();
-        cache.invalidateUpTo(address);
-        assertThat(cache.size()).isZero();
+        List<ConflictTxStream> entry = Collections.singletonList(
+                new ConflictTxStream(streamId, intToByteArray(capacity - 1)));
+
+        assertThrows(IllegalStateException.class, () -> cache.put(entry, capacity - 2));
+        verifyData(recordMap, cache);
     }
 
-    @Test
-    /*
-        Test the evication the firstAddress while the cache is full, by generating address in order
+    /**
+     * Test that performing a put on with conflict key for a version that was already cached
+     * throws an exception. The cache should also remain unmodified.
      */
-    public void testSequencerCacheEvict2() {
+    @Test
+    public void testSequencerPutSameVersion() {
+        final UUID streamId = UUID.randomUUID();
+        final int capacity = 10;
+
+        SequencerServerCache cache = new SequencerServerCache(capacity, Address.NOT_FOUND);
+        Map<ConflictTxStream, Long> recordMap = new HashMap<>();
+        for (int i = 0; i < capacity; i++) {
+            generateData(recordMap, cache, 1, i, false);
+        }
+
+        verifyData(recordMap, cache);
+
+        List<ConflictTxStream> entry = Collections.singletonList(
+                new ConflictTxStream(streamId, intToByteArray(capacity)));
+
+        assertThrows(IllegalStateException.class, () -> cache.put(entry, capacity - 1));
+        verifyData(recordMap, cache);
+    }
+
+    /**
+     * Test that performing a put on with more conflict keys than the capacity of
+     * the cache throws an exception.
+     */
+    @Test
+    public void testSequencerPutLargerThanCapacity() {
+        SequencerServerCache cache = new SequencerServerCache(1, Address.NOT_FOUND);
+        final ConflictTxStream firstKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{});
+        final ConflictTxStream secondKey = new ConflictTxStream(UUID.randomUUID(), new byte[]{});
+
+        assertThrows(IllegalStateException.class,
+                () -> cache.put(Arrays.asList(firstKey, secondKey), 0));
+    }
+
+    /**
+     * Test that cache eviction does not evict incorrect conflict keys.
+     */
+    @Test
+    public void testSequencerEvictLoss() {
+        final UUID streamId = UUID.randomUUID();
+        final int capacity = 3;
+
+        SequencerServerCache cache = new SequencerServerCache(capacity, Address.NOT_FOUND);
+        Map<ConflictTxStream, Long> recordMap = new HashMap<>();
+
+        // TX1: ck1 and ck2 for v1
+        generateData(recordMap, cache, streamId, 2, 0, false);
+
+        // TX2: ck1 for v2
+        generateData(recordMap, cache, streamId, 1, 1, false);
+
+        // TX3: ck3 and ck4 for v3 - This should trigger an eviction.
+        generateData(recordMap, cache, streamId, 2, 2, 2, false);
+
+        // Validate that (ck2, v1) was evicted.
+        ConflictTxStream evicted = recordMap.entrySet().stream()
+                .filter(entry -> entry.getValue() == 0)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList()).get(0);
+
+        assertThat(cache.get(evicted)).isEqualTo(Address.NON_ADDRESS);
+
+        recordMap = recordMap.entrySet().stream()
+                .filter(entry -> entry.getValue() > 0)
+                .collect(Collectors.<Map.Entry<ConflictTxStream, Long>, ConflictTxStream, Long>toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        verifyData(recordMap, cache);
+    }
+
+    /**
+     * Test the eviction of firstAddress while the cache is full.
+     */
+    @Test
+    public void testSequencerCacheEvict() {
         SequencerServerCache cache = new SequencerServerCache(cacheSize, Address.NOT_FOUND);
         long address = 0;
-        HashMap<ConflictTxStream, Long> recordMap = new HashMap<>();
+        Map<ConflictTxStream, Long> recordMap = new HashMap<>();
 
         // put entries to the cache, make it full, some entries have the same address
-        while (cache.size() < cacheSize) {
-            for (int j = 0; j < entryPerAddress; j++) {
-                generateData(recordMap, cache, address++, false);
-            }
+        for (int i = 0; i < iterations; i++) {
+            generateData(recordMap, cache, entryPerAddress, address++, false);
         }
 
         verifyData(recordMap, cache);
 
         assertThat(cache.size()).isEqualTo(cacheSize);
         // Each put should evict all streams with the same address
-        for (int i = 0; i < iterations; i++, address++) {
-            generateData(recordMap, cache, address, true);
+        for (int i = 0; i < iterations; i++) {
+            generateData(recordMap, cache, 1, address++, true);
         }
 
-        verifyData(recordMap, cache);
-        log.info("cacheSize {} cacheByteSize {} cacheEntriesBytes {} ", cache.size(), cache.byteSize(), cache.byteSize());
-        long entrySize = cache.byteSize() / cache.size();
+        // Update the recordMap to remove entries that are no longer expected to be there.
+        // All versions from 5 and onward should still be present, since we added a total of
+        // iteration entries into the cache. As a result, we should have evicted the first
+        // iterations / entryPerAddress versions (i.e. addresses 0 through 4).
+        recordMap = recordMap.entrySet().stream()
+                .filter(entry -> entry.getValue() >= 5)
+                .collect(Collectors.<Map.Entry<ConflictTxStream, Long>, ConflictTxStream, Long>toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        cache.invalidateUpTo(address - numRemains);
+        verifyData(recordMap, cache);
+
+        cache.evictUpTo(address - numRemains);
         assertThat(cache.size()).isEqualTo(numRemains);
 
-        // this assume that the all conflickstreams has the same size of the parameters.
-        assertThat(entrySize).isEqualTo(cache.byteSize() / cache.size());
-        log.info("cacheSize {} cacheByteSize {} cacheEntriesBytes {} ", cache.size(), cache.byteSize(), cache.byteSize());
-        cache.invalidateUpTo(address);
+        cache.evictUpTo(address);
         assertThat(cache.size()).isZero();
     }
 
-      @Test
-    /*
-        Test the value regression for the same key
+
+    /**
+     * Test the value regression for the same keys.
      */
+    @Test
     public void testSequencerRegression() {
         SequencerServerCache cache = new SequencerServerCache(cacheSize, Address.NOT_FOUND);
         long address = 0;
         HashMap<ConflictTxStream, Long> recordMap = new HashMap<>();
-        boolean result;
 
         // put entries to the cache, make it full, some entries have the same address
         while (cache.size() < cacheSize) {
-            for (int j = 0; j < entryPerAddress && cache.size() < cacheSize; j++) {
-                generateData(recordMap, cache, address++, false);
-            }
+            generateData(recordMap, cache, entryPerAddress, address++, false);
         }
 
+        verifyData(recordMap, cache);
 
-        Comparator<Map.Entry<ConflictTxStream, Long>> valueComparator = new Comparator<Map.Entry<ConflictTxStream, Long>>() {
-            @Override public int compare(Map.Entry<ConflictTxStream, Long> e1, Map.Entry<ConflictTxStream, Long> e2)
-            { long v1 = e1.getValue(); long v2 = e2.getValue(); return (int)(v1 - v2); } };
+        Comparator<Map.Entry<ConflictTxStream, Long>> valueComparator = (e1, e2) -> {
+            long v1 = e1.getValue();
+            long v2 = e2.getValue();
+            return (int)(v1 - v2);
+        };
 
-        List<Map.Entry<ConflictTxStream, Long>> listOfEntries = new ArrayList<Map.Entry<ConflictTxStream, Long>>(recordMap.entrySet());
-
+        List<Map.Entry<ConflictTxStream, Long>> listOfEntries = new ArrayList<>(recordMap.entrySet());
         Collections.sort(listOfEntries, valueComparator);
 
-        address = 0;
         for (Map.Entry<ConflictTxStream, Long> entryVal : listOfEntries) {
-            ConflictTxStream entry = entryVal.getKey();
-            if (entry.txVersion != address++) {
-                log.debug("****txV " + entry.txVersion + " address " + address);
+            if (entryVal.getValue() != address) {
+                log.debug("txV " + entryVal.getValue() + " address " + address);
             }
-            result = cache.put(new ConflictTxStream(entry.getStreamId(), entry.getConflictParam(), entry.txVersion));
-            assertThat(result).isTrue();
+
+            final List<ConflictTxStream> entry = Collections.singletonList(entryVal.getKey());
+            assertThrows(IllegalStateException.class, () -> cache.put(entry, entryVal.getValue()));
         }
 
-        int i = 0;
-        for (Map.Entry<ConflictTxStream, Long> entryVal : listOfEntries) {
-            ConflictTxStream entry = entryVal.getKey();
-            if (entry.txVersion != address++) {
-                log.debug("txV " + entry.txVersion + " address " + address);
-            }
+        verifyData(recordMap, cache);
+    }
 
-            ConflictTxStream txEle = new ConflictTxStream(entry.getStreamId(), entry.getConflictParam(), entry.txVersion - 1);
-            long txVersion = cache.get(txEle);
-            result = cache.put(txEle);
-
-            i++;
-            if (result) {
-                log.debug("\n not false  i " + i + " txV " + txVersion + " result " + result + " size " + recordMap.keySet().size() + " cacheSize " + cache.size());
-            }
-            assertThat(result).isFalse();
-        }
+    private byte[] intToByteArray(int data) {
+        byte[] result = new byte[4];
+        result[0] = (byte) ((data & 0xFF000000) >> 24);
+        result[1] = (byte) ((data & 0x00FF0000) >> 16);
+        result[2] = (byte) ((data & 0x0000FF00) >> 8);
+        result[3] = (byte) ((data & 0x000000FF));
+        return result;
     }
 }


### PR DESCRIPTION
The sequencer cache implements a sliding window to help with cache eviction, which incorrectly assumes that conflict keys are unique. This can lead to a memory leak when the same keys are written over and over again. This patch also fixes a bug where the cache evicts partial conflicts keys for a particular timestamp. This can lead to incorrect resolutions and can cause data loss.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
