### PR TITLE
Routing Queue Client Interface

### DIFF
--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -129,7 +129,9 @@ message ReplicationEvent {
 
   enum ReplicationEventType {
     FORCE_SNAPSHOT_SYNC = 0;
-    UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC = 1; // Intent to queue force sync for all sessions
+    UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC = 1; // Intent to queue force sync for all full table sessions
+    RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC = 2;
+    ROLE_CHANGE_FORCE_SNAPSHOT_SYNC = 3;
   }
   string clusterId = 1;
   string eventId = 2;

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueClient.java
@@ -1,0 +1,17 @@
+package org.corfudb.runtime;
+
+import org.corfudb.runtime.collections.LRMessageWithDestinations;
+
+import java.util.List;
+
+public interface LogReplicationRoutingQueueClient {
+    /**
+     * Transmits Delta Messages.
+     * Must be invoked with the same transaction builder that was used for as actual data modification.
+     * This method must be used if transaction has multiple messages. Repetitive calls in the same transaction to the
+     * transmitDeltaMessages/transmitDeltaMessage won't be supported
+     */
+    void transmitDeltaMessage(byte[] payload, List<String> destinations);
+
+    void transmitDeltaMessages(List<LRMessageWithDestinations> messages);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/LRMessageWithDestinations.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/LRMessageWithDestinations.java
@@ -1,0 +1,25 @@
+package org.corfudb.runtime.collections;
+
+import lombok.Getter;
+
+import java.util.List;
+
+public class LRMessageWithDestinations {
+
+    /**
+     * Opaque payload for log replication.
+     */
+    @Getter
+    private final byte[] payload;
+
+    /**
+     * List of destinations for a transaction.
+     */
+    @Getter
+    private final List<String> destinations;
+
+    public LRMessageWithDestinations(byte[] payload, List<String> destinations) {
+        this.payload = payload;
+        this.destinations = destinations;
+    }
+}


### PR DESCRIPTION
## Overview

Description:

Initial definition of the routing queue client interface, and addition of supporting enums for force sync operations.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
