### PR TITLE
Request Snapshot Sync Data from Routing Queues Client After Negotiation.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationClientConfigListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationClientConfigListener.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.infrastructure.logreplication.utils.SnapshotSyncUtils;
 import org.corfudb.runtime.CorfuStoreMetadata;
@@ -178,7 +179,8 @@ public class LogReplicationClientConfigListener extends StreamListenerResumeOrFu
             if (impactedSessions != null) {
                 log.info("Sessions that a forced snapshot sync will be triggered: {}", impactedSessions);
                 impactedSessions.forEach(session -> {
-                    SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore);
+                    SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
+                            LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
                 });
             }
         }
@@ -213,7 +215,8 @@ public class LogReplicationClientConfigListener extends StreamListenerResumeOrFu
         CorfuStoreMetadata.Timestamp timestamp = configManager.onClientListenerResume();
         configManager.generateConfig(sessionManager.getSessions());
         sessionManager.getSessions().forEach(session -> {
-            SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore);
+            SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
+                    LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
         });
         return timestamp;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -2,13 +2,16 @@ package org.corfudb.infrastructure.logreplication.runtime.fsm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationNegotiationException;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientServerRouter;
+import org.corfudb.infrastructure.logreplication.utils.SnapshotSyncUtils;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
+import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.view.Address;
 
@@ -209,8 +212,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
          */
         if (negotiationResponse.getSnapshotStart() == Address.NON_ADDRESS) {
             log.info("No snapshot available in remote. Initiate SNAPSHOT sync to {}", fsm.getSession());
-            fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
-                    new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
+            startSnapshotSync();
             return;
         }
 
@@ -228,8 +230,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
         if (negotiationResponse.getSnapshotStart() > negotiationResponse.getSnapshotTransferred()) {
             log.info("Previous Snapshot Sync transfer did not complete. Restart SNAPSHOT sync, snapshotStart={}, snapshotTransferred={}",
                     negotiationResponse.getSnapshotStart(), negotiationResponse.getSnapshotTransferred());
-            fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
-                    new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
+            startSnapshotSync();
             return;
         }
 
@@ -294,8 +295,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 //  in the the transaction stream.
                 log.info(" Start SNAPSHOT sync. LOG ENTRY Sync cannot resume, address space has been trimmed." +
                         "logHead={}, lastLogProcessed={}", logHead, negotiationResponse.getLastLogEntryTimestamp());
-                fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
-                        new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
+                startSnapshotSync();
             }
 
             return;
@@ -310,5 +310,15 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 negotiationResponse);
         fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                 new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
+    }
+
+    private void startSnapshotSync() {
+        // If Routing Queue Replication Model, request LR Client to provide full sync data
+        if (fsm.getSession().getSubscriber().getModel() == LogReplication.ReplicationModel.ROUTING_QUEUES) {
+            SnapshotSyncUtils.enforceSnapshotSync(fsm.getSession(), new CorfuStore(metadataManager.getRuntime()),
+                LogReplicationMetadata.ReplicationEvent.ReplicationEventType.RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC);
+        }
+        fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
+            new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
@@ -46,7 +46,8 @@ public final class SnapshotSyncUtils {
      * @param session Session for which the snapshot sync will be enforced.
      * @param corfuStore Caller of this method should provide a corfuStore instance for executing the transaction.
      */
-    public static void enforceSnapshotSync(LogReplicationSession session, CorfuStore corfuStore) {
+    public static void enforceSnapshotSync(LogReplicationSession session, CorfuStore corfuStore,
+                                           ReplicationEventType eventType) {
         UUID forceSyncId = UUID.randomUUID();
 
         log.info("Forced snapshot sync will be triggered because of group destination change, session={}, sync_id={}",
@@ -59,7 +60,7 @@ public final class SnapshotSyncUtils {
 
         ReplicationEvent event = ReplicationEvent.newBuilder()
                 .setEventId(forceSyncId.toString())
-                .setType(ReplicationEventType.FORCE_SNAPSHOT_SYNC)
+                .setType(eventType)
                 .setEventTimestamp(Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build())
                 .build();
 


### PR DESCRIPTION
## Overview

Description:
Snapshot Sync Data for Routing Queues Replication Model is computed by the Client and provided to LR.  On determining the need for a snapshot sync, LR must request for this data through the event table.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
