### PR TITLE
Fix: Status query could come from Sink side

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -170,6 +170,11 @@ public class LogReplicationMetadataManager {
         txnContext.clear(txnContext.getTable(REPLICATION_EVENT_TABLE_NAME));
     }
 
+    /**
+     * Initialize LogReplicationStatus table. Note that it is required to initialize those fields explicitly instead
+     * of relying on the default value, as some clients of log replicator v1 consume the status table with hasField
+     * check.
+     */
     private void initializeMetadata(TxnContext txn, LogReplicationSession session, boolean incomingSession,
                                     long topologyConfigId) {
         if (incomingSession) {


### PR DESCRIPTION
## Overview

Description:
Some of our clients will query replication status from Sink side and `SnapshotSyncInfo` field will be consumed. We need to setup that field to avoid regression of FULL_TABLE use case 


Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
