### PR TITLE
Snapshot Sync Readers must wait for Data of End Marker before considering sync complete for Routing Queues Model.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
@@ -113,6 +113,20 @@ public final class DefaultClusterConfig {
         return sessions;
     }
 
+    public static List<LogReplicationSession> getRoutingQueueSessions() {
+        List<LogReplicationSession> sessions = new LinkedList<>();
+        for(String sourceClusterId : sourceClusterIds) {
+            for(String sinkClusterId : sinkClusterIds) {
+                sessions.add(LogReplicationSession.newBuilder()
+                    .setSourceClusterId(sourceClusterId)
+                    .setSinkClusterId(sinkClusterId)
+                    .setSubscriber(LogReplicationConfigManager.getDefaultRoutingQueueSubscriber())
+                    .build());
+            }
+        }
+        return sessions;
+    }
+
     public String getDefaultNodeId(String endpoint) {
         String port = getPortFromEndpointURL(endpoint);
         if (Objects.equals(port, backupLogReplicationPort)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -43,20 +43,20 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     /**
      * The max size of data for SMR entries in data message.
      */
-    private final int maxDataSizePerMsg;
+    protected final int maxDataSizePerMsg;
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
-    private final CorfuRuntime rt;
-    private long snapshotTimestamp;
+    protected final CorfuRuntime rt;
+    protected long snapshotTimestamp;
     protected Set<String> streams;
     private PriorityQueue<String> streamsToSend;
     private long preMsgTs;
     private long currentMsgTs;
-    private OpaqueStreamIterator currentStreamInfo;
+    protected OpaqueStreamIterator currentStreamInfo;
     private long sequence;
-    private OpaqueEntry lastEntry = null;
+    protected OpaqueEntry lastEntry = null;
 
     @Getter
-    private ObservableValue<Integer> observeBiggerMsg = new ObservableValue(0);
+    protected ObservableValue<Integer> observeBiggerMsg = new ObservableValue(0);
 
     protected final LogReplication.LogReplicationSession session;
     protected final LogReplicationContext replicationContext;
@@ -86,7 +86,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
      * @param entryList
      * @return
      */
-    private OpaqueEntry generateOpaqueEntry(long version, UUID streamID, SMREntryList entryList) {
+    protected OpaqueEntry generateOpaqueEntry(long version, UUID streamID, SMREntryList entryList) {
         Map<UUID, List<SMREntry>> map = new HashMap<>();
         map.put(streamID, entryList.getSmrEntries());
         return new OpaqueEntry(version, map);
@@ -135,7 +135,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
      * @param stream
      * @return
      */
-    private SMREntryList next(OpaqueStreamIterator stream) {
+    protected SMREntryList next(OpaqueStreamIterator stream) {
         List<SMREntry> smrList = new ArrayList<>();
         int currentMsgSize = 0;
 
@@ -192,7 +192,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
      * @param stream bookkeeping of the current stream information.
      * @return
      */
-    private LogReplication.LogReplicationEntryMsg read(OpaqueStreamIterator stream, UUID syncRequestId) {
+    protected LogReplication.LogReplicationEntryMsg read(OpaqueStreamIterator stream, UUID syncRequestId) {
         SMREntryList entryList = next(stream);
         LogReplication.LogReplicationEntryMsg txMsg = generateMessage(stream, entryList, syncRequestId);
         log.info("Successfully generate a snapshot message for stream {} with snapshotTimestamp={}, numEntries={}, " +
@@ -257,7 +257,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
         return new SnapshotReadMessage(messages, endSnapshotSync);
     }
 
-    private boolean currentStreamHasNext() {
+    protected boolean currentStreamHasNext() {
         return currentStreamInfo.iterator.hasNext() || lastEntry != null;
     }
 
@@ -282,8 +282,8 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     public static class OpaqueStreamIterator {
         private String name;
         private UUID uuid;
-        private Iterator iterator;
-        private long maxVersion; // the max address of the log entries processed for this stream.
+        Iterator iterator;
+        protected long maxVersion; // the max address of the log entries processed for this stream.
 
         OpaqueStreamIterator(String name, CorfuRuntime rt, long snapshot) {
             this.name = name;
@@ -295,6 +295,12 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
             Stream stream = (new OpaqueStream(rt.getStreamsView().get(uuid, options))).streamUpTo(snapshot);
             iterator = stream.iterator();
             maxVersion = 0;
+        }
+
+        OpaqueStreamIterator(OpaqueStream opaqueStream, String name, long snapshot) {
+            this.name = name;
+            uuid = CorfuRuntime.getStreamID(name);
+            iterator = opaqueStream.streamUpTo(snapshot).iterator();
         }
     }
 
@@ -309,7 +315,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     /**
      * Record a list of SMR entries
      */
-    private static class SMREntryList {
+    public static class SMREntryList {
 
         // The total sizeInBytes of smrEntries in bytes.
         @Getter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -258,6 +258,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     }
 
     protected boolean currentStreamHasNext() {
+        log.info("Iterator hasNext = {}", currentStreamInfo.iterator.hasNext());
         return currentStreamInfo.iterator.hasNext() || lastEntry != null;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -1,18 +1,61 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import com.google.common.base.Preconditions;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.replication.send.IllegalSnapshotEntrySizeException;
+import org.corfudb.protocols.logprotocol.OpaqueEntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.LogReplicationUtils;
+import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.stream.OpaqueStream;
+import org.corfudb.util.retry.ExponentialBackoffRetry;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.RetryNeededException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.corfudb.infrastructure.logreplication.config.LogReplicationConfig.DEFAULT_MAX_DATA_MSG_SIZE;
 
 /**
  * Snapshot reader implementation for Routing Queues Replication Model.
  */
+@Slf4j
 public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
+
+    private static final long DATA_WAIT_TIMEOUT_MS = 120000;
+
+    private String streamToReplicate;
+
+    private UUID snapshotSyncQueueId;
+
+    private ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    private boolean endMarkerReached = false;
+
+    private long lastReadTimestamp;
 
     public RoutingQueuesSnapshotReader(CorfuRuntime corfuRuntime, LogReplicationSession session,
                                        LogReplicationContext replicationContext) {
         super(corfuRuntime, session, replicationContext);
+        streamToReplicate = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
+        snapshotSyncQueueId = CorfuRuntime.getStreamID(LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER);
+        lastReadTimestamp = snapshotTimestamp;
     }
 
     @Override
@@ -25,5 +68,169 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
     public void reset(long ts) {
         // In addition to setting the snapshot timestamp to ts, write to the table subscribed to by the client
         // requesting for a snapshot sync
+    }
+
+    @Override
+    public SnapshotReadMessage read(UUID syncRequestId) {
+        List<LogReplication.LogReplicationEntryMsg> messages = new ArrayList<>();
+
+        LogReplication.LogReplicationEntryMsg msg;
+
+        log.info("Start Snapshot Sync replication for stream name={}, id={}", streamToReplicate,
+            CorfuRuntime.getStreamID(streamToReplicate));
+
+        // If the current opaque stream has data, read and send it
+        if (currentStreamHasNext()) {
+            msg = read(currentStreamInfo, syncRequestId);
+            if (msg != null) {
+                messages.add(msg);
+            }
+        } else {
+            // Wait for more data to be written by the client and send it once it is received
+            waitForData();
+            msg = read(currentStreamInfo, syncRequestId);
+            if (msg != null) {
+                messages.add(msg);
+            }
+        }
+        return new SnapshotReadMessage(messages, endMarkerReached);
+    }
+
+    private void waitForData() {
+        // Create an opaque stream on snapshot sync stream for this destination and seek upto the timestamp at which
+        // snapshot was taken + 1
+        OpaqueStream opaqueStream =
+            new OpaqueStream(rt.getStreamsView().get(CorfuRuntime.getStreamID(streamToReplicate)));
+        opaqueStream.seek(lastReadTimestamp + 1);
+
+        // Create a task to wait for more data until DATA_WAIT_TIMEOUT_MS
+        StreamQueryTask streamQueryTask = new StreamQueryTask(opaqueStream);
+        Future<Void> queryFuture = executorService.submit(streamQueryTask);
+
+        try {
+            queryFuture.get(DATA_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Timed out waiting for data or end marker for Snapshot Sync");
+        } catch (Exception e) {
+            // Handle all other types of exceptions
+        }
+    }
+
+    private boolean isEndMarker(OpaqueEntry opaqueEntry) {
+
+        Preconditions.checkState(opaqueEntry.getEntries().get(snapshotSyncQueueId).size() == 1);
+        SMREntry smrEntry = opaqueEntry.getEntries().get(snapshotSyncQueueId).get(0);
+
+        // Deserialize the entry to get the marker
+        Object[] objs = smrEntry.getSMRArguments();
+        ByteBuf valueBuf = Unpooled.wrappedBuffer((byte[]) objs[1]);
+        RoutingTableEntryMsg routingTableEntryMsg =
+            (RoutingTableEntryMsg) replicationContext.getProtobufSerializer().deserialize(valueBuf, null);
+
+        return (routingTableEntryMsg.getIsSnapshotEnd());
+    }
+
+    @Override
+    protected SMREntryList next(OpaqueStreamIterator stream) {
+        List<SMREntry> smrList = new ArrayList<>();
+        int currentMsgSize = 0;
+
+        try {
+            while (currentMsgSize < maxDataSizePerMsg) {
+                if (lastEntry != null) {
+
+                    // Only the entries from Routing Queue for Snapshot Sync must be found
+                    Preconditions.checkState(lastEntry.getEntries().keySet().size() == 1);
+                    Preconditions.checkState(lastEntry.getEntries().keySet().contains(snapshotSyncQueueId));
+
+                    // If this OpaqueEntry was for the end marker, no further processing is required.
+                    if (isEndMarker(lastEntry)) {
+                        endMarkerReached = true;
+                        break;
+                    }
+
+                    List<SMREntry> smrEntries = lastEntry.getEntries().get(snapshotSyncQueueId);
+                    if (smrEntries != null) {
+                        int currentEntrySize = ReaderUtility.calculateSize(smrEntries);
+
+                        if (currentEntrySize > DEFAULT_MAX_DATA_MSG_SIZE) {
+                            log.error("The current entry size {} is bigger than the maxDataSizePerMsg {} supported",
+                                currentEntrySize, DEFAULT_MAX_DATA_MSG_SIZE);
+                            throw new IllegalSnapshotEntrySizeException(" The snapshot entry is bigger than the system supported");
+                        } else if (currentEntrySize > maxDataSizePerMsg) {
+                            observeBiggerMsg.setValue(observeBiggerMsg.getValue()+1);
+                            log.warn("The current entry size {} is bigger than the configured maxDataSizePerMsg {}",
+                                currentEntrySize, maxDataSizePerMsg);
+                        }
+
+                        // Skip append this entry in this message. Will process it first at the next round.
+                        if (currentEntrySize + currentMsgSize > maxDataSizePerMsg && currentMsgSize != 0) {
+                            break;
+                        }
+
+                        smrList.addAll(smrEntries);
+                        currentMsgSize += currentEntrySize;
+                        stream.maxVersion = Math.max(stream.maxVersion, lastEntry.getVersion());
+                        lastReadTimestamp = stream.maxVersion;
+                    }
+                    lastEntry = null;
+                }
+
+                if (stream.iterator.hasNext()) {
+                    lastEntry = (OpaqueEntry) stream.iterator.next();
+                }
+
+                if (lastEntry == null) {
+                    break;
+                }
+            }
+        } catch (TrimmedException e) {
+            log.error("Caught a TrimmedException", e);
+            throw e;
+        }
+
+        log.trace("CurrentMsgSize {} lastEntrySize {}  maxDataSizePerMsg {}",
+            currentMsgSize, lastEntry == null ? 0 : ReaderUtility.calculateSize(lastEntry.getEntries().get(snapshotSyncQueueId)),
+            maxDataSizePerMsg);
+        return new SMREntryList(currentMsgSize, smrList);
+    }
+
+    @Override
+    protected OpaqueEntry generateOpaqueEntry(long version, UUID streamID, SMREntryList entryList) {
+        Map<UUID, List<SMREntry>> map = new HashMap<>();
+        UUID streamId = UUID.fromString(LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX);
+        map.put(streamId, entryList.getSmrEntries());
+        return new OpaqueEntry(version, map);
+    }
+
+    private class StreamQueryTask implements Callable<Void> {
+
+        OpaqueStream opaqueStream;
+
+        StreamQueryTask(OpaqueStream opaqueStream) {
+            this.opaqueStream = opaqueStream;
+        }
+
+        @Override
+        public Void call() {
+            try {
+                IRetry.build(ExponentialBackoffRetry.class, () -> {
+                    try {
+                        currentStreamInfo = new OpaqueStreamIterator(opaqueStream, streamToReplicate,
+                            rt.getAddressSpaceView().getLogTail());
+
+                        if (!currentStreamHasNext()) {
+                            throw new RuntimeException("Retry");
+                        }
+                    } catch (Exception e) {
+                        throw new RetryNeededException();
+                    }
+                    return null;
+                }).run();
+            } catch (InterruptedException ie) {
+                throw new RuntimeException("Interrupted Exception");
+            }
+            return null;
+        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -69,7 +69,7 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
         lastReadTimestamp = snapshotTimestamp;
 
         String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
-                LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX);
+                LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId());
         replicatedQueueId = CorfuRuntime.getStreamID(replicatedQueueName);
 
         buildOpaqueStreamIterator();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -270,9 +270,7 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
             throw e;
         }
 
-        log.trace("CurrentMsgSize {} lastEntrySize {}  maxDataSizePerMsg {}",
-            currentMsgSize, lastEntry == null ? 0 : ReaderUtility.calculateSize(lastEntry.getEntries().get(snapshotSyncQueueId)),
-            maxDataSizePerMsg);
+        log.trace("CurrentMsgSize {}  maxDataSizePerMsg {}", currentMsgSize, maxDataSizePerMsg);
         return new SMREntryList(currentMsgSize, smrList);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -103,8 +103,6 @@ public class LogReplicationConfigManager {
     private List<Map.Entry<TableName, CorfuRecord<TableDescriptors, TableMetadata>>> registryTableEntries =
             new ArrayList<>();
 
-
-
     /**
      * Used for non-upgrade testing purpose only. Note that this constructor will keep the version table in
      * uninitialized state, in which case LR will be constantly considered to be not upgraded.

--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -32,5 +32,15 @@ message RoutingTableEntryMsg {
     ReplicationType type = 2;
 
     // The actual payload carrying data that will be replicated to the destinations specified.
-    bytes opaque_payload = 3;
+    bytes opaque_payload = 2;
+}
+
+message RoutingTableSnapshotEndKeyMsg {
+    string snapshot_sync_id = 1;
+}
+
+// Marker message denoting the end of a snapshot sync
+message RoutingTableSnapshotEndMarkerMsg {
+    // Destination corresponding to this snapshot sync
+    string destination = 1;
 }

--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -32,7 +32,7 @@ message RoutingTableEntryMsg {
     ReplicationType type = 2;
 
     // The actual payload carrying data that will be replicated to the destinations specified.
-    bytes opaque_payload = 2;
+    bytes opaque_payload = 3;
 }
 
 message RoutingTableSnapshotEndKeyMsg {

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -65,6 +65,8 @@ public final class LogReplicationUtils {
     // Stream tag applied to the replicated queue on the receiver
     public static final String REPLICATED_QUEUE_TAG_PREFIX = "lrq_recv_";
 
+    public static final String SNAPSHOT_END_MARKER_TABLE_NAME = "SnapshotSyncEndMarker";
+
     // ---- End RoutingQueue Model constants -------/
 
     public static final UUID lrLogEntrySendQId = CorfuRuntime.getStreamID(TableRegistry

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
@@ -1,0 +1,114 @@
+package org.corfudb.infrastructure.logreplication;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.BaseSnapshotReader;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.RoutingQueuesSnapshotReader;
+import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.LogReplicationUtils;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Before;
+import org.junit.Test;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_END_MARKER_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+public class RoutingQueuesSnapshotReaderTest extends AbstractViewTest {
+
+    private UUID syncRequestId;
+    private BaseSnapshotReader snapshotReader;
+    private CorfuRuntime runtime1;
+    private CorfuRuntime runtime2;
+    private LogReplication.LogReplicationSession session;
+    private LogReplicationConfigManager configManager;
+    private LogReplicationContext replicationContext;
+    private CorfuStore corfuStore;
+    String streamTagFollowed;
+
+    @Before
+    public void setUp() {
+        syncRequestId = UUID.randomUUID();
+        runtime1 = getDefaultRuntime();
+        runtime2 = getNewRuntime(getDefaultNode()).connect();
+        corfuStore = new CorfuStore(runtime2);
+        session = DefaultClusterConfig.getRoutingQueueSessions().get(0);
+
+        configManager = new LogReplicationConfigManager(runtime1, session.getSourceClusterId());
+        replicationContext = new LogReplicationContext(configManager, 5, session.getSourceClusterId(),
+                true, new LogReplicationPluginConfig(""));
+        configManager.generateConfig(Collections.singleton(session));
+        snapshotReader = new RoutingQueuesSnapshotReader(runtime1, session, replicationContext);
+        snapshotReader.reset(runtime1.getAddressSpaceView().getLogTail());
+
+        streamTagFollowed = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
+    }
+
+    @Test
+    public void testRead() throws Exception {
+        generateData();
+        snapshotReader.read(syncRequestId);
+    }
+
+    private void generateData() throws Exception {
+
+        String tableName = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
+        String namespace = CORFU_SYSTEM_NAMESPACE;
+
+        Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> q =
+                corfuStore.openQueue(namespace, tableName, Queue.RoutingTableEntryMsg.class,
+                    TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+
+        log.info("Stream UUID: {}", CorfuRuntime.getStreamID(streamTagFollowed));
+
+        for (int i = 0; i < 10; i++) {
+                ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE);
+                buffer.putInt(i);
+            Queue.RoutingTableEntryMsg val =
+                    Queue.RoutingTableEntryMsg.newBuilder().setOpaquePayload(ByteString.copyFrom(buffer.array()))
+                        .build();
+
+            try (TxnContext txnContext = corfuStore.txn(namespace)) {
+                txnContext.logUpdateEnqueue(q, val, Arrays.asList(CorfuRuntime.getStreamID(streamTagFollowed)),
+                    corfuStore);
+                log.info("Committed at {}", txnContext.commit());
+            } catch (Exception e) {
+                log.error("Failed to add data to the queue", e);
+            }
+        }
+        log.info("Queue Size = {}.  Stream tags = {}", q.count(), q.getStreamTags());
+
+        Table<Queue.RoutingTableSnapshotEndKeyMsg, Queue.RoutingTableSnapshotEndMarkerMsg, Message> endMarkerTable =
+            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_END_MARKER_TABLE_NAME,
+                Queue.RoutingTableSnapshotEndKeyMsg.class, Queue.RoutingTableSnapshotEndMarkerMsg.class, null,
+                TableOptions.fromProtoSchema(Queue.RoutingTableSnapshotEndMarkerMsg.class));
+
+        Queue.RoutingTableSnapshotEndKeyMsg snapshotSyncId =
+                Queue.RoutingTableSnapshotEndKeyMsg.newBuilder().setSnapshotSyncId(syncRequestId.toString()).build();
+
+        Queue.RoutingTableSnapshotEndMarkerMsg endMarker =
+            Queue.RoutingTableSnapshotEndMarkerMsg.newBuilder().setDestination(session.getSinkClusterId()).build();
+
+        try (TxnContext txnContext = corfuStore.txn(namespace)) {
+            txnContext.putRecord(endMarkerTable, snapshotSyncId, endMarker, null);
+            txnContext.commit();
+        } catch (Exception e) {
+            log.error("Failed to add End Marker", e);
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
