### PR TITLE
bug fixes: leadership_loss msg + logical group proto check

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -213,7 +213,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
                 } catch (Exception e) {
                     log.error("Caught an exception. Stop discovery service.", e);
                     shouldRun = false;
-                    stopLogReplication();
+                    stopLogReplication(false);
                     if (e instanceof InterruptedException) {
                         Thread.interrupted();
                     }
@@ -436,8 +436,8 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     /**
      * Stop Log Replication
      */
-    private void stopLogReplication() {
-        if (sessionManager.getReplicationContext().getIsLeader().get()) {
+    private void stopLogReplication(boolean lockReleased) {
+        if (lockReleased || sessionManager.getReplicationContext().getIsLeader().get()) {
             log.info("Stopping log replication.");
             sessionManager.stopReplication();
         }
@@ -459,13 +459,9 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
      */
     public void processLockRelease() {
         log.debug("Lock released");
-        // Unset isLeader flag after stopping log replication
-        stopLogReplication();
-        if (interClusterServerNode != null) {
-            interClusterServerNode.close();
-        }
         sessionManager.getReplicationContext().setIsLeader(false);
         sessionManager.notifyLeadershipChange();
+        stopLogReplication(true);
         recordLockRelease();
     }
 
@@ -507,7 +503,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             isValid = processDiscoveredTopology(discoveredTopology, topologyDescriptor.getLocalClusterDescriptor() == null);
         } catch (Throwable t) {
             log.error("Exception when processing the discovered topology", t);
-            stopLogReplication();
+            stopLogReplication(false);
             return;
         }
 
@@ -515,7 +511,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             onTopologyChange(discoveredTopology);
         } else {
             // Stop Log Replication in case this node was previously SOURCE but no longer belongs to the Topology
-            stopLogReplication();
+            stopLogReplication(false);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -374,7 +374,7 @@ public class SessionManager {
 
     private void updateRouterWithNewSessions() {
         newSessionsDiscovered.forEach(session -> {
-            router.getSessionToRequestIdCounter().put(session, new AtomicLong(0));
+            router.getSessionToRequestIdCounter().putIfAbsent(session, new AtomicLong(0));
             if(incomingSessions.contains(session)) {
                 router.getSessionToRemoteClusterDescriptor()
                         .put(session, topology.getRemoteSourceClusters().get(session.getSourceClusterId()));
@@ -383,12 +383,10 @@ public class SessionManager {
             } else {
                 router.getSessionToRemoteClusterDescriptor()
                         .put(session, topology.getRemoteSinkClusters().get(session.getSinkClusterId()));
-                router.getSessionToOutstandingRequests().put(session, new HashMap<>());
             }
 
             if(router.isConnectionStarterForSession(session)) {
-                router.getSessionToLeaderConnectionFuture().put(session, new CompletableFuture<>());
-                router.getSessionToOutstandingRequests().putIfAbsent(session, new HashMap<>());
+                router.getSessionToLeaderConnectionFuture().putIfAbsent(session, new CompletableFuture<>());
                 if (incomingSessions.contains(session)) {
                     router.getSessionToRemoteSourceLeaderManager().put(session,
                             new RemoteSourceLeadershipManager(session, router,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -220,9 +220,8 @@ public class SessionManager {
                 } catch (TransactionAbortedException e) {
                     throw new RetryNeededException();
                 }
-
-                updateTopology(newTopology);
                 stopReplication(sessionsToRemove);
+                updateTopology(newTopology);
                 updateReplicationParameters(Sets.intersection(sessionsUnchanged, outgoingSessions));
                 createSessions();
                 return null;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
-import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLeadershipLoss;
+import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLeadershipLossResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLeadershipResponse;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getHeaderMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getResponseMsg;
@@ -350,7 +350,7 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
      */
     private void sendLeadershipLoss(@Nonnull RequestMsg request, @Nonnull IClientServerRouter router) {
         HeaderMsg responseHeader = getHeaderMsg(request.getHeader());
-        ResponseMsg response = getLeadershipLoss(responseHeader, localNodeId);
+        ResponseMsg response = getLeadershipLossResponseMsg(responseHeader, localNodeId);
         router.sendResponse(response);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 
 /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 
 /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
@@ -165,6 +165,10 @@ public class LogReplicationSourceManager {
      * Termination of the Log Replication State Machine, to enable replication a JVM restart is required.
      */
     public void shutdown() {
+        if(runtime.isShutdown()) {
+            log.debug("No-op : received a duplicate shutdown request.");
+            return;
+        }
         // Enqueue event into Log Replication FSM
         LogReplicationEvent logReplicationEvent = new LogReplicationEvent(LogReplicationEventType.REPLICATION_STOP);
         logReplicationFSM.input(logReplicationEvent);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -309,31 +309,10 @@ public class CorfuLogReplicationRuntime {
     }
 
     /**
-     * stopReplication and stopping FSM are asynchronous events. For scenarios where the source is the connection endpoint,
-     * the 2 events should be synchronized so the in-memory objects, that is holding a ref to futures and LR objects, are
-     * not cleared before receiving an ACK from remote.
-     */
-    private void awaitTransitionToStopWhenConnectionEndpoint() {
-        if (router.isConnectionStarterForSession(session)) {
-            return;
-        }
-        while(!state.getType().equals(LogReplicationRuntimeStateType.STOPPED)) {
-            try {
-                TimeUnit.MILLISECONDS.sleep(CorfuLogReplicationRuntime.DEFAULT_TIMEOUT);
-            } catch (InterruptedException e) {
-                log.debug("Sleep was interrupted. Checking if FSM has successfully transitioned to STOPPED state. {}", e);
-                continue;
-            }
-        }
-        log.debug("FSM has successfully transitioned to STOPPED state");
-    }
-
-    /**
      * Stop Log Replication, regardless of current state.
      */
     public void stop() {
         input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.LOCAL_LEADER_LOSS,
                 router.isConnectionStarterForSession(session)));
-        awaitTransitionToStopWhenConnectionEndpoint();
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -155,6 +155,9 @@ public class CorfuLogReplicationRuntime {
     @Getter
     public final LogReplicationSession session;
 
+    @Getter
+    private final LogReplicationContext replicationContext;
+
     /**
      * Default Constructor
      */
@@ -167,6 +170,7 @@ public class CorfuLogReplicationRuntime {
         this.sourceManager = new LogReplicationSourceManager(parameters,router, metadataManager,
                 session, replicationContext);
         this.connectedNodes = new HashSet<>();
+        this.replicationContext = replicationContext;
 
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("runtime-fsm-worker-"+session.hashCode())
             .build();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -320,6 +321,7 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
             // Get the next request ID.
             requestId = sessionToRequestIdCounter.getOrDefault(session, new AtomicLong(0)).getAndIncrement();
 
+            sessionToOutstandingRequests.putIfAbsent(session, new HashMap<>());
             sessionToOutstandingRequests.get(session).put(requestId, cf);
 
             header.setRequestId(requestId);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -18,6 +18,7 @@ import org.corfudb.infrastructure.logreplication.transport.IClientServerRouter;
 import org.corfudb.infrastructure.logreplication.transport.client.ChannelAdapterException;
 import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
 import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
@@ -48,7 +49,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getHeaderMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getResponseMsg;
 
 /**
  * Router, interfaces between the custom transport layer and LR core components.
@@ -114,6 +117,7 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
     /**
      * local node ID
      */
+    @Getter
     private final String localNodeId;
 
     /**
@@ -314,7 +318,7 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
         final CompletableFuture<T> cf = new CompletableFuture<>();
         try {
             // Get the next request ID.
-            requestId = sessionToRequestIdCounter.get(session).getAndIncrement();
+            requestId = sessionToRequestIdCounter.getOrDefault(session, new AtomicLong(0)).getAndIncrement();
 
             sessionToOutstandingRequests.get(session).put(requestId, cf);
 
@@ -362,10 +366,12 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
             // In the case the message is intended for a specific endpoint, we do not
             // block on connection future, this is the case of leader verification.
             if(isConnectionStarterForSession(session)) {
-                log.info("Send requestID {} via clientChannelAdapter for session {}", header.getRequestId(), session);
+                log.info("Send requestID/payload {}/{} via clientChannelAdapter for session {}", header.getRequestId(),
+                        payload.getPayloadCase(), session);
                 clientChannelAdapter.send(nodeId, getRequestMsg(header.build(), payload));
             } else {
-                log.info("Send requestID {} via serverChannelAdapter for session {}", header.getRequestId(), session);
+                log.info("Send requestID/payload {}/{} via serverChannelAdapter for session {}", header.getRequestId(),
+                        payload.getPayloadCase(), session);
                 serverChannelAdapter.send(getRequestMsg(header.build(), payload));
             }
 
@@ -477,6 +483,11 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
         }
     }
 
+    public void inputRemoteSourceLeaderLoss(LogReplicationSession session) {
+        sessionToRemoteSourceLeaderManager.get(session).input(
+                new LogReplicationSinkEvent(LogReplicationSinkEvent.LogReplicationSinkEventType.REMOTE_LEADER_LOSS));
+    }
+
     @Override
     public void receive(CorfuMessage.ResponseMsg msg) {
         try {
@@ -511,6 +522,13 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
                 sessionToRuntimeFSM.get(session).setRemoteLeaderNodeId(remoteLeaderId);
                 // Start runtimeFSM
                 addConnectionUpEvent(session, remoteLeaderId);
+            } else if (isAckForLocalLeaderLoss(msg)) {
+                log.debug("Received an ACK for requestID/payload {}/{}", msg.getHeader().getRequestId(),
+                        msg.getPayload().getPayloadCase());
+                // the ACK for leadership loss msg from SOURCE is completed with null
+                completeRequest(msg.getHeader().getSession(), msg.getHeader().getRequestId(), null);
+                return;
+
             } else {
                 // Route the message to the handler.
                 if (log.isTraceEnabled()) {
@@ -527,9 +545,30 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
         }
     }
 
+    private boolean isAckForLocalLeaderLoss(CorfuMessage.ResponseMsg msg) {
+        return msg.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK) &&
+                !msg.getPayload().getLrEntryAck().hasMetadata();
+    }
+
     @Override
     public void receive(CorfuMessage.RequestMsg message) {
         log.debug("Received request message {}", message.getPayload().getPayloadCase());
+        try {
+            if (message.getPayload().getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_LOSS)) {
+                sessionToRemoteSourceLeaderManager.get(message.getHeader().getSession()).input(new LogReplicationSinkEvent(
+                        LogReplicationSinkEvent.LogReplicationSinkEventType.REMOTE_LEADER_LOSS,
+                        message.getPayload().getLrLeadershipLoss().getNodeId()));
+                // ack the leadership loss msg with an empty payload
+                CorfuMessage.ResponsePayloadMsg responsePayloadMsg = CorfuMessage.ResponsePayloadMsg.newBuilder()
+                        .setLrEntryAck(LogReplication.LogReplicationEntryMsg.newBuilder().build()).build();
+                sendResponse(getResponseMsg(getHeaderMsg(message.getHeader()), responsePayloadMsg));
+                return;
+            }
+        } catch (NullPointerException npe) {
+            log.error("Ignoring the leadership_loss msg. The replication components has already been stopped for " +
+                    "session {} ", message.getHeader().getSession());
+            return;
+        }
 
         // Route the message to the handler.
         if (log.isTraceEnabled()) {
@@ -608,7 +647,8 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
     private boolean isValidMessage(CorfuMessage.RequestPayloadMsg message) {
         return message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_ENTRY) ||
                 message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST) ||
-                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY);
+                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY) ||
+                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_LOSS);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
@@ -12,7 +12,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLeadershipLossRequestPayloadMsg;
 
 @Slf4j
 public class LogReplicationFsmUtil {
@@ -123,6 +127,51 @@ public class LogReplicationFsmUtil {
                             LogReplicationSinkEvent.LogReplicationSinkEventType.REMOTE_LEADER_NOT_FOUND,
                             leader));
         }
+    }
+
+    /**
+     * Check if stop event can be enqueued. STOPPED event can be enqueued for a connection endpoint, only after sending
+     * a leadership loss msg to remote.
+     *
+     * @param router
+     * @param fsm
+     * @return
+     */
+    public static boolean canEnqueueStopRuntimeFsmEvent(LogReplicationClientServerRouter router, CorfuLogReplicationRuntime fsm,
+                                                        boolean isConnectionStarter) {
+        // send a leadershipLoss msg to remote when the local cluster is NOT a connection starter
+        if (!isConnectionStarter) {
+            return sendLeadershipLossRequestMsg(router, fsm);
+        }
+        return true;
+    }
+
+    /**
+     * SOURCE to send leadership loss msg when it is the connection endpoint for a session and the local node looses the
+     * leadership.
+     *
+     * @param router send msg to remote via the router
+     * @param fsm  runtime fsm
+     */
+    private static boolean sendLeadershipLossRequestMsg(LogReplicationClientServerRouter router, CorfuLogReplicationRuntime fsm) {
+        try {
+            log.debug("Sending LEADERSHIP_LOSS msg for session {}", fsm.getSession());
+            CompletableFuture<LogReplication.LogReplicationMetadataResponseMsg> cf = router
+                    .sendRequestAndGetCompletable(fsm.session,
+                            getLeadershipLossRequestPayloadMsg(router.getLocalNodeId()),
+                            fsm.getRemoteLeaderNodeId().get());
+            cf.get(CorfuLogReplicationRuntime.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+            return true;
+        } catch(TimeoutException | ExecutionException | InterruptedException ex) {
+            log.error("Retry sending leadership loss msg until an ACK is received ", ex);
+            fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.LOCAL_LEADER_LOSS, false));
+        } catch (Exception ex) {
+            // error occurring due to transport/network layer failure can be ignored as the remote will be notified. The
+            // remote will then initiate a new connection. In this case, its safe to transition FSM to STOPPED state
+            log.error("Sending leadership loss msg failed. Transitioning the FSM to STOPPED state. ", ex);
+            return true;
+        }
+        return false;
     }
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
@@ -154,6 +154,11 @@ public class LogReplicationFsmUtil {
      * @param fsm  runtime fsm
      */
     private static boolean sendLeadershipLossRequestMsg(LogReplicationClientServerRouter router, CorfuLogReplicationRuntime fsm) {
+        if(fsm.getReplicationContext().getIsLeader().get()) {
+            log.debug("the local node acquired the leadership. Stop sending Leadership_loss msg");
+            // do not transition to another state
+            return false;
+        }
         try {
             log.debug("Sending LEADERSHIP_LOSS msg for session {}", fsm.getSession());
             CompletableFuture<LogReplication.LogReplicationMetadataResponseMsg> cf = router

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationRuntimeEvent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationRuntimeEvent.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.runtime.fsm;
 
 import lombok.Data;
+import lombok.Getter;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 
 /**
@@ -36,7 +37,8 @@ public class LogReplicationRuntimeEvent {
     // Exception for ON_ERROR event
     private Throwable t;
 
-    boolean isConnectionStarter;
+    @Getter
+    private boolean isConnectionStarter;
 
     /**
      * Constructor

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationRuntimeEvent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationRuntimeEvent.java
@@ -36,6 +36,8 @@ public class LogReplicationRuntimeEvent {
     // Exception for ON_ERROR event
     private Throwable t;
 
+    boolean isConnectionStarter;
+
     /**
      * Constructor
      *
@@ -43,6 +45,16 @@ public class LogReplicationRuntimeEvent {
      */
     public LogReplicationRuntimeEvent(LogReplicationRuntimeEventType type) {
         this.type = type;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param type runtime event type
+     */
+    public LogReplicationRuntimeEvent(LogReplicationRuntimeEventType type, boolean isConnectionStarter) {
+        this.type = type;
+        this.isConnectionStarter = isConnectionStarter;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -90,7 +90,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 }
                 return null;
             case LOCAL_LEADER_LOSS:
-                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
+                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter())) {
                     return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
                 }
                 return null;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -18,6 +18,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationFsmUtil.canEnqueueStopRuntimeFsmEvent;
+
 /**
  * Log Replication Runtime Negotiating State.
  *
@@ -88,7 +90,10 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 }
                 return null;
             case LOCAL_LEADER_LOSS:
-                return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
+                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
+                    return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
+                }
+                return this;
             case ERROR:
                 ((UnrecoverableState)fsm.getStates().get(LogReplicationRuntimeStateType.UNRECOVERABLE)).setThrowableCause(event.getT().getCause());
                 return fsm.getStates().get(LogReplicationRuntimeStateType.UNRECOVERABLE);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -93,7 +93,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
                     return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
                 }
-                return this;
+                return null;
             case ERROR:
                 ((UnrecoverableState)fsm.getStates().get(LogReplicationRuntimeStateType.UNRECOVERABLE)).setThrowableCause(event.getT().getCause());
                 return fsm.getStates().get(LogReplicationRuntimeStateType.UNRECOVERABLE);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -71,7 +71,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 fsm.updateConnectedNodes(event.getNodeId());
                 return null;
             case LOCAL_LEADER_LOSS:
-                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
+                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter())) {
                     return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
                 }
                 return null;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -4,8 +4,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationSourceManager;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientServerRouter;
 
 import java.util.UUID;
+
+import static org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationFsmUtil.canEnqueueStopRuntimeFsmEvent;
 
 /**
  * Log Replication Runtime Replicating State.
@@ -20,10 +23,13 @@ public class ReplicatingState implements LogReplicationRuntimeState {
     private CorfuLogReplicationRuntime fsm;
     private LogReplicationSourceManager replicationSourceManager;
     private LogReplicationEvent replicationEvent;
+    private LogReplicationClientServerRouter router;
 
-    public ReplicatingState(CorfuLogReplicationRuntime fsm, LogReplicationSourceManager sourceManager) {
+    public ReplicatingState(CorfuLogReplicationRuntime fsm, LogReplicationSourceManager sourceManager,
+                            LogReplicationClientServerRouter router) {
         this.fsm = fsm;
         this.replicationSourceManager = sourceManager;
+        this.router = router;
     }
 
     @Override
@@ -65,7 +71,10 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 fsm.updateConnectedNodes(event.getNodeId());
                 return null;
             case LOCAL_LEADER_LOSS:
-                return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
+                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
+                    return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
+                }
+                return this;
             default: {
                 log.warn("Unexpected communication event {} when in init state.", event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -74,7 +74,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
                     return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
                 }
-                return this;
+                return null;
             default: {
                 log.warn("Unexpected communication event {} when in init state.", event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
@@ -64,7 +64,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
                 if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
                     return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
                 }
-                return this;
+                return null;
             default: {
                 log.warn("Unexpected communication event {} when in init state.", event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
@@ -61,7 +61,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
                 fsm.updateConnectedNodes(event.getNodeId());
                 return this;
             case LOCAL_LEADER_LOSS:
-                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter)) {
+                if (canEnqueueStopRuntimeFsmEvent(router, fsm, event.isConnectionStarter())) {
                     return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
                 }
                 return null;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -20,6 +20,7 @@ import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientServerRouter;
 import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.util.NodeLocator;
@@ -225,6 +226,9 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                 public void onNext(RequestMsg request) {
                     try {
                         log.info("Received request {}", request.getHeader().getRequestId());
+                        if (request.getPayload().getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_LOSS)) {
+                            responseObserverMap.remove(sessionMsg);
+                        }
                         receive(request);
                     } catch (Exception e) {
                         log.error("Caught exception while receiving Requests", e);
@@ -240,6 +244,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                     getRouter().completeExceptionally(sessionMsg, requestId, t);
                     responseObserverMap.remove(sessionMsg);
                     onServiceUnavailable(t, finalNodeId, sessionMsg);
+                    getRouter().inputRemoteSourceLeaderLoss(sessionMsg);
                 }
 
                 @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.LogReplicationGrpc;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientServerRouter;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
@@ -208,7 +209,9 @@ public class GRPCLogReplicationServerHandler extends LogReplicationGrpc.LogRepli
                 if (!reverseReplicationStreamObserverMap.containsKey(session)) {
                     log.warn("Corfu Message {} has no pending observer. Message {} will not be sent.",
                             msg.getHeader().getRequestId(), msg.getPayload().getPayloadCase().name());
-
+                    router.completeExceptionally(session, msg.getHeader().getRequestId(),
+                            new NetworkException(String.format("No pending observer for session %s", session),
+                                    session.getSinkClusterId()));
                     return;
                 }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -230,7 +230,8 @@ public class LogReplicationConfigManager {
                 streamsToReplicate.add(tableName);
                 // Collect tags for merge-only stream
                 streamToTagsMap.put(streamId, Collections.singletonList(LOG_REPLICATOR_STREAM_INFO.getStreamId()));
-            } else if (entry.getValue().getMetadata().getTableOptions().hasReplicationGroup()) {
+            } else if (entry.getValue().getMetadata().getTableOptions().hasReplicationGroup() &&
+                    !entry.getValue().getMetadata().getTableOptions().getReplicationGroup().getLogicalGroup().isEmpty()) {
                 // Find streams to replicate for every logical group for this session
                 String logicalGroup = entry.getValue().getMetadata().getTableOptions()
                         .getReplicationGroup().getLogicalGroup();

--- a/runtime/proto/service/corfu_message.proto
+++ b/runtime/proto/service/corfu_message.proto
@@ -93,6 +93,7 @@ message RequestPayloadMsg {
     LogReplicationEntryMsg lr_entry = 70;
     LogReplicationMetadataRequestMsg lr_metadata_request = 71;
     LogReplicationLeadershipRequestMsg lr_leadership_query = 72;
+    LogReplicationLeadershipLossMsg lr_leadership_loss = 73;
   }
 }
 
@@ -148,7 +149,7 @@ message ResponsePayloadMsg {
     LogReplicationMetadataResponseMsg lr_metadata_response = 71;
     LogReplicationLeadershipResponseMsg lr_leadership_response = 72;
 
-    LogReplicationLeadershipLossResponseMsg lr_leadership_loss = 73;
+    LogReplicationLeadershipLossMsg lr_leadership_loss = 73;
     ReverseReplicateMsg lr_reverse_replicate_msg = 74;
 
     // Server Error

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -34,7 +34,7 @@ message LogReplicationMetadataResponseMsg {
   uint64 lastLogEntryTimestamp = 6;
 }
 
-message LogReplicationLeadershipLossResponseMsg {
+message LogReplicationLeadershipLossMsg {
   string nodeId = 1;
 }
 

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
@@ -9,7 +9,6 @@ import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
@@ -18,7 +17,6 @@ import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getResponseMsg;
 
 /**

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
@@ -9,6 +9,8 @@ import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
@@ -16,6 +18,7 @@ import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getResponseMsg;
 
 /**
@@ -173,13 +176,37 @@ public final class CorfuProtocolLogReplication {
         return getResponseMsg(header, payload);
     }
 
-    public static ResponseMsg getLeadershipLoss(HeaderMsg header, String nodeId) {
-        LogReplication.LogReplicationLeadershipLossResponseMsg response = LogReplication.LogReplicationLeadershipLossResponseMsg
+    /**
+     * construct a leadership loss msg embedded in a response msg. This is used by the SINK to notify the SOURCE when the
+     * latter is the connection starter
+     *
+     * @param header
+     * @param nodeId
+     * @return
+     */
+    public static ResponseMsg getLeadershipLossResponseMsg(HeaderMsg header, String nodeId) {
+        LogReplication.LogReplicationLeadershipLossMsg leadershipLossMsg = LogReplication.LogReplicationLeadershipLossMsg
                 .newBuilder()
                 .setNodeId(nodeId)
                 .build();
         ResponsePayloadMsg payload = ResponsePayloadMsg.newBuilder()
-                .setLrLeadershipLoss(response).build();
+                .setLrLeadershipLoss(leadershipLossMsg).build();
         return getResponseMsg(header, payload);
+    }
+
+    /**
+     * construct a leadership loss msg embedded in a request msg. This is used by the SOURCE to notify the SINK when the
+     * latter is the connection starter
+     *
+     * @param nodeId
+     * @return
+     */
+    public static RequestPayloadMsg getLeadershipLossRequestPayloadMsg(String nodeId) {
+        LogReplication.LogReplicationLeadershipLossMsg leadershipLossMsg = LogReplication.LogReplicationLeadershipLossMsg
+                .newBuilder()
+                .setNodeId(nodeId)
+                .build();
+        return RequestPayloadMsg.newBuilder()
+                .setLrLeadershipLoss(leadershipLossMsg).build();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -25,6 +25,7 @@ import org.corfudb.runtime.collections.CorfuDynamicKey;
 import org.corfudb.runtime.collections.CorfuDynamicRecord;
 import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.PersistentCorfuTable;
 import org.corfudb.runtime.collections.StreamListener;
@@ -1559,6 +1560,10 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      * 6. Revoke source's lock and wait for 10 sec
      * 7. Write 5 more entries to source map
      * 8. Verify data will not be replicated, since source's lock is released
+     * (when sink is connection starter, verify via logs that the source sends the leadership loss msg, and the
+     *        sink sends a leadership query)
+     * 9. After the SOURCE fsm is stopped, make the SOURCE a leader again
+     * 10.Verify remaining data on SOURCE gets replicated to SINK
      */
     @Test
     public void testSourceLockRelease() throws Exception {
@@ -1630,8 +1635,18 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         sourceCorfuStore.subscribeListener(listener, LogReplicationMetadataManager.NAMESPACE,
             LR_STATUS_STREAM_TAG);
 
+        final String lockGroup = "Log_Replication_Group";
+        final String lockName = "Log_Replication_Lock";
+
+        LockDataTypes.LockId lockId = LockDataTypes.LockId.newBuilder()
+                .setLockGroup(lockGroup)
+                .setLockName(lockName)
+                .build();
+        CorfuStoreEntry record;
+
         // Release Source's lock by deleting the lock table
         try (TxnContext txnContext = sourceCorfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+            record = txnContext.getRecord(sourceLockTable, lockId);
             txnContext.clear(sourceLockTable);
             txnContext.commit();
         }
@@ -1657,6 +1672,30 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         // Sink map should still have secondBatch size
         log.info("Sink map should still have {} size", secondBatch);
         assertThat(mapSink.count()).isEqualTo(secondBatch);
+
+        //source acquires lock again.
+        // If SOURCE is connection starter, it will send queryLeadership msg to SINK and
+        // replicate data. Otherwise, the SINK will send queryLeadership after getting a leadershipLoss msg from SOURCE.
+        // The SOURCE will then replicate via the reverseReplicate rpc.
+        try (TxnContext txnContext = sourceCorfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+            LockDataTypes.LockData oldLockData = LockDataTypes.LockData.newBuilder().mergeFrom(record.getPayload()).build();
+            txnContext.putRecord(sourceLockTable, lockId,
+                    LockDataTypes.LockData.newBuilder().mergeFrom(oldLockData)
+                            .setLeaseAcquisitionNumber(oldLockData.getLeaseAcquisitionNumber() + 1)
+                            .setLeaseRenewalNumber(oldLockData.getLeaseRenewalNumber() + 1).build(), null);
+            txnContext.commit();
+        }
+
+        Assert.assertEquals(1, sourceLockTable.count());
+        log.info("Source's lock table has a lock entry");
+
+        // Wait until the third batch is replicated to sink
+        waitForReplication(size -> size == thirdBatch, mapSink, thirdBatch);
+
+        // Sink map should now have the third batch size
+        log.info("Sink map now has {} size", thirdBatch);
+        assertThat(mapSink.count()).isEqualTo(thirdBatch);
+
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -1642,11 +1642,11 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 .setLockGroup(lockGroup)
                 .setLockName(lockName)
                 .build();
-        CorfuStoreEntry record;
+        CorfuStoreEntry lockTableRecord;
 
         // Release Source's lock by deleting the lock table
         try (TxnContext txnContext = sourceCorfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            record = txnContext.getRecord(sourceLockTable, lockId);
+            lockTableRecord = txnContext.getRecord(sourceLockTable, lockId);
             txnContext.clear(sourceLockTable);
             txnContext.commit();
         }
@@ -1678,7 +1678,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         // replicate data. Otherwise, the SINK will send queryLeadership after getting a leadershipLoss msg from SOURCE.
         // The SOURCE will then replicate via the reverseReplicate rpc.
         try (TxnContext txnContext = sourceCorfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            LockDataTypes.LockData oldLockData = LockDataTypes.LockData.newBuilder().mergeFrom(record.getPayload()).build();
+            LockDataTypes.LockData oldLockData = LockDataTypes.LockData.newBuilder().mergeFrom(lockTableRecord.getPayload()).build();
             txnContext.putRecord(sourceLockTable, lockId,
                     LockDataTypes.LockData.newBuilder().mergeFrom(oldLockData)
                             .setLeaseAcquisitionNumber(oldLockData.getLeaseAcquisitionNumber() + 1)

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -85,6 +85,7 @@ import static org.mockito.Mockito.spy;
  * Simple test that inserts data into CorfuStore via a separate server process
  */
 @Slf4j
+@SuppressWarnings("checkstyle:magicnumber")
 public class CorfuStoreIT extends AbstractIT {
 
     private static String corfuSingleNodeHost;


### PR DESCRIPTION
Bug fixes: 
- Leadership_loss msg when Source, a connection endpoint, looses leadership
- Do not stop the server when leadership changes.
- Check the value of logicalGroup in the proto msgs to identify streamsToReplicate for LogicalGroup usecase

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
