### PR TITLE
Add logging fixes for compactor

### DIFF
--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -289,7 +289,8 @@ class CompactorRunner(object):
                     return
             cmd = self._command_builder.get_corfu_compactor_cmd(compactor_config, class_to_invoke)
             self._print_and_log("Start compacting. Command %s" % cmd)
-            check_call(cmd, shell=True)
+            with open(corfu_paths["CompactorLogfile"], 'a') as f:
+                check_call(cmd, stdout=f, stderr=f, shell=True)
             self._print_and_log("Finished running corfu compactor tool.")
 
         except Exception as ex:


### PR DESCRIPTION
1. On OutOfMemory or other errors, check_call method logs to the shell. Capture those logs in the compactor audit logfile.
2. When the leader marks the checkpoint status of a table as FAILED, retain the client that was responsible for checkpointing the table.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
