### PR TITLE
Fix Flaky BatchProcessorTest::testRestart

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -1,8 +1,8 @@
 package org.corfudb.infrastructure;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.TextFormat;
-import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.infrastructure.BatchWriterOperation.Type;
@@ -23,10 +23,8 @@ import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
 import org.corfudb.runtime.view.Layout;
 
 import javax.annotation.Nonnull;
-import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -71,18 +69,13 @@ public class BatchProcessor implements AutoCloseable {
      * @param sync      If true, the batch writer will sync writes to secondary storage
      */
     public BatchProcessor(StreamLog streamLog, BatchProcessorContext context, long sealEpoch, boolean sync) {
-        this(new LinkedBlockingQueue<>(), streamLog, context, sealEpoch, sync);
-    }
-
-    public BatchProcessor(BlockingQueue<BatchWriterOperation<?>> operationsQueue, StreamLog streamLog,
-                          BatchProcessorContext context, long sealEpoch, boolean sync) {
         this.sealEpoch = sealEpoch;
         this.sync = sync;
         this.streamLog = streamLog;
         this.context = context;
 
         BATCH_SIZE = 50;
-        this.operationsQueue = operationsQueue;
+        this.operationsQueue = new LinkedBlockingQueue<>();
 
         processorService = newExecutorService();
         processorService.submit(this::process);
@@ -99,14 +92,6 @@ public class BatchProcessor implements AutoCloseable {
                 .build();
 
         return Executors.newSingleThreadExecutor(threadFactory);
-    }
-
-    private void recordRunnable(Runnable runnable, Optional<Timer> timer) {
-        if (timer.isPresent()) {
-            timer.get().record(runnable);
-        } else {
-            runnable.run();
-        }
     }
 
     /**
@@ -276,11 +261,13 @@ public class BatchProcessor implements AutoCloseable {
     public static class BatchProcessorContext {
         private final AtomicReference<BatchProcessorStatus> status = new AtomicReference<>(BatchProcessorStatus.BP_STATUS_OK);
 
-        private void setErrorStatus() {
+        @VisibleForTesting
+        void setErrorStatus() {
             status.set(BatchProcessorStatus.BP_STATUS_ERROR);
         }
 
-        public void setOkStatus() {
+        @VisibleForTesting
+        void setOkStatus() {
             status.set(BatchProcessorStatus.BP_STATUS_OK);
         }
 


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: Fixes a race condition in the BatchProcessorTest::testRestart unit test.

Related issue(s) (if applicable): #3669 


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
