### PR TITLE
Start Event Listener on Receiving a Topology Change Where Local is Source and Leader

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -59,10 +59,6 @@ public final class LogReplicationEventListener implements StreamListener {
 
         // If the current node is not a leader, ignore the notifications.
         synchronized (discoveryService) {
-            if (!discoveryService.getSessionManager().getReplicationContext().getIsLeader().get()) {
-                log.info("onNext[{}] :: skipped as current node is not the leader", results.getTimestamp());
-                return;
-            }
 
             log.info("onNext[{}] :: processing updates for tables {}", results.getTimestamp(),
                     results.getEntries().keySet().stream().map(TableSchema::getTableName).collect(Collectors.toList()));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -57,40 +57,35 @@ public final class LogReplicationEventListener implements StreamListener {
     @Override
     public void onNext(CorfuStreamEntries results) {
 
-        // If the current node is not a leader, ignore the notifications.
-        synchronized (discoveryService) {
+        log.info("onNext[{}] :: processing updates for tables {}", results.getTimestamp(),
+            results.getEntries().keySet().stream().map(TableSchema::getTableName).collect(Collectors.toList()));
 
-            log.info("onNext[{}] :: processing updates for tables {}", results.getTimestamp(),
-                    results.getEntries().keySet().stream().map(TableSchema::getTableName).collect(Collectors.toList()));
-
-            // If the current node is the leader, it generates a discovery event and puts it into the discovery
-            // service event queue.
-            for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {
-                for (CorfuStreamEntry entry : entryList) {
-                    if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
-                        log.warn("LREventListener ignoring a CLEAR operation");
-                        continue;
-                    }
-                    ReplicationEventInfoKey key = (ReplicationEventInfoKey) entry.getKey();
-                    ReplicationEvent event = (ReplicationEvent) entry.getPayload();
-                    log.info("Received event :: id={}, type={}, session={}, ts={}", event.getEventId(), event.getType(),
-                            key.getSession(), event.getEventTimestamp());
-                    if (event.getType().equals(ReplicationEventType.FORCE_SNAPSHOT_SYNC)) {
-                        discoveryService.input(new DiscoveryServiceEvent(DiscoveryServiceEventType.ENFORCE_SNAPSHOT_SYNC,
-                            key.getSession(), event.getEventId()));
-                    } else if (event.getType().equals(ReplicationEventType.UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC)) {
-                        // Note: This block will not get executed in the first version of LRv2 because in this version,
-                        // LR does not start until all nodes in the cluster are on the same version.  So the event to
-                        // trigger a forced snapshot sync will not be received as an update on the listener.
-                        // Instead, it will be read on startup in processPendingRequests().
-                        // In later versions of LRv2, the Log Replication process will run even when nodes are on
-                        // different versions.  At that time, this event will be processed as an update from this
-                        // block.
-                        triggerForcedSnapshotSyncForAllSessions(event);
-                    } else {
-                        log.warn("Received invalid event :: id={}, type={}, cluster_id={} ts={}", event.getEventId(),
-                            event.getType(), event.getClusterId(), event.getEventTimestamp());
-                    }
+        // Generate a discovery event and put it into the discovery service event queue.
+        for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {
+            for (CorfuStreamEntry entry : entryList) {
+                if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
+                    log.warn("LREventListener ignoring a CLEAR operation");
+                    continue;
+                }
+                ReplicationEventInfoKey key = (ReplicationEventInfoKey) entry.getKey();
+                ReplicationEvent event = (ReplicationEvent) entry.getPayload();
+                log.info("Received event :: id={}, type={}, session={}, ts={}", event.getEventId(), event.getType(),
+                    key.getSession(), event.getEventTimestamp());
+                if (event.getType().equals(ReplicationEventType.FORCE_SNAPSHOT_SYNC)) {
+                    discoveryService.input(new DiscoveryServiceEvent(DiscoveryServiceEventType.ENFORCE_SNAPSHOT_SYNC,
+                        key.getSession(), event.getEventId()));
+                } else if (event.getType().equals(ReplicationEventType.UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC)) {
+                    // Note: This block will not get executed in the first version of LRv2 because in this version,
+                    // LR does not start until all nodes in the cluster are on the same version.  So the event to
+                    // trigger a forced snapshot sync will not be received as an update on the listener.
+                    // Instead, it will be read on startup in processPendingRequests().
+                    // In later versions of LRv2, the Log Replication process will run even when nodes are on
+                    // different versions.  At that time, this event will be processed as an update from this
+                    // block.
+                    triggerForcedSnapshotSyncForAllSessions(event);
+                } else {
+                    log.warn("Received invalid event :: id={}, type={}, cluster_id={} ts={}", event.getEventId(),
+                        event.getType(), event.getClusterId(), event.getEventTimestamp());
                 }
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -228,6 +228,16 @@ public class SessionManager {
             log.error("Unrecoverable exception while refreshing sessions", e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
+
+        // When a node acquires the lock, check if all the sessions present in the system tables are still valid.
+        // Since the metadata table is written to only by the leader node, we can run into the scenario where
+        // leadership was acquired after processing a topology change.
+        // On acquiring leadership, stale sessions will not get removed from the metadata table as the in-memory copy
+        // of sessions have already been updated.
+        // Therefore, iterate over the sessions in the system tables and remove the stale sessions if any.
+        if (replicationContext.getIsLeader().get()) {
+            removeStaleSessionOnLeadershipAcquire();
+        }
     }
 
     /**
@@ -406,16 +416,7 @@ public class SessionManager {
                 .build();
     }
 
-    /**
-     * When a node acquires the lock, check if all the sessions present in the system tables are still valid.
-     *
-     * Since the metadata table is written to only by the leader node, we can run into the scenario where the leader node
-     * missed updating the system table because the leadership changed at that precise moment.
-     * If the new leader node had already received the topology change notification before becoming the leader, the stale
-     * sessions would not be recognized on "refresh".
-     * Therefore, iterate over the sessions in the system tables and remove the stale sessions if any.
-     */
-    public void removeStaleSessionOnLeadershipAcquire() {
+    private void removeStaleSessionOnLeadershipAcquire() {
         try {
             IRetry.build(IntervalRetry.class, () -> {
                 try (TxnContext txn = metadataManager.getTxnContext()) {


### PR DESCRIPTION
If a topology change is received where the Local cluster becomes a Source and is a leader, start the event listener.  Also consolidated the code in this part a bit.

## Overview

Description:

Why should this be merged:  Bug Fix 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
