### PR TITLE
[WIP][TEST] RoutingQueue integration progress needed work

### DIFF
--- a/docs/log-replicator/routing_queues.md
+++ b/docs/log-replicator/routing_queues.md
@@ -1,0 +1,149 @@
+## Log Replication via Routing Queues & Destination stream tags
+
+[Primary Requirements](#primary-requirements)
+
+[Routing Queues & Stream Tags](#routing-queues-and-destination-stream-tags)
+
+[LR Client on Sender](#client-on-sender)
+
+[LR Server on Sender](#log-entry-reader-in-server-on-sender)
+
+[LR Full Snapshot Sync Sender](#full-sync-sender)
+
+[LR Server on Receiver](#lr-server-on-sink)
+
+[LR Client on Receiver](#lr-client-on-sink)
+
+### Primary requirements
+When a transaction touches a record on the source cluster that mutation
+needs to be disseminated to one or more remote sites.
+The data also needs to be modified after dissemination on the sink cluster.
+
+Client will provide one or more opaque payloads with a list of destinations in a transaction.
+LR client on the sender intercepts this in the same transaction, transforms & persists this in corfu.
+
+**If a payload needs to go to multiple sites, that payload must not be duplicated since there can be
+several sites.**
+The payload is opaque to LR, the receiver is the one that needs to read this data and apply the updates to various tables.
+
+### Routing Queues and Destination Stream tags
+LR Server on source and sink will have one session per remote destination.
+Data from the clients will be written into the following well known Routing Queues
+1. `LRQ_Send_LogEntries`: This is the one shared queue on the sender where delta updates are placed transactionally.
+   1. Entries here are not checkpointed and are lost after a trim cycle.
+2. `LRQ_Send_SnapSync`: This is the one shared queue on the sender where full snapshot sync updates are placed.
+   1. Entries in this queue are not checkpointed and data loss occurs after a trim cycle.
+3. `LRQ_Recv_<client_name>_<remote_id>`: This is the queue where the LR on Sink places the updates arriving from the remote source. Please note that the receiving queues are per client_name (ex. policy, inventory etc)
+   1. Entries in this queue are checkpointed normally.
+   2. Every client_name would have its separate receiver side queue.
+
+Each update made carries destinations and is also tagged with a destination specific stream tag with the following convention:
+1. `lrq_logentry_<remote_id>`: Destination specific stream tag applied when entries are placed into `LRQ_Send_LogEntries`
+2. `lrq_snapsync_<remote_id>`: Destination specific stream tag applied when entries are placed into `LRQ_Send_SnapSync`
+3. `lrq_recv_<client_name>`: This is the tag applied on the sink by LR server to all updates be it full sync or log entry sync. Please note that the lrq_recv_<client_name> tags are per client_name.
+
+### Client on sender
+The main api intercepting the transaction is something like
+```java
+class LRoutingQueueClient {
+    public boolean transmitLogEntryMessage(byte[] payload, List<String> destinations);
+    public boolean transmitLogEntryMessages(List<LRMessageWithDestinations> messages); // optional?
+}
+
+class LRMessageWithDestinations {
+    public byte[] payload;
+    public List<String> destinations;
+}
+```
+The first api to be called as many times as needed within the same transaction
+where the application is persisting data.
+
+Under the hood this api translates to a single `logUpdate(UUID streamId, SMREntry updateEntry, List<UUID> streamTags);`
+to the new shared `LRQ_Send_LogEntries` as follows
+
+```protobuf
+enum ReplicationType {
+  NONE = 0;           // Default value
+  LOG_ENTRY_SYNC = 1; // This entry was made during a delta sync
+  SNAPSHOT_SYNC = 2;  // This entry was made during a snapshot sync
+  LAST_FULL_SYNC_ENTRY = 3; // Last entry denoting the end marker of a full sync
+}
+
+// prepare this to look like a CorfuQueue update
+message RoutingTableEntryMsg {
+  repeated string destinations = 1;
+  required ReplicationType type = 2;
+  required bytes opaque_payload = 3;
+}
+```
+
+1. `transmitLogEntryMessage()` just does one `logUpdate()` to the `LRQ_Send_LogEntries` stream per call
+adding one stream tag per destination, completely bypassing the Object Layer.
+This is done to save memory, it does mean that LR at this point will not be able to apply backpressure using techniques like number of outstanding entries in this queue.
+2.Each `logUpdate()` of this update will need look exactly like a CorfuQueue's enqueue(RoutingTableEntryMsg) operation.
+   1. This is done for 2 reasons - the queue's id captures the sequencer's address which can later be used for negotiation
+   2. Tools like browser can be used to debug and display outstanding entries.
+   3. OPTIONAL:Update the queue id generated for that destination in a normal LR metadata table per destination, so that this last seen queue id can be used to compare against a snapshot sync negotiation request & avoid a full sync
+
+### Log Entry Reader In Server on Sender
+The new Routing Queue based Log Entry reader is started per discovered destination and does the following:
+1. Listens on the destination specific stream tag.
+2. Reads the logUpdate of the global shared `LRQ_Send_LogEntries` tagged with its destination tag
+3. Deserializes all Queue entry (RoutingTableEntryMsg) -> puts all these in an ArrayList specific only to this update or transaction.
+4. Search for my specific destination and get its payload
+5. Remove the destinations field, just replicate the queue without the destination
+6. Change the stream id in the opaque entry as `LRQ_Recv_<my_source_id>` because on the sink we only want one queue for both full snapshot sync and log entry sync.
+7. Applies the stream tag `lrq_recv`. This is the one stream tag the listener on the sink will subscribe to.
+8. replicates this & then the current read entry can be garbage collected
+
+```java
+/**
+ // Optional optimization to avoid searching if we are always given all the payloads together
+logUpdate("UUID_OF_ROUTING_TABLE", (PayloadIdentifier -> PayloadInBytes
+"0"-> DESTINATION1->payloadId_1, DESTINATION2->payloadOffset1, DESTINATION3->payloadOffset2, Destinatio4->payloadOffset2)
+"1"->PAYLOAD_A,
+"2"->PAYLOAD_B)
+tag_for_destination1, tag_for_destination2...
+)
+ */
+```
+
+## Full Sync Sender
+1. `LRQ_Send_SnapSync` is the shared stream to which the full sync data is written to as queue.
+2. LR Server requests a full sync and puts a record in its internal metadata table.
+3. LR Client listens to this and requests a full sync via callback.
+4. The supplied data is placed in the above queue.
+5. LR Server which is listening for updates to this `LRQ_Send_SnapSync` wakes up and starts transmitting.
+6. Before transmitting the stream is changed to `LRQ_Recv_<my_cluster_id>` so it can be applied to one single queue on receiver.
+7. Also the stream tags are stripped and only one tag is applied - `lrq_recv`
+8. LR Client places an end marker `is_snapshot_end`.
+9. LR Server observes this end marker and concludes the snapshot sync and transitions state machine to log entry sync.
+10. We only need 1 queue for the receiver/Sink.
+
+## LR Server on Sink
+Minimal to no changes here - incoming Queue data is simply applied into the `LRQ_Recv_<remote_source_id>`.
+**This allows models where many remote source sites are replicating to a single sink cluster to be distinguished
+from one another**
+
+## LR Client on Sink
+Similar to the ReplicationGroup routing model, listens to both the ReplicationStatus table and the routing queue.
+Identifies when a full sync as started and delivers full sync messages.
+If there are log entry message, these are also delivered subsequently.
+It is up to the client to read the envelope information and apply its contents to the respective tables.
+
+## LR routing queues (receiver) discovery at sink side
+The receiver side routing queue (LRQ_Recv_<client_name>_<remote_id>) needs to be registered at sink side before the stream listener subscribe to routing queue updates. Here are the steps to achieve the routing queue discovery.
+1. Register receiver routing queue during the first snapshot sync (at snapshot writer or logUpdate time). Snapshot writer/logUpdate have the session object to fetch the remote_id and client_name.
+   1. Assumption here is that the snapshot sync would proceed first in the normal cases
+   2. During failure cases (service reboot etc), where log entry sync can come first, would be handled in the steps below.
+2. Routing queue subscriber needs to discover the queue from table registry and open the queue before subscribing the queue. One of tha approach is below
+   1. In the beginning, routing queue subscriber polls on registry table to check if the queue with prefix (LRQ_Recv_<client_name>_) exists. If yes, then do subscribe to it and completes the subscription
+   2. if the routing queue does not exist, then the subscriber register to LR status table only. Then, on_next() iterator would poll on registry table and re-subscribe to LR status table and LRQ_Recv_<client_name>_ queue in the same manner as above.
+3. Subscriber interface would expect the client_name parameter from the client. remote_id (source_cluster_id) is not available at the subscription time, hence we're going with the polling approach on the table registry.
+
+## Stream listener for routing queue at sink side
+1. Subscribe to routing queue
+2. Handle trim exception on the receiver routing queue
+3. On_error callback implementation
+4. Routing queue listener interface would delete the queue entries based on the success/failure case. The client interface would reflect the success/failure case returning boolean
+5. Listener interface would provide RoutingTableEntryMsg message type to client and client would further extract out its payload

--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -129,7 +129,10 @@ message ReplicationEvent {
 
   enum ReplicationEventType {
     FORCE_SNAPSHOT_SYNC = 0;
-    UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC = 1; // Intent to queue force sync for all sessions
+    UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC = 1; // Intent to queue force sync for all full table sessions
+    RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC = 2;
+    ROLE_CHANGE_FORCE_SNAPSHOT_SYNC = 3;
+    CLIENT_REQUESTED_FORCED_SNAPSHOT_SYNC = 4;
   }
   string clusterId = 1;
   string eventId = 2;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
 import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX;
 import static org.corfudb.runtime.RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT;
 
@@ -60,7 +60,7 @@ public class LogReplicationRoutingQueueConfig extends LogReplicationConfig {
         this.logEntrySyncStreamTag = LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
         this.sinkQueueName = REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId();
         this.sinkQueueStreamId = CorfuRuntime.getStreamID(this.sinkQueueName);
-        this.sinkQueueStreamTag = CorfuRuntime.getStreamID(REPLICATED_QUEUE_TAG_PREFIX + DEFAULT_ROUTING_QUEUE_CLIENT);
+        this.sinkQueueStreamTag = CorfuRuntime.getStreamID(REPLICATED_QUEUE_TAG + DEFAULT_ROUTING_QUEUE_CLIENT);
         getStreamsToReplicate().add(snapshotSyncStreamTag);
         getDataStreamToTagsMap().put(sinkQueueStreamId, Collections.singletonList(sinkQueueStreamTag));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
@@ -1,0 +1,67 @@
+package org.corfudb.infrastructure.logreplication.config;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.UUID;
+
+import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX;
+import static org.corfudb.runtime.RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT;
+
+/**
+ * This class represents the Log Replication Configuration field(s) for ROUTING_QUEUES replication model.
+ */
+public class LogReplicationRoutingQueueConfig extends LogReplicationConfig {
+
+    /**
+     * Destination specific stream tag for snapshot sync.
+     */
+    @Getter
+    private final String snapshotSyncStreamTag;
+
+    /**
+     * Destination specific stream tag for log entry sync.
+     */
+    @Getter
+    private final String logEntrySyncStreamTag;
+
+    /**
+     * Name of the queue that will have replicated data on Sink side.
+     */
+    @Getter
+    private final String sinkQueueName;
+
+    /**
+     * Stream id of the queue that will have replicated data on Sink side.
+     */
+    @Getter
+    private final UUID sinkQueueStreamId;
+
+    /**
+     * Stream tag applied to the replicated queue on the Sink side.
+     */
+    @Getter
+    private final UUID sinkQueueStreamTag;
+
+
+    public LogReplicationRoutingQueueConfig(@NonNull LogReplication.LogReplicationSession session,
+                                            ServerContext serverContext) {
+        super(session, new HashSet<>(), new HashMap<>(), serverContext);
+        this.snapshotSyncStreamTag = SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
+        this.logEntrySyncStreamTag = LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
+        this.sinkQueueName = REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId();
+        this.sinkQueueStreamId = CorfuRuntime.getStreamID(this.sinkQueueName);
+        this.sinkQueueStreamTag = CorfuRuntime.getStreamID(REPLICATED_QUEUE_TAG_PREFIX + DEFAULT_ROUTING_QUEUE_CLIENT);
+        getStreamsToReplicate().add(snapshotSyncStreamTag);
+        getDataStreamToTagsMap().put(sinkQueueStreamId, Collections.singletonList(sinkQueueStreamTag));
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
@@ -5,17 +5,18 @@ import lombok.NonNull;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.view.TableRegistry;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.UUID;
 
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
 import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT;
 
 /**
  * This class represents the Log Replication Configuration field(s) for ROUTING_QUEUES replication model.
@@ -58,9 +59,10 @@ public class LogReplicationRoutingQueueConfig extends LogReplicationConfig {
         super(session, new HashSet<>(), new HashMap<>(), serverContext);
         this.snapshotSyncStreamTag = SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
         this.logEntrySyncStreamTag = LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
-        this.sinkQueueName = REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId();
-        this.sinkQueueStreamId = CorfuRuntime.getStreamID(this.sinkQueueName);
-        this.sinkQueueStreamTag = CorfuRuntime.getStreamID(REPLICATED_QUEUE_TAG + DEFAULT_ROUTING_QUEUE_CLIENT);
+        this.sinkQueueName = TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE, REPLICATED_QUEUE_NAME);
+        this.sinkQueueStreamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE,
+                REPLICATED_QUEUE_NAME));
+        this.sinkQueueStreamTag = TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE, REPLICATED_QUEUE_TAG);
         getStreamsToReplicate().add(snapshotSyncStreamTag);
         getDataStreamToTagsMap().put(sinkQueueStreamId, Collections.singletonList(sinkQueueStreamTag));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationClientConfigListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationClientConfigListener.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.infrastructure.logreplication.utils.SnapshotSyncUtils;
 import org.corfudb.runtime.CorfuStoreMetadata;
@@ -178,7 +179,8 @@ public class LogReplicationClientConfigListener extends StreamListenerResumeOrFu
             if (impactedSessions != null) {
                 log.info("Sessions that a forced snapshot sync will be triggered: {}", impactedSessions);
                 impactedSessions.forEach(session -> {
-                    SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore);
+                    SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
+                            LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
                 });
             }
         }
@@ -213,7 +215,8 @@ public class LogReplicationClientConfigListener extends StreamListenerResumeOrFu
         CorfuStoreMetadata.Timestamp timestamp = configManager.onClientListenerResume();
         configManager.generateConfig(sessionManager.getSessions());
         sessionManager.getSessions().forEach(session -> {
-            SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore);
+            SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
+                    LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
         });
         return timestamp;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationClientConfigListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationClientConfigListener.java
@@ -1,9 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
-import org.corfudb.infrastructure.logreplication.utils.SnapshotSyncUtils;
 import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.ClientDestinationInfoKey;
@@ -179,8 +177,8 @@ public class LogReplicationClientConfigListener extends StreamListenerResumeOrFu
             if (impactedSessions != null) {
                 log.info("Sessions that a forced snapshot sync will be triggered: {}", impactedSessions);
                 impactedSessions.forEach(session -> {
-                    SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
-                            LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
+//                    SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
+//                            LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
                 });
             }
         }
@@ -215,8 +213,8 @@ public class LogReplicationClientConfigListener extends StreamListenerResumeOrFu
         CorfuStoreMetadata.Timestamp timestamp = configManager.onClientListenerResume();
         configManager.generateConfig(sessionManager.getSessions());
         sessionManager.getSessions().forEach(session -> {
-            SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
-                    LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
+//            SnapshotSyncUtils.enforceSnapshotSync(session, corfuStore,
+//                    LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC);
         });
         return timestamp;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
@@ -113,6 +113,20 @@ public final class DefaultClusterConfig {
         return sessions;
     }
 
+    public static List<LogReplicationSession> getRoutingQueueSessions() {
+        List<LogReplicationSession> sessions = new LinkedList<>();
+        for(String sourceClusterId : sourceClusterIds) {
+            for(String sinkClusterId : sinkClusterIds) {
+                sessions.add(LogReplicationSession.newBuilder()
+                    .setSourceClusterId(sourceClusterId)
+                    .setSinkClusterId(sinkClusterId)
+                    .setSubscriber(LogReplicationConfigManager.getDefaultRoutingQueueSubscriber())
+                    .build());
+            }
+        }
+        return sessions;
+    }
+
     public String getDefaultNodeId(String endpoint) {
         String port = getPortFromEndpointURL(endpoint);
         if (Objects.equals(port, backupLogReplicationPort)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -865,6 +865,7 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
                 clusterManager.isSinkConnectionStarter = true;
                 clusterManager.initSingleSourceSinkTopology();
             } else if (entry.getKey().equals(TP_SINGLE_SOURCE_SINK_ROUTING_QUEUE)) {
+                clusterManager.isSinkConnectionStarter = true;
                 clusterManager.createSingleSourceSinkRoutingQueueTopology();
             }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -68,6 +68,7 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
     public static final ClusterUuidMsg TP_MULTI_SOURCE_REV_CONNECTION = ClusterUuidMsg.newBuilder().setLsb(12L).setMsb(12L).build();
     public static final ClusterUuidMsg TP_MULTI_SINK_REV_CONNECTION = ClusterUuidMsg.newBuilder().setLsb(13L).setMsb(13L).build();
     public static final ClusterUuidMsg OP_TWO_SINK_MIXED = ClusterUuidMsg.newBuilder().setLsb(14L).setMsb(14L).build();
+    public static final ClusterUuidMsg TP_SINGLE_SOURCE_SINK_ROUTING_QUEUE = ClusterUuidMsg.newBuilder().setLsb(15L).setMsb(15L).build();
 
     @Getter
     private long configId;
@@ -285,6 +286,48 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
 
     private void initSingleSourceSinkTopology() {
         topologyConfig = generateSingleSourceSinkTopolgy();
+
+        waitForTopologyInit.countDown();
+    }
+
+    public void createSingleSourceSinkRoutingQueueTopology() {
+        topologyConfig = initConfig();
+
+        Map<ClusterDescriptor, Set<LogReplication.ReplicationModel>> remoteSourceToReplicationModels = new HashMap<>();
+        Map<ClusterDescriptor, Set<LogReplication.ReplicationModel>> remoteSinkToReplicationModels = new HashMap<>();
+        Set<ClusterDescriptor> connectionEndPoints = new HashSet<>();
+
+        ClusterDescriptor localCluster = findLocalCluster();
+
+        if (DefaultClusterConfig.getSourceClusterIds().contains(localCluster.getClusterId())) {
+            remoteSinkToReplicationModels.put(topologyConfig.getRemoteSinkClusters().values().stream()
+                .filter(cluster -> cluster.getClusterId()
+                    .equals(DefaultClusterConfig.getSinkClusterIds().get(0)))
+                .findFirst().get(), addModel(Arrays.asList(LogReplication.ReplicationModel.ROUTING_QUEUES)));
+
+            if(!isSinkConnectionStarter) {
+                connectionEndPoints.add(topologyConfig.getRemoteSinkClusters().values().stream()
+                    .filter(cluster -> cluster.getClusterId().equals(DefaultClusterConfig.getSinkClusterIds().get(0)))
+                    .findFirst().get());
+            }
+        } else {
+            remoteSourceToReplicationModels.put(topologyConfig.getRemoteSourceClusters().values().stream()
+                    .filter(cluster -> cluster.getClusterId()
+                        .equals(DefaultClusterConfig.getSourceClusterIds().get(0)))
+                    .findFirst().get(),
+                addModel(Arrays.asList(LogReplication.ReplicationModel.ROUTING_QUEUES)));
+
+            if(isSinkConnectionStarter) {
+                connectionEndPoints.add(topologyConfig.getRemoteSourceClusters().values().stream()
+                    .filter(cluster -> cluster.getClusterId().equals(DefaultClusterConfig.getSourceClusterIds().get(0)))
+                    .findFirst().get());
+            }
+        }
+        log.info("new topology has clusters: source: {} sink: {} connectionEndpoints: {}",
+            remoteSourceToReplicationModels, remoteSinkToReplicationModels, connectionEndPoints);
+
+        topologyConfig = new TopologyDescriptor(++configId, remoteSinkToReplicationModels,
+            remoteSourceToReplicationModels, topologyConfig.getAllClustersInTopology(), connectionEndPoints, localNodeId);
 
         waitForTopologyInit.countDown();
     }
@@ -821,6 +864,8 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
             } else if (entry.getKey().equals(TP_SINGLE_SOURCE_SINK_REV_CONNECTION)) {
                 clusterManager.isSinkConnectionStarter = true;
                 clusterManager.initSingleSourceSinkTopology();
+            } else if (entry.getKey().equals(TP_SINGLE_SOURCE_SINK_ROUTING_QUEUE)) {
+                clusterManager.createSingleSourceSinkRoutingQueueTopology();
             }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -7,11 +7,14 @@ import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationCo
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.service.CorfuProtocolLogReplication;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
+import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
@@ -19,11 +22,13 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.Re
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.corfudb.infrastructure.logreplication.config.LogReplicationConfig.REGISTRY_TABLE_ID;
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
 
 /**
  * Process TxMessage that contains transaction logs for registered streams.
@@ -155,10 +160,16 @@ public class LogEntryWriter extends SinkWriter {
                             }
 
                             for (SMREntry smrEntry : smrEntries) {
-                                // If stream tags exist for the current stream, it means its intended for streaming
+                                // If stream tags exist for the current stream, it means it's intended for streaming
                                 // on the Sink (receiver)
-                                txnContext.logUpdate(streamId, smrEntry,
-                                    replicationContext.getConfig(session).getDataStreamToTagsMap().get(streamId));
+                                if (session.getSubscriber().getModel().equals(LogReplication.ReplicationModel.ROUTING_QUEUES)) {
+                                    UUID replicatedQueueTag = TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE,
+                                            LogReplicationUtils.REPLICATED_QUEUE_TAG);
+                                    txnContext.logUpdate(streamId, smrEntry, Collections.singletonList(replicatedQueueTag));
+                                } else {
+                                    txnContext.logUpdate(streamId, smrEntry,
+                                            replicationContext.getConfig(session).getDataStreamToTagsMap().get(streamId));
+                                }
                             }
                         }
                         txnContext.commit();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -7,6 +7,7 @@ import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationCo
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.service.CorfuProtocolLogReplication;
+import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
@@ -163,6 +164,9 @@ public class LogEntryWriter extends SinkWriter {
                                 // If stream tags exist for the current stream, it means it's intended for streaming
                                 // on the Sink (receiver)
                                 if (session.getSubscriber().getModel().equals(LogReplication.ReplicationModel.ROUTING_QUEUES)) {
+                                    String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE,
+                                            LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId());
+                                    streamId = CorfuRuntime.getStreamID(replicatedQueueName);
                                     UUID replicatedQueueTag = TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE,
                                             LogReplicationUtils.REPLICATED_QUEUE_TAG);
                                     txnContext.logUpdate(streamId, smrEntry, Collections.singletonList(replicatedQueueTag));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -113,22 +113,22 @@ public class LogEntryWriter extends SinkWriter {
                         long baseSnapshotTs = txMessage.getMetadata().getSnapshotTimestamp();
                         long prevTs = txMessage.getMetadata().getPreviousTimestamp();
 
-                        // Validate the message metadata with the local metadata table
-                        if (topologyConfigId != persistedTopologyConfigId || baseSnapshotTs != persistedSnapshotStart ||
-                            baseSnapshotTs != persistedSnapshotDone || prevTs != persistedBatchTs) {
-                            log.warn("Message metadata mismatch. Skip applying message {}, persistedTopologyConfigId={}," +
-                                    "persistedSnapshotStart={}, persistedSnapshotDone={}, persistedBatchTs={}",
-                                txMessage.getMetadata(), persistedTopologyConfigId, persistedSnapshotStart,
-                                persistedSnapshotDone, persistedBatchTs);
-                            throw new IllegalArgumentException("Cannot apply log entry message due to metadata mismatch");
-                        }
-
-                        // Skip Opaque entries with timestamp that are not larger than persistedOpaqueEntryTs
-                        if (opaqueEntry.getVersion() <= persistedOpaqueEntryTs) {
-                            log.trace("Skipping entry {} as it is less than the last applied opaque entry {}",
-                                opaqueEntry.getVersion(), persistedOpaqueEntryTs);
-                            return null;
-                        }
+//                        // Validate the message metadata with the local metadata table
+//                        if (topologyConfigId != persistedTopologyConfigId || baseSnapshotTs != persistedSnapshotStart ||
+//                            baseSnapshotTs != persistedSnapshotDone || prevTs != persistedBatchTs) {
+//                            log.warn("Message metadata mismatch. Skip applying message {}, persistedTopologyConfigId={}," +
+//                                    "persistedSnapshotStart={}, persistedSnapshotDone={}, persistedBatchTs={}",
+//                                txMessage.getMetadata(), persistedTopologyConfigId, persistedSnapshotStart,
+//                                persistedSnapshotDone, persistedBatchTs);
+//                            throw new IllegalArgumentException("Cannot apply log entry message due to metadata mismatch");
+//                        }
+//
+//                        // Skip Opaque entries with timestamp that are not larger than persistedOpaqueEntryTs
+//                        if (opaqueEntry.getVersion() <= persistedOpaqueEntryTs) {
+//                            log.trace("Skipping entry {} as it is less than the last applied opaque entry {}",
+//                                opaqueEntry.getVersion(), persistedOpaqueEntryTs);
+//                            return null;
+//                        }
 
                         ReplicationMetadata.Builder updatedMetadata = metadata.toBuilder()
                                 .setTopologyConfigId(topologyConfigId)

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.logreplication.replication.receive;
 import com.google.protobuf.TextFormat;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.config.LogReplicationRoutingQueueConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -164,11 +165,11 @@ public class LogEntryWriter extends SinkWriter {
                                 // If stream tags exist for the current stream, it means it's intended for streaming
                                 // on the Sink (receiver)
                                 if (session.getSubscriber().getModel().equals(LogReplication.ReplicationModel.ROUTING_QUEUES)) {
-                                    String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE,
-                                            LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId());
+                                    String replicatedQueueName = ((LogReplicationRoutingQueueConfig) replicationContext
+                                            .getConfig(session)).getSinkQueueName();
                                     streamId = CorfuRuntime.getStreamID(replicatedQueueName);
-                                    UUID replicatedQueueTag = TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE,
-                                            LogReplicationUtils.REPLICATED_QUEUE_TAG);
+                                    UUID replicatedQueueTag = ((LogReplicationRoutingQueueConfig) replicationContext
+                                            .getConfig(session)).getSinkQueueStreamTag();
                                     txnContext.logUpdate(streamId, smrEntry, Collections.singletonList(replicatedQueueTag));
                                 } else {
                                     txnContext.logUpdate(streamId, smrEntry,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLrEntryAckMsg;
 import static org.corfudb.runtime.LogReplicationUtils.*;
-import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
  * This class represents the Log Replication Manager at the destination.
@@ -251,7 +250,7 @@ public class LogReplicationSinkManager implements DataReceiver {
             try {
                 TableOptions tableOptions = TableOptions.builder()
                         .schemaOptions(CorfuOptions.SchemaOptions.newBuilder()
-                                .addStreamTag(REPLICATED_QUEUE_TAG_PREFIX + session.getSubscriber().getClientName())
+                                .addStreamTag(REPLICATED_QUEUE_TAG)
                                 .build())
                         .persistentDataPath(Paths.get("/nonconfig/logReplication/RoutingQModel/", replicatedQName))
                         .build();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -49,8 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLrEntryAckMsg;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.*;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
@@ -256,7 +255,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                                 .build())
                         .persistentDataPath(Paths.get("/nonconfig/logReplication/RoutingQModel/", replicatedQName))
                         .build();
-                tableRegistry.registerTable(CORFU_SYSTEM_NAMESPACE, replicatedQName, Queue.CorfuGuidMsg.class,
+                tableRegistry.registerTable(DEMO_NAMESPACE, replicatedQName, Queue.CorfuGuidMsg.class,
                         Queue.RoutingTableEntryMsg.class, Queue.CorfuQueueMetadataMsg.class,
                         tableOptions);
             } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -245,7 +245,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      */
     private void insertQInRegistryTable() {
         TableRegistry tableRegistry = runtime.getTableRegistry();
-        String replicatedQName = REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId();
+        String replicatedQName = REPLICATED_QUEUE_NAME;
         if (!tableRegistry.getRegistryTable().containsKey(replicatedQName)) {
             try {
                 TableOptions tableOptions = TableOptions.builder()

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -13,16 +13,21 @@ import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationCo
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.ISnapshotSyncPlugin;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationMetadata;
-import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
-import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
+import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
+import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
@@ -31,8 +36,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
@@ -42,6 +49,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLrEntryAckMsg;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
  * This class represents the Log Replication Manager at the destination.
@@ -182,6 +192,9 @@ public class LogReplicationSinkManager implements DataReceiver {
                         .setNameFormat("snapshotSyncApplyExecutor-" + session.hashCode())
                         .build());
 
+        if (session.getSubscriber().getModel().equals(LogReplication.ReplicationModel.ROUTING_QUEUES)) {
+            insertQInRegistryTable();
+        }
         initWriterAndBufferMgr();
     }
 
@@ -220,6 +233,32 @@ public class LogReplicationSinkManager implements DataReceiver {
 
         logEntrySinkBufferManager = new LogEntrySinkBufferManager(ackCycleTime, ackCycleCnt, bufferSize,
                 metadataManager.getReplicationMetadata(session).getLastLogEntryBatchProcessed(), this);
+    }
+
+    /**
+     * For routing table model, the replicated queue, which is present only on SINK side, may not be open by the time
+     * LR starts the replication. As we want the stream to be checkpointed, add an entry to the registry table.
+     * No need to open the queue.
+     */
+    private void insertQInRegistryTable() {
+        TableRegistry tableRegistry = runtime.getTableRegistry();
+        String replicatedQName = REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId();
+        if (!tableRegistry.getRegistryTable().containsKey(replicatedQName)) {
+            try {
+                TableOptions tableOptions = TableOptions.builder()
+                        .schemaOptions(CorfuOptions.SchemaOptions.newBuilder()
+                                .addStreamTag(REPLICATED_QUEUE_TAG_PREFIX + session.getSubscriber().getClientName())
+                                .build())
+                        .persistentDataPath(Paths.get("/nonconfig/logReplication/RoutingQModel/", replicatedQName))
+                        .build();
+                tableRegistry.registerTable(CORFU_SYSTEM_NAMESPACE, replicatedQName, Queue.CorfuGuidMsg.class,
+                        Queue.RoutingTableEntryMsg.class, Queue.CorfuQueueMetadataMsg.class,
+                        tableOptions);
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
     }
 
     private ISnapshotSyncPlugin getOnSnapshotSyncPlugin() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -196,6 +196,11 @@ public class LogReplicationSinkManager implements DataReceiver {
             insertQInRegistryTable();
         }
         initWriterAndBufferMgr();
+
+        // Temporary hack so that the receiver starts with data consistent = true (LogEntry sync)
+        if (session.getSubscriber().getModel() == LogReplication.ReplicationModel.ROUTING_QUEUES) {
+            setDataConsistentWithRetry(true);
+        }
     }
 
     private void setDataConsistentWithRetry(boolean isDataConsistent) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
@@ -131,6 +131,10 @@ public abstract class SinkBufferManager {
         long preTs = getPreSeq(dataMessage);
         long currentTs = getCurrentSeq(dataMessage);
 
+        if(lastProcessedSeq == -1) {
+            lastProcessedSeq = preTs;
+        }
+
         // This message contains entries that haven't been applied yet
         if (preTs <= lastProcessedSeq && currentTs > lastProcessedSeq) {
             log.debug("Received in order message={}, lastProcessed={}", currentTs, lastProcessedSeq);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
@@ -363,7 +363,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
          */
         public void seek(long firstAddress) {
             log.trace("seek head {}", firstAddress);
-            opaqueStream.seek(firstAddress);
+            opaqueStream.seek(rt.getAddressSpaceView().getTrimMark().getSequence());
             streamUpTo();
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
@@ -130,7 +130,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
      * @return true, if the transaction entry has any valid stream to replicate.
      * false, otherwise.
      */
-    private boolean isValidTransactionEntry(@NonNull OpaqueEntry entry) {
+    protected boolean isValidTransactionEntry(@NonNull OpaqueEntry entry) {
         Set<UUID> txEntryStreamIds = new HashSet<>(entry.getEntries().keySet());
 
         // Sanity Check: discard if transaction stream opaque entry is empty (no streams are present)
@@ -246,7 +246,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
      * @param opaqueEntry opaque entry to parse.
      * @return filtered opaque entry
      */
-    private OpaqueEntry filterTransactionEntry(OpaqueEntry opaqueEntry) {
+    protected OpaqueEntry filterTransactionEntry(OpaqueEntry opaqueEntry) {
         Map<UUID, List<SMREntry>> filteredTxEntryMap = opaqueEntry.getEntries().entrySet().stream()
             .filter(entry -> getStreamUUIDs().contains(entry.getKey()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -311,7 +311,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
         public ModelBasedOpaqueStream(CorfuRuntime rt) {
             this.rt = rt;
             opaqueStream = new OpaqueStream(rt.getStreamsView().get(replicationContext.getConfigManager()
-                    .getOpaqueStreamToTrack(session.getSubscriber())));
+                    .getLogEntrySyncOpaqueStream(session)));
             streamUpTo();
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -43,20 +43,20 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     /**
      * The max size of data for SMR entries in data message.
      */
-    private final int maxDataSizePerMsg;
+    protected final int maxDataSizePerMsg;
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
-    private final CorfuRuntime rt;
-    private long snapshotTimestamp;
+    protected final CorfuRuntime rt;
+    protected long snapshotTimestamp;
     protected Set<String> streams;
     private PriorityQueue<String> streamsToSend;
     private long preMsgTs;
     private long currentMsgTs;
-    private OpaqueStreamIterator currentStreamInfo;
+    protected OpaqueStreamIterator currentStreamInfo;
     private long sequence;
-    private OpaqueEntry lastEntry = null;
+    protected OpaqueEntry lastEntry = null;
 
     @Getter
-    private ObservableValue<Integer> observeBiggerMsg = new ObservableValue(0);
+    protected ObservableValue<Integer> observeBiggerMsg = new ObservableValue(0);
 
     protected final LogReplication.LogReplicationSession session;
     protected final LogReplicationContext replicationContext;
@@ -86,7 +86,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
      * @param entryList
      * @return
      */
-    private OpaqueEntry generateOpaqueEntry(long version, UUID streamID, SMREntryList entryList) {
+    protected OpaqueEntry generateOpaqueEntry(long version, UUID streamID, SMREntryList entryList) {
         Map<UUID, List<SMREntry>> map = new HashMap<>();
         map.put(streamID, entryList.getSmrEntries());
         return new OpaqueEntry(version, map);
@@ -135,7 +135,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
      * @param stream
      * @return
      */
-    private SMREntryList next(OpaqueStreamIterator stream) {
+    protected SMREntryList next(OpaqueStreamIterator stream) {
         List<SMREntry> smrList = new ArrayList<>();
         int currentMsgSize = 0;
 
@@ -192,7 +192,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
      * @param stream bookkeeping of the current stream information.
      * @return
      */
-    private LogReplication.LogReplicationEntryMsg read(OpaqueStreamIterator stream, UUID syncRequestId) {
+    protected LogReplication.LogReplicationEntryMsg read(OpaqueStreamIterator stream, UUID syncRequestId) {
         SMREntryList entryList = next(stream);
         LogReplication.LogReplicationEntryMsg txMsg = generateMessage(stream, entryList, syncRequestId);
         log.info("Successfully generate a snapshot message for stream {} with snapshotTimestamp={}, numEntries={}, " +
@@ -257,7 +257,8 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
         return new SnapshotReadMessage(messages, endSnapshotSync);
     }
 
-    private boolean currentStreamHasNext() {
+    protected boolean currentStreamHasNext() {
+        log.info("Iterator hasNext = {}", currentStreamInfo.iterator.hasNext());
         return currentStreamInfo.iterator.hasNext() || lastEntry != null;
     }
 
@@ -282,8 +283,8 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     public static class OpaqueStreamIterator {
         private String name;
         private UUID uuid;
-        private Iterator iterator;
-        private long maxVersion; // the max address of the log entries processed for this stream.
+        Iterator iterator;
+        protected long maxVersion; // the max address of the log entries processed for this stream.
 
         OpaqueStreamIterator(String name, CorfuRuntime rt, long snapshot) {
             this.name = name;
@@ -295,6 +296,12 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
             Stream stream = (new OpaqueStream(rt.getStreamsView().get(uuid, options))).streamUpTo(snapshot);
             iterator = stream.iterator();
             maxVersion = 0;
+        }
+
+        OpaqueStreamIterator(OpaqueStream opaqueStream, String name, long snapshot) {
+            this.name = name;
+            uuid = CorfuRuntime.getStreamID(name);
+            iterator = opaqueStream.streamUpTo(snapshot).iterator();
         }
     }
 
@@ -309,7 +316,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     /**
      * Record a list of SMR entries
      */
-    private static class SMREntryList {
+    public static class SMREntryList {
 
         // The total sizeInBytes of smrEntries in bytes.
         @Getter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
-import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 
 /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
 
 
 /**
@@ -57,7 +57,7 @@ public class RoutingQueuesLogEntryReader extends BaseLogEntryReader {
             }
         }
         HashMap<UUID, List<SMREntry>> opaqueEntryMap = new HashMap<>();
-        opaqueEntryMap.put(CorfuRuntime.getStreamID(REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId()),
+        opaqueEntryMap.put(CorfuRuntime.getStreamID(REPLICATED_QUEUE_NAME),
                 filteredMsgs);
         return new OpaqueEntry(opaqueEntry.getVersion(), opaqueEntryMap);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
@@ -13,17 +13,14 @@ import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
 import org.corfudb.runtime.collections.CorfuRecord;
-import org.corfudb.runtime.collections.CorfuStore;
-import org.corfudb.runtime.collections.TableOptions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
 
 
@@ -68,11 +65,6 @@ public class RoutingQueuesLogEntryReader extends BaseLogEntryReader {
     @Override
     protected boolean isValidTransactionEntry(@NonNull OpaqueEntry entry) {
         Set<UUID> txEntryStreamIds = new HashSet<>(entry.getEntries().keySet());
-        if (txEntryStreamIds.size() != 1) {
-            log.warn("Routing queue session's log entries should only come from the shared data queue " +
-                    "for log entry sync");
-            return false;
-        }
 
         return txEntryStreamIds.contains(LogReplicationUtils.lrLogEntrySendQId);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -38,9 +38,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
 import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_END_MARKER_TABLE_NAME;
 import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
-import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 import static org.corfudb.infrastructure.logreplication.config.LogReplicationConfig.DEFAULT_MAX_DATA_MSG_SIZE;
 
 /**
@@ -75,7 +75,7 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
         super(corfuRuntime, session, replicationContext);
         streamTagFollowed = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
 
-        String snapshotSyncQueueFullyQualifiedName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+        String snapshotSyncQueueFullyQualifiedName = TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE,
                 SNAPSHOT_SYNC_QUEUE_NAME_SENDER);
         snapshotSyncQueueId = CorfuRuntime.getStreamID(snapshotSyncQueueFullyQualifiedName);
 
@@ -84,14 +84,14 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
         dataPoller = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("snapshot-sync-data" +
             "-poller-" + session.hashCode()).build());
 
-        String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+        String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE,
                 LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId());
         replicatedQueueId = CorfuRuntime.getStreamID(replicatedQueueName);
 
         // Open the marker table so that its entries can be deserialized
         try {
             CorfuStore corfuStore = new CorfuStore(replicationContext.getConfigManager().getRuntime());
-            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_END_MARKER_TABLE_NAME,
+            corfuStore.openTable(DEMO_NAMESPACE, SNAPSHOT_END_MARKER_TABLE_NAME,
                 Queue.RoutingTableSnapshotEndKeyMsg.class, Queue.RoutingTableSnapshotEndMarkerMsg.class, null,
                 TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
@@ -99,7 +99,7 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
             throw new RuntimeException(e);
         }
 
-        String endMarkerTableName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+        String endMarkerTableName = TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE,
             SNAPSHOT_END_MARKER_TABLE_NAME);
         endMarkerStreamId = CorfuRuntime.getStreamID(endMarkerTableName);
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -1,29 +1,309 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.protobuf.Message;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.replication.send.IllegalSnapshotEntrySizeException;
+import org.corfudb.protocols.logprotocol.OpaqueEntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
+import org.corfudb.runtime.LogReplicationUtils;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.runtime.view.stream.OpaqueStream;
+import org.corfudb.util.retry.ExponentialBackoffRetry;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.RetryNeededException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_END_MARKER_TABLE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.corfudb.infrastructure.logreplication.config.LogReplicationConfig.DEFAULT_MAX_DATA_MSG_SIZE;
 
 /**
  * Snapshot reader implementation for Routing Queues Replication Model.
  */
+@Slf4j
 public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
+
+    private static final long DATA_WAIT_TIMEOUT_MS = 120000;
+
+    // UUID of the global queue which contains snapshot sync data
+    private UUID snapshotSyncQueueId;
+
+    // Stream tag which will be followed to fetch any writes to the snapshot sync queue for this destination
+    private String streamTagFollowed;
+
+    private final ExecutorService dataPoller;
+
+    private boolean endMarkerReached = false;
+
+    // Timestamp of the last read entry in the queue.  Every subsequent batch read will continue from this timestamp
+    private long lastReadTimestamp;
+
+    // UUID of the replicated queue on the receiver(Sink)
+    private UUID replicatedQueueId;
+
+    // UUID of the stream which contains snapshot end markers
+    private UUID endMarkerStreamId;
 
     public RoutingQueuesSnapshotReader(CorfuRuntime corfuRuntime, LogReplicationSession session,
                                        LogReplicationContext replicationContext) {
         super(corfuRuntime, session, replicationContext);
+        streamTagFollowed = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
+
+        String snapshotSyncQueueFullyQualifiedName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+                SNAPSHOT_SYNC_QUEUE_NAME_SENDER);
+        snapshotSyncQueueId = CorfuRuntime.getStreamID(snapshotSyncQueueFullyQualifiedName);
+
+        lastReadTimestamp = snapshotTimestamp;
+
+        dataPoller = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("snapshot-sync-data" +
+            "-poller-" + session.hashCode()).build());
+
+        String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+                LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId());
+        replicatedQueueId = CorfuRuntime.getStreamID(replicatedQueueName);
+
+        // Open the marker table so that its entries can be deserialized
+        try {
+            CorfuStore corfuStore = new CorfuStore(replicationContext.getConfigManager().getRuntime());
+            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_END_MARKER_TABLE_NAME,
+                Queue.RoutingTableSnapshotEndKeyMsg.class, Queue.RoutingTableSnapshotEndMarkerMsg.class, null,
+                TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            log.error("Failed to open the End Marker table", e);
+            throw new RuntimeException(e);
+        }
+
+        String endMarkerTableName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+            SNAPSHOT_END_MARKER_TABLE_NAME);
+        endMarkerStreamId = CorfuRuntime.getStreamID(endMarkerTableName);
+
+        buildOpaqueStreamIterator();
     }
 
+    // Create an opaque stream and iterator for the stream of interest, starting from lastReadTimestamp+1 to the global
+    // log tail
+    private void buildOpaqueStreamIterator() {
+        OpaqueStream opaqueStream =
+                new OpaqueStream(rt.getStreamsView().get(CorfuRuntime.getStreamID(streamTagFollowed)));
+
+        // Seek till the last read timestamp so that duplicate entries are eliminated.
+        opaqueStream.seek(lastReadTimestamp + 1);
+
+        long logTail = rt.getAddressSpaceView().getLogTail();
+
+        currentStreamInfo = new OpaqueStreamIterator(opaqueStream, streamTagFollowed, logTail);
+
+        log.info("Start reading data from {}, log tail = {}", lastReadTimestamp, logTail);
+    }
+
+    /**
+     * Fetch the set of streams to replicate.
+     */
     @Override
     protected void refreshStreamsToReplicateSet() {
-        throw new IllegalStateException("Unexpected workflow encountered.  Stream UUIDs cannot be refreshed for this " +
-            "model");
+        streams = replicationContext.getConfig(session).getStreamsToReplicate();
     }
 
     @Override
     public void reset(long ts) {
-        // In addition to setting the snapshot timestamp to ts, write to the table subscribed to by the client
-        // requesting for a snapshot sync
+        streams = replicationContext.getConfig(session).getStreamsToReplicate();
+        snapshotTimestamp = ts;
+    }
+
+    /**
+     * Reads data from the Snapshot Sync Queue, waiting for a predetermined time for new data to appear if there is
+     * none.  This data is sent to the destination.
+     * @param syncRequestId
+     * @return
+     */
+    @Override
+    public SnapshotReadMessage read(UUID syncRequestId) {
+        List<LogReplication.LogReplicationEntryMsg> messages = new ArrayList<>();
+
+        LogReplication.LogReplicationEntryMsg msg;
+
+        log.info("Start Snapshot Sync replication for stream name={}, id={}", streamTagFollowed,
+                CorfuRuntime.getStreamID(streamTagFollowed));
+
+        // If the current opaque stream has data, read and send it
+        if (currentStreamHasNext()) {
+            msg = read(currentStreamInfo, syncRequestId);
+            if (msg != null) {
+                messages.add(msg);
+            }
+        } else {
+            // Wait for more data to be written by the client and send it once it is received
+            waitForData();
+            msg = read(currentStreamInfo, syncRequestId);
+            if (msg != null) {
+                messages.add(msg);
+            }
+        }
+        return new SnapshotReadMessage(messages, endMarkerReached);
+    }
+
+    // Waits for a default timeout period for data to get written for this destination on the Snapshot Sync queue
+    private void waitForData() {
+        // Create a task to wait for more data until DATA_WAIT_TIMEOUT_MS
+        StreamQueryTask streamQueryTask = new StreamQueryTask();
+        Future<Void> queryFuture = dataPoller.submit(streamQueryTask);
+
+        try {
+            queryFuture.get(DATA_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Timed out waiting for data or end marker for Snapshot Sync");
+        } catch (Exception e) {
+            // Handle all other types of exceptions
+        }
+    }
+
+    // Check if the Opaque Entry contains an End Marker, denoting the end of snapshot sync data
+    private boolean isEndMarker(OpaqueEntry opaqueEntry) {
+        if (!opaqueEntry.getEntries().keySet().contains(endMarkerStreamId)) {
+            return false;
+        }
+
+        // There should be a single SMR update for the end marker
+        Preconditions.checkState(opaqueEntry.getEntries().get(endMarkerStreamId).size() == 1);
+        SMREntry smrEntry = opaqueEntry.getEntries().get(endMarkerStreamId).get(0);
+
+        // Deserialize the entry to get the marker
+        Object[] objs = smrEntry.getSMRArguments();
+
+        ByteBuf valueBuf = Unpooled.wrappedBuffer((byte[]) objs[1]);
+        CorfuRecord<Queue.RoutingTableSnapshotEndMarkerMsg, Message> record =
+            (CorfuRecord<Queue.RoutingTableSnapshotEndMarkerMsg, Message>)
+                replicationContext.getProtobufSerializer().deserialize(valueBuf, null);
+
+        Preconditions.checkState(Objects.equals(record.getPayload().getDestination(), session.getSinkClusterId()));
+
+        // TODO Pankti: Pass the sync request id and return true only if the marker is for this snapshot sync
+        return true;
+    }
+
+    /**
+     * Constructs a list of SMR entries to be sent to the destination.  Max size of this list is 'maxDataSizePerMsg'
+     * @param stream Iterator over the Opaque Stream
+     * @return List of SMR entries
+     */
+    @Override
+    protected SMREntryList next(OpaqueStreamIterator stream) {
+        List<SMREntry> smrList = new ArrayList<>();
+        int currentMsgSize = 0;
+
+        try {
+            while (currentMsgSize < maxDataSizePerMsg) {
+                if (lastEntry != null) {
+
+                    // Only the entries from Routing Queue OR End Marker for Snapshot Sync must be found
+                    Preconditions.checkState(lastEntry.getEntries().keySet().size() == 1);
+
+                    // If this OpaqueEntry was for the end marker, no further processing is required.
+                    if (isEndMarker(lastEntry)) {
+                        endMarkerReached = true;
+                        break;
+                    }
+
+                    List<SMREntry> smrEntries = lastEntry.getEntries().get(snapshotSyncQueueId);
+                    if (smrEntries != null) {
+                        int currentEntrySize = ReaderUtility.calculateSize(smrEntries);
+
+                        if (currentEntrySize > DEFAULT_MAX_DATA_MSG_SIZE) {
+                            log.error("The current entry size {} is bigger than the maxDataSizePerMsg {} supported",
+                                currentEntrySize, DEFAULT_MAX_DATA_MSG_SIZE);
+                            throw new IllegalSnapshotEntrySizeException(" The snapshot entry is bigger than the system supported");
+                        } else if (currentEntrySize > maxDataSizePerMsg) {
+                            observeBiggerMsg.setValue(observeBiggerMsg.getValue()+1);
+                            log.warn("The current entry size {} is bigger than the configured maxDataSizePerMsg {}",
+                                currentEntrySize, maxDataSizePerMsg);
+                        }
+
+                        // Skip append this entry in this message. Will process it first at the next round.
+                        if (currentEntrySize + currentMsgSize > maxDataSizePerMsg && currentMsgSize != 0) {
+                            break;
+                        }
+
+                        smrList.addAll(smrEntries);
+                        currentMsgSize += currentEntrySize;
+                        stream.maxVersion = Math.max(stream.maxVersion, lastEntry.getVersion());
+                        lastReadTimestamp = stream.maxVersion;
+                    }
+                    lastEntry = null;
+                }
+
+                if (stream.iterator.hasNext()) {
+                    lastEntry = (OpaqueEntry) stream.iterator.next();
+                }
+
+                if (lastEntry == null) {
+                    break;
+                }
+            }
+        } catch (TrimmedException e) {
+            log.error("Caught a TrimmedException", e);
+            throw e;
+        }
+
+        log.trace("CurrentMsgSize {}  maxDataSizePerMsg {}", currentMsgSize, maxDataSizePerMsg);
+        return new SMREntryList(currentMsgSize, smrList);
+    }
+
+    @Override
+    protected OpaqueEntry generateOpaqueEntry(long version, UUID streamID, SMREntryList entryList) {
+        Map<UUID, List<SMREntry>> map = new HashMap<>();
+        map.put(replicatedQueueId, entryList.getSmrEntries());
+        return new OpaqueEntry(version, map);
+    }
+
+    // Internal Utility class which polls for new data to be available on the Sender Routing Queue.  It uses
+    // Exponential Backoff mechanism to wait between subsequent retries.
+    private class StreamQueryTask implements Callable<Void> {
+
+        @Override
+        public Void call() {
+            try {
+                IRetry.build(ExponentialBackoffRetry.class, () -> {
+                    try {
+                        buildOpaqueStreamIterator();
+                        if (!currentStreamHasNext()) {
+                            log.info("Retrying");
+                            throw new RuntimeException("Retry");
+                        }
+                    } catch (Exception e) {
+                        throw new RetryNeededException();
+                    }
+                    return null;
+                }).run();
+            } catch (InterruptedException ie) {
+                throw new RuntimeException("Interrupted Exception");
+            }
+            return null;
+        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -6,6 +6,7 @@ import com.google.protobuf.Message;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.config.LogReplicationRoutingQueueConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.replication.send.IllegalSnapshotEntrySizeException;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
@@ -84,8 +85,8 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
         dataPoller = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("snapshot-sync-data" +
             "-poller-" + session.hashCode()).build());
 
-        String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(DEMO_NAMESPACE,
-                LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId());
+        String replicatedQueueName = ((LogReplicationRoutingQueueConfig) replicationContext
+                .getConfig(session)).getSinkQueueName();
         replicatedQueueId = CorfuRuntime.getStreamID(replicatedQueueName);
 
         // Open the marker table so that its entries can be deserialized

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -323,7 +323,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
             SnapshotSyncUtils.enforceSnapshotSync(fsm.getSession(), new CorfuStore(metadataManager.getRuntime()),
                 LogReplicationMetadata.ReplicationEvent.ReplicationEventType.RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC);
         }
+        // Temporary hack to always request LogEntry Sync
         fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
-            new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
+            new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST)));
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -318,12 +318,14 @@ public class NegotiatingState implements LogReplicationRuntimeState {
     }
 
     private void startSnapshotSync() {
-        // If Routing Queue Replication Model, request LR Client to provide full sync data
-        if (fsm.getSession().getSubscriber().getModel() == LogReplication.ReplicationModel.ROUTING_QUEUES) {
-            SnapshotSyncUtils.enforceSnapshotSync(fsm.getSession(), new CorfuStore(metadataManager.getRuntime()),
-                LogReplicationMetadata.ReplicationEvent.ReplicationEventType.RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC);
-        }
-        // Temporary hack to always request LogEntry Sync
+        // TODO: Revert this! Temporary hack to always request LogEntry Sync
+
+//        // If Routing Queue Replication Model, request LR Client to provide full sync data
+//        if (fsm.getSession().getSubscriber().getModel() == LogReplication.ReplicationModel.ROUTING_QUEUES) {
+//            SnapshotSyncUtils.enforceSnapshotSync(fsm.getSession(), new CorfuStore(metadataManager.getRuntime()),
+//                LogReplicationMetadata.ReplicationEvent.ReplicationEventType.RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC);
+//        }
+
         fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
             new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST)));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -501,7 +501,10 @@ public class LogReplicationConfigManager {
             case ROUTING_QUEUES:
                 String logEntrySyncStreamTag = ((LogReplicationRoutingQueueConfig) sessionToConfigMap.get(session))
                         .getLogEntrySyncStreamTag();
-                return TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE, logEntrySyncStreamTag);
+                log.info("logEntrySyncStreamTag: {}", logEntrySyncStreamTag);
+                UUID tagID = TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE, logEntrySyncStreamTag);
+                log.info("tagID: {}", tagID);
+                return tagID;
             default:
                 log.error("Unsupported replication model received: {}", session.getSubscriber().getModel());
                 return null;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -9,6 +9,7 @@ import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.config.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.config.LogReplicationFullTableConfig;
 import org.corfudb.infrastructure.logreplication.config.LogReplicationLogicalGroupConfig;
+import org.corfudb.infrastructure.logreplication.config.LogReplicationRoutingQueueConfig;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
@@ -56,6 +57,7 @@ import static org.corfudb.infrastructure.logreplication.config.LogReplicationCon
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.DEFAULT_LOGICAL_GROUP_CLIENT;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_MODEL_METADATA_TABLE_NAME;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_REGISTRATION_TABLE_NAME;
+import static org.corfudb.runtime.RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT;
 import static org.corfudb.runtime.view.ObjectsView.LOG_REPLICATOR_STREAM_INFO;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -101,8 +103,6 @@ public class LogReplicationConfigManager {
     private List<Map.Entry<TableName, CorfuRecord<TableDescriptors, TableMetadata>>> registryTableEntries =
             new ArrayList<>();
 
-
-
     /**
      * Used for non-upgrade testing purpose only. Note that this constructor will keep the version table in
      * uninitialized state, in which case LR will be constantly considered to be not upgraded.
@@ -131,6 +131,13 @@ public class LogReplicationConfigManager {
                 .build();
     }
 
+    public static ReplicationSubscriber getDefaultRoutingQueueSubscriber() {
+        return ReplicationSubscriber.newBuilder()
+                .setClientName(DEFAULT_ROUTING_QUEUE_CLIENT)
+                .setModel(ReplicationModel.ROUTING_QUEUES)
+                .build();
+    }
+
     public static ReplicationSubscriber getDefaultSubscriber() {
         return ReplicationSubscriber.newBuilder()
                 .setClientName(DEFAULT_CLIENT)
@@ -149,6 +156,7 @@ public class LogReplicationConfigManager {
         // TODO (V2): This builder should be removed after the rpc stream is added for Sink side session creation.
         //  and logical group subscribers should come from client registration.
         registeredSubscribers.add(getDefaultLogicalGroupSubscriber());
+        registeredSubscribers.add(getDefaultRoutingQueueSubscriber());
         openClientConfigTables();
         syncWithRegistryTable();
     }
@@ -199,9 +207,24 @@ public class LogReplicationConfigManager {
                                 TextFormat.shortDebugString(session));
                         generateLogicalGroupConfig(session);
                         break;
+                    case ROUTING_QUEUES:
+                        log.debug("Generating ROUTING_QUEUE config for session {}",
+                                TextFormat.shortDebugString(session));
+                        generateRoutingQueueConfig(session);
                     default: break;
                 }
         });
+    }
+
+    private void generateRoutingQueueConfig(LogReplicationSession session) {
+        if (!sessionToConfigMap.containsKey(session)) {
+            LogReplicationRoutingQueueConfig routingQueueConfig =
+                    new LogReplicationRoutingQueueConfig(session, serverContext);
+            sessionToConfigMap.put(session, routingQueueConfig);
+            log.info("Routing queue session {} config generated.", session);
+        } else {
+            log.warn("Routing queue config for session {} already exists!", session);
+        }
     }
 
     private void generateLogicalGroupConfig(LogReplicationSession session) {
@@ -459,14 +482,18 @@ public class LogReplicationConfigManager {
         return preprocessAndGetTail();
     }
 
-    public UUID getOpaqueStreamToTrack(ReplicationSubscriber subscriber) {
-        switch(subscriber.getModel()) {
+    public UUID getLogEntrySyncOpaqueStream(LogReplicationSession session) {
+        switch(session.getSubscriber().getModel()) {
             case FULL_TABLE:
                 return ObjectsView.getLogReplicatorStreamId();
             case LOGICAL_GROUPS:
-                return ObjectsView.getLogicalGroupStreamTagInfo(subscriber.getClientName()).getStreamId();
+                return ObjectsView.getLogicalGroupStreamTagInfo(session.getSubscriber().getClientName()).getStreamId();
+            case ROUTING_QUEUES:
+                String logEntrySyncStreamTag = ((LogReplicationRoutingQueueConfig) sessionToConfigMap.get(session))
+                        .getLogEntrySyncStreamTag();
+                return CorfuRuntime.getStreamID(logEntrySyncStreamTag);
             default:
-                log.error("Unsupported replication model received: {}", subscriber.getModel());
+                log.error("Unsupported replication model received: {}", session.getSubscriber().getModel());
                 return null;
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -58,6 +58,7 @@ import static org.corfudb.infrastructure.logreplication.config.LogReplicationCon
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.DEFAULT_LOGICAL_GROUP_CLIENT;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_MODEL_METADATA_TABLE_NAME;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_REGISTRATION_TABLE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
 import static org.corfudb.runtime.RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT;
 import static org.corfudb.runtime.view.ObjectsView.LOG_REPLICATOR_STREAM_INFO;
@@ -163,7 +164,7 @@ public class LogReplicationConfigManager {
         syncWithRegistryTable();
 
         try {
-            corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER, Queue.RoutingTableEntryMsg.class,
+            corfuStore.openQueue(DEMO_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER, Queue.RoutingTableEntryMsg.class,
                 TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
         } catch (Exception e) {
             log.error("Failed to open the Log Entry Sync Queue", e);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -23,6 +23,7 @@ import org.corfudb.runtime.LogReplication.DestinationInfoVal;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
 import org.corfudb.runtime.LogReplication.ReplicationModel;
 import org.corfudb.runtime.LogReplication.ReplicationSubscriber;
+import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
@@ -57,6 +58,7 @@ import static org.corfudb.infrastructure.logreplication.config.LogReplicationCon
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.DEFAULT_LOGICAL_GROUP_CLIENT;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_MODEL_METADATA_TABLE_NAME;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_REGISTRATION_TABLE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
 import static org.corfudb.runtime.RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT;
 import static org.corfudb.runtime.view.ObjectsView.LOG_REPLICATOR_STREAM_INFO;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
@@ -159,6 +161,13 @@ public class LogReplicationConfigManager {
         registeredSubscribers.add(getDefaultRoutingQueueSubscriber());
         openClientConfigTables();
         syncWithRegistryTable();
+
+        try {
+            corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER, Queue.RoutingTableEntryMsg.class,
+                TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+        } catch (Exception e) {
+            log.error("Failed to open the Log Entry Sync Queue", e);
+        }
     }
 
     private void openClientConfigTables() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -501,7 +501,7 @@ public class LogReplicationConfigManager {
             case ROUTING_QUEUES:
                 String logEntrySyncStreamTag = ((LogReplicationRoutingQueueConfig) sessionToConfigMap.get(session))
                         .getLogEntrySyncStreamTag();
-                return CorfuRuntime.getStreamID(logEntrySyncStreamTag);
+                return TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE, logEntrySyncStreamTag);
             default:
                 log.error("Unsupported replication model received: {}", session.getSubscriber().getModel());
                 return null;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
@@ -46,7 +46,8 @@ public final class SnapshotSyncUtils {
      * @param session Session for which the snapshot sync will be enforced.
      * @param corfuStore Caller of this method should provide a corfuStore instance for executing the transaction.
      */
-    public static void enforceSnapshotSync(LogReplicationSession session, CorfuStore corfuStore) {
+    public static void enforceSnapshotSync(LogReplicationSession session, CorfuStore corfuStore,
+                                           ReplicationEventType eventType) {
         UUID forceSyncId = UUID.randomUUID();
 
         log.info("Forced snapshot sync will be triggered because of group destination change, session={}, sync_id={}",
@@ -59,7 +60,7 @@ public final class SnapshotSyncUtils {
 
         ReplicationEvent event = ReplicationEvent.newBuilder()
                 .setEventId(forceSyncId.toString())
-                .setType(ReplicationEventType.FORCE_SNAPSHOT_SYNC)
+                .setType(eventType)
                 .setEventTimestamp(Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build())
                 .build();
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
@@ -50,7 +50,7 @@ public final class SnapshotSyncUtils {
                                            ReplicationEventType eventType) {
         UUID forceSyncId = UUID.randomUUID();
 
-        log.info("Forced snapshot sync will be triggered because of group destination change, session={}, sync_id={}",
+        log.info("Forced snapshot sync will be triggered, session={}, sync_id={}",
                 session, forceSyncId);
 
         // Write a force sync event to the logReplicationEventTable

--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -15,3 +15,56 @@ message CorfuGuidMsg {
 message CorfuQueueMetadataMsg {
     int64 txSequence = 1;
 }
+
+enum ReplicationType {
+    NONE = 0;
+    LOG_ENTRY_SYNC = 1; // This entry was made during a delta sync
+    SNAPSHOT_SYNC = 2; // This entry was made during a snapshot sync
+    LAST_FULL_SYNC_ENTRY = 3; // Last entry denoting the end marker of a full sync
+}
+
+enum OperationType {
+    INVALID = 0;
+    PUT = 1;
+    REMOVE = 2;
+}
+
+message DataLocatorMsg {
+
+    // Name of the table that will be modified.
+    string tableName = 1;
+
+    // Serialized form of the keys of the table that will be modified.
+    bytes key_serialized = 2;
+}
+
+// This message forms the value part of the payload used for LogReplication over Routing Queues
+message RoutingTableEntryMsg {
+    // Source cluster id that is sending messages
+    string source_cluster_id = 1;
+
+    // List of unique destinations from topology.
+    repeated string destinations = 2;
+
+    // Specify the replication type for routing queue model.
+    ReplicationType replication_type = 3;
+
+    // The actual payload carrying data that will be replicated to the destinations specified.
+    bytes opaque_payload = 4;
+
+    // Contains the table name and serialized keys that will be updated of that table
+    DataLocatorMsg dataLocator = 5;
+
+    // Operation type that marks the table content is being created or removed.
+    OperationType operation_type = 6;
+}
+
+message RoutingTableSnapshotEndKeyMsg {
+    string snapshot_sync_id = 1;
+}
+
+// Marker message denoting the end of a snapshot sync
+message RoutingTableSnapshotEndMarkerMsg {
+    // Destination corresponding to this snapshot sync
+    string destination = 1;
+}

--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -52,11 +52,14 @@ message RoutingTableEntryMsg {
     // The actual payload carrying data that will be replicated to the destinations specified.
     bytes opaque_payload = 4;
 
+    // Serialized metadata field for certain types
+    bytes opaque_metadata = 5;
+
     // Contains the table name and serialized keys that will be updated of that table
-    DataLocatorMsg dataLocator = 5;
+    DataLocatorMsg dataLocator = 6;
 
     // Operation type that marks the table content is being created or removed.
-    OperationType operation_type = 6;
+    OperationType operation_type = 7;
 }
 
 message RoutingTableSnapshotEndKeyMsg {

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -177,3 +177,25 @@ message ReplicationInfo {
 message ReverseReplicateMsg {
   string sinkLeaderNodeId = 1;
 }
+
+/*------- Log Replication Event Table Schema ----------*/
+
+message ReplicationEventInfoKey {
+  org.corfudb.runtime.LogReplicationSession session = 1;
+}
+
+message ReplicationEvent {
+  option (org.corfudb.runtime.table_schema).stream_tag = "log_replication";
+
+  enum ReplicationEventType {
+    FORCE_SNAPSHOT_SYNC = 0;
+    UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC = 1; // Intent to queue force sync for all full table sessions
+    RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC = 2;
+    ROLE_CHANGE_FORCE_SNAPSHOT_SYNC = 3;
+    CLIENT_REQUESTED_FORCED_SNAPSHOT_SYNC = 4;
+  }
+  string clusterId = 1;
+  string eventId = 2;
+  ReplicationEventType type = 3;
+  google.protobuf.Timestamp eventTimestamp = 4;
+}

--- a/runtime/src/main/java/org/corfudb/runtime/FullStateReplicationContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/FullStateReplicationContext.java
@@ -1,0 +1,65 @@
+package org.corfudb.runtime;
+
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
+import org.corfudb.runtime.LogReplication.ReplicationEvent.ReplicationEventType;
+import org.corfudb.runtime.collections.FullStateMessage;
+import org.corfudb.runtime.collections.TxnContext;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
+
+public interface FullStateReplicationContext {
+    /**
+     * LR starts this transaction and the callback must use the same to do its full table scans
+     *
+     */
+     TxnContext getTxn();
+
+     /**
+      * Returns destination site ID.
+      * Data is transmitted from this site.
+      *
+      */
+    String getDestinationSiteId();
+
+    /**
+     * Returns unique ID for the full state sync request.
+     *
+     */
+    UUID getRequestId();
+
+    /**
+     * Returns reason for full state sync request.
+     *
+     */
+    @Nullable
+    ReplicationEventType getReason();
+
+    /**
+     * Transmits one message for full sync.
+     *
+     */
+    void transmit(FullStateMessage message) throws CancellationException;
+
+    /**
+     * Transmits one message for full sync.
+     *
+     * @param message message to transmit.
+     * @param progress indicates progress of transmission, value between 0 and 100.
+     */
+    void transmit(FullStateMessage message, int progress) throws CancellationException;
+
+    /**
+     * Indicates that all data was transmitted from application to client.
+     *
+     */
+    void markCompleted(Timestamp timestamp) throws CancellationException;
+
+    /**
+     * Cancels this full sync replication.
+     * Application cannot continue and full sync has to be restarted.
+     *
+     */
+    void cancel();
+}

--- a/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
@@ -1,0 +1,69 @@
+package org.corfudb.runtime;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.TableOptions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
+
+@Slf4j
+public abstract class LiteRoutingQueueListener implements StreamListener {
+
+    private final CorfuStore corfuStore;
+
+
+    public LiteRoutingQueueListener(CorfuStore corfuStore) {
+        this.corfuStore = corfuStore;
+        try {
+            corfuStore.openQueue(DEMO_NAMESPACE, LogReplicationUtils.REPLICATED_QUEUE_NAME,
+                    Queue.RoutingTableEntryMsg.class,
+                    TableOptions.builder().schemaOptions(
+                                    CorfuOptions.SchemaOptions.newBuilder()
+                                            .addStreamTag(LogReplicationUtils.REPLICATED_QUEUE_TAG)
+                                            .build())
+                            .build());
+        } catch (Exception e) {
+            log.error("Failed to open replicated queue due to exception!", e);
+        }
+    }
+
+    @Override
+    public void onNext(CorfuStreamEntries results) {
+        log.info("LR LiteRoutingQueueListener received updates!");
+        List<CorfuStreamEntry> entries = results.getEntries().entrySet().stream()
+                .map(Map.Entry::getValue).findFirst().get();
+        for (CorfuStreamEntry entry : entries) {
+            if (entry.getOperation().equals(CorfuStreamEntry.OperationType.CLEAR)) {
+                log.warn("CLEAR_ENTRY received, snapshot sync is ongoing, skip this entry");
+                continue;
+            }
+            Queue.RoutingTableEntryMsg msg = (Queue.RoutingTableEntryMsg) entry.getPayload();
+            if (msg.getReplicationType()
+                    .equals(Queue.ReplicationType.LOG_ENTRY_SYNC)) {
+                log.info("Process log entry sync msg: {}", msg);
+                processUpdatesInLogEntrySync(Collections.singletonList(msg));
+            } else {
+                log.info("Process snapshot sync msg: {}", msg);
+                processUpdatesInSnapshotSync(Collections.singletonList(msg));
+            }
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        log.error("onError:: resubscribing LiteRoutingQueueListener ", throwable);
+        corfuStore.subscribeListenerFromTrimMark(this, DEMO_NAMESPACE, REPLICATED_QUEUE_TAG);
+    }
+
+    protected abstract boolean processUpdatesInSnapshotSync(List<Queue.RoutingTableEntryMsg> updates);
+
+    protected abstract boolean processUpdatesInLogEntrySync(List<Queue.RoutingTableEntryMsg> updates);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationClient.java
@@ -1,0 +1,125 @@
+package org.corfudb.runtime;
+
+import com.google.common.base.Strings;
+import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.LogReplication.ClientRegistrationId;
+import org.corfudb.runtime.LogReplication.ClientRegistrationInfo;
+import org.corfudb.runtime.LogReplication.ReplicationModel;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.util.retry.ExponentialBackoffRetry;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.RetryNeededException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+public abstract class LogReplicationClient {
+    /**
+     * Key: ClientRegistrationId
+     * Value: ClientRegistrationInfo
+     */
+    public static final String LR_REGISTRATION_TABLE_NAME = "LogReplicationRegistrationTable";
+
+    private Table<ClientRegistrationId, ClientRegistrationInfo, Message> replicationRegistrationTable;
+
+    /**
+     * Registers client for replication.
+     *
+     */
+    public void register(CorfuStore corfuStore, String clientName, ReplicationModel model)
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+
+        ClientRegistrationId clientKey = ClientRegistrationId.newBuilder()
+                .setClientName(clientName)
+                .build();
+        Instant time = Instant.now();
+        Timestamp timestamp = Timestamp.newBuilder().setSeconds(time.getEpochSecond())
+                .setNanos(time.getNano()).build();
+        ClientRegistrationInfo clientInfo = ClientRegistrationInfo.newBuilder()
+                .setClientName(clientName)
+                .setModel(model)
+                .setRegistrationTime(timestamp)
+                .build();
+
+        try {
+            replicationRegistrationTable = corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LR_REGISTRATION_TABLE_NAME);
+        } catch (NoSuchElementException | IllegalArgumentException e) {
+            log.warn("Failed getTable operation, opening table.", e);
+            replicationRegistrationTable = corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, LR_REGISTRATION_TABLE_NAME,
+                    ClientRegistrationId.class,
+                    ClientRegistrationInfo.class,
+                    null,
+                    TableOptions.fromProtoSchema(ClientRegistrationInfo.class));
+        }
+
+        try {
+            IRetry.build(ExponentialBackoffRetry.class, () -> {
+                try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+                    ClientRegistrationInfo clientRegistrationInfo = txn.getRecord(replicationRegistrationTable, clientKey).getPayload();
+
+                    if (clientRegistrationInfo != null) {
+                        log.warn(String.format("Client already registered.\n--- ClientRegistrationId ---\n%s" +
+                                "--- ClientRegistrationInfo ---\n%s", clientKey, clientRegistrationInfo));
+                    } else {
+                        txn.putRecord(replicationRegistrationTable, clientKey, clientInfo, null);
+                    }
+
+                    txn.commit();
+                } catch (TransactionAbortedException tae) {
+                    log.error(String.format("[%s] Unable to register client.", clientName), tae);
+                    throw new RetryNeededException();
+                }
+                return null;
+            }).run();
+        } catch (InterruptedException e) {
+            log.error(String.format("[%s] Client registration failed.", clientName), e);
+            throw new UnrecoverableCorfuInterruptedError(e);
+        }
+    }
+
+    protected boolean isValid(final Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj instanceof Collection) {
+            return !((Collection<?>) obj).isEmpty();
+        } else {
+            return !Strings.isNullOrEmpty(obj.toString());
+        }
+    }
+
+    protected boolean hasNoNullOrEmptyElements(final Collection<?> collection) {
+        if (collection == null) {
+            return false;
+        }
+        for (Object obj : collection) {
+            if (obj == null || obj instanceof String && ((String) obj).isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected Set<String> deduplicate(List<String> list, String clientName) {
+        int initialSize = list.size();
+        Set<String> set = new HashSet<>(list);
+        if (initialSize != set.size()) {
+            log.info(String.format("[%s] Duplicate elements removed from list.", clientName));
+        }
+        return set;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
@@ -1,13 +1,9 @@
 package org.corfudb.runtime;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.protobuf.Message;
-import com.google.protobuf.Timestamp;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.LogReplication.ClientDestinationInfoKey;
-import org.corfudb.runtime.LogReplication.ClientRegistrationId;
-import org.corfudb.runtime.LogReplication.ClientRegistrationInfo;
 import org.corfudb.runtime.LogReplication.DestinationInfoVal;
 import org.corfudb.runtime.LogReplication.ReplicationModel;
 import org.corfudb.runtime.collections.CorfuStore;
@@ -21,9 +17,7 @@ import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.RetryNeededException;
 
 import java.lang.reflect.InvocationTargetException;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -39,15 +33,9 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
  * may succeed concurrently, leading to potential race conditions as retries are not deterministic.
  */
 @Slf4j
-public class LogReplicationLogicalGroupClient {
+public class LogReplicationLogicalGroupClient extends LogReplicationClient{
     // TODO (V2): This field should be removed after the rpc stream is added for Sink side session creation.
     public static final String DEFAULT_LOGICAL_GROUP_CLIENT = "00000000-0000-0000-0000-0000000000001";
-
-    /**
-     * Key: ClientRegistrationId
-     * Value: ClientRegistrationInfo
-     */
-    public static final String LR_REGISTRATION_TABLE_NAME = "LogReplicationRegistrationTable";
 
     /**
      * Key: ClientDestinationInfoKey
@@ -57,12 +45,9 @@ public class LogReplicationLogicalGroupClient {
 
     private static final ReplicationModel model = ReplicationModel.LOGICAL_GROUPS;
 
-    private Table<ClientRegistrationId, ClientRegistrationInfo, Message> replicationRegistrationTable;
     private Table<ClientDestinationInfoKey, DestinationInfoVal, Message> sourceMetadataTable;
 
     private final CorfuStore corfuStore;
-    private final ClientRegistrationId clientKey;
-    private final ClientRegistrationInfo clientInfo;
     private final String clientName;
 
     /**
@@ -82,28 +67,6 @@ public class LogReplicationLogicalGroupClient {
         this.corfuStore = new CorfuStore(runtime);
         // TODO (V2): client name cannot be customized as Sink side does not have a way to create sessions for now
         this.clientName = DEFAULT_LOGICAL_GROUP_CLIENT;
-        this.clientKey = ClientRegistrationId.newBuilder()
-                .setClientName(clientName)
-                .build();
-        Instant time = Instant.now();
-        Timestamp timestamp = Timestamp.newBuilder().setSeconds(time.getEpochSecond())
-                .setNanos(time.getNano()).build();
-        this.clientInfo = ClientRegistrationInfo.newBuilder()
-                .setClientName(clientName)
-                .setModel(model)
-                .setRegistrationTime(timestamp)
-                .build();
-
-        try {
-            this.replicationRegistrationTable = corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LR_REGISTRATION_TABLE_NAME);
-        } catch (NoSuchElementException | IllegalArgumentException e) {
-            log.warn("Failed getTable operation, opening table.", e);
-            this.replicationRegistrationTable = corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, LR_REGISTRATION_TABLE_NAME,
-                    ClientRegistrationId.class,
-                    ClientRegistrationInfo.class,
-                    null,
-                    TableOptions.fromProtoSchema(ClientRegistrationInfo.class));
-        }
 
         try {
             this.sourceMetadataTable = corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LR_MODEL_METADATA_TABLE_NAME);
@@ -116,37 +79,7 @@ public class LogReplicationLogicalGroupClient {
                     TableOptions.fromProtoSchema(DestinationInfoVal.class));
         }
 
-        register();
-    }
-
-    /**
-     * Registers client for replication utilizing logical groups.
-     *
-     */
-    private void register() {
-        try {
-            IRetry.build(ExponentialBackoffRetry.class, () -> {
-                try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-                    ClientRegistrationInfo clientRegistrationInfo = txn.getRecord(replicationRegistrationTable, clientKey).getPayload();
-
-                    if (clientRegistrationInfo != null) {
-                        log.warn(String.format("Client already registered.\n--- ClientRegistrationId ---\n%s" +
-                                "--- ClientRegistrationInfo ---\n%s", clientKey, clientRegistrationInfo));
-                    } else {
-                        txn.putRecord(replicationRegistrationTable, clientKey, clientInfo, null);
-                    }
-
-                    txn.commit();
-                } catch (TransactionAbortedException tae) {
-                    log.error(String.format("[%s] Unable to register client.", clientName), tae);
-                    throw new RetryNeededException();
-                }
-                return null;
-            }).run();
-        } catch (InterruptedException e) {
-            log.error(String.format("[%s] Client registration failed.", clientName), e);
-            throw new UnrecoverableCorfuInterruptedError(e);
-        }
+        register(corfuStore, clientName, model);
     }
 
     /**
@@ -169,7 +102,7 @@ public class LogReplicationLogicalGroupClient {
                 String.format("[%s] remoteDestinations is null or empty.", clientName));
         Preconditions.checkArgument(hasNoNullOrEmptyElements(remoteDestinations),
                 String.format("[%s] remoteDestinations contains null or empty elements.", clientName));
-        List<String> finalRemoteDestinations = new ArrayList<>(deduplicate(remoteDestinations));
+        List<String> finalRemoteDestinations = new ArrayList<>(deduplicate(remoteDestinations, clientName));
         try {
             IRetry.build(ExponentialBackoffRetry.class, () -> {
                 try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
@@ -228,7 +161,7 @@ public class LogReplicationLogicalGroupClient {
                 String.format("[%s] remoteDestinations is null.", clientName));
         Preconditions.checkArgument(hasNoNullOrEmptyElements(remoteDestinations),
                 String.format("[%s] remoteDestinations contains null or empty elements.", clientName));
-        List<String> finalRemoteDestinations = new ArrayList<>(deduplicate(remoteDestinations));
+        List<String> finalRemoteDestinations = new ArrayList<>(deduplicate(remoteDestinations, clientName));
         try {
             IRetry.build(ExponentialBackoffRetry.class, () -> {
                 try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
@@ -284,7 +217,7 @@ public class LogReplicationLogicalGroupClient {
                 String.format("[%s] remoteDestinations is null or empty.", clientName));
         Preconditions.checkArgument(hasNoNullOrEmptyElements(remoteDestinations),
                 String.format("[%s] remoteDestinations contains null or empty elements.", clientName));
-        Set<String> removeRemoteDestinationsSet = deduplicate(remoteDestinations);
+        Set<String> removeRemoteDestinationsSet = deduplicate(remoteDestinations, clientName);
         try {
             IRetry.build(ExponentialBackoffRetry.class, () -> {
                 try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
@@ -369,37 +302,6 @@ public class LogReplicationLogicalGroupClient {
             log.error(String.format("[%s] Unable to get destinations.", clientName), e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
-    }
-
-    private boolean isValid(final Object obj) {
-        if (obj == null) {
-            return false;
-        } else if (obj instanceof Collection) {
-            return !((Collection<?>) obj).isEmpty();
-        } else {
-            return !Strings.isNullOrEmpty(obj.toString());
-        }
-    }
-
-    private boolean hasNoNullOrEmptyElements(final Collection<?> collection) {
-        if (collection == null) {
-            return false;
-        }
-        for (Object obj : collection) {
-            if (obj == null || obj instanceof String && ((String) obj).isEmpty()) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private Set<String> deduplicate(List<String> list) {
-        int initialSize = list.size();
-        Set<String> set = new HashSet<>(list);
-        if (initialSize != set.size()) {
-            log.info(String.format("[%s] Duplicate elements removed from list.", clientName));
-        }
-        return set;
     }
 
     private ClientDestinationInfoKey buildClientDestinationInfoKey(String logicalGroup) {

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueClient.java
@@ -1,8 +1,10 @@
 package org.corfudb.runtime;
 
 import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
+import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TxnContext;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 public interface LogReplicationRoutingQueueClient {
@@ -12,7 +14,7 @@ public interface LogReplicationRoutingQueueClient {
      * This method must be used if transaction has multiple messages. Repetitive calls in the same transaction to the
      * transmitDeltaMessages/transmitDeltaMessage won't be supported
      */
-    void transmitDeltaMessage(TxnContext txn, RoutingTableEntryMsg message);
+    void transmitDeltaMessage(TxnContext txn, RoutingTableEntryMsg message, CorfuStore corfuStore) throws Exception;
 
-    void transmitDeltaMessages(TxnContext txn, List<RoutingTableEntryMsg> messages);
+    void transmitDeltaMessages(TxnContext txn, List<RoutingTableEntryMsg> messages, CorfuStore corfuStore) throws Exception;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueClient.java
@@ -1,0 +1,18 @@
+package org.corfudb.runtime;
+
+import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
+import org.corfudb.runtime.collections.TxnContext;
+
+import java.util.List;
+
+public interface LogReplicationRoutingQueueClient {
+    /**
+     * Transmits Delta Messages.
+     * Must be invoked with the same transaction builder that was used for as actual data modification.
+     * This method must be used if transaction has multiple messages. Repetitive calls in the same transaction to the
+     * transmitDeltaMessages/transmitDeltaMessage won't be supported
+     */
+    void transmitDeltaMessage(TxnContext txn, RoutingTableEntryMsg message);
+
+    void transmitDeltaMessages(TxnContext txn, List<RoutingTableEntryMsg> messages);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
@@ -75,7 +75,7 @@ public abstract class LogReplicationRoutingQueueListener implements StreamListen
         this.corfuStore = corfuStore;
         this.namespace = namespace;
         this.routingQueue =
-                corfuStore.openQueue(namespace, LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX,
+                corfuStore.openQueue(namespace, LogReplicationUtils.REPLICATED_QUEUE_NAME,
                         Queue.RoutingTableEntryMsg.class,
                         TableOptions.builder().schemaOptions(
                                         CorfuOptions.SchemaOptions.newBuilder()

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
@@ -1,0 +1,324 @@
+package org.corfudb.runtime;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.TableSchema;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.exceptions.StreamingException;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Objects;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+
+/**
+ * This is the interface that a client must subscribe to if it needs to observe and bifurcate the data updates received
+ * on Log Entry and Snapshot Sync.
+ *
+ * The client implementing this interface will only observe the data updates from client streams
+ */
+@Slf4j
+public abstract class LogReplicationRoutingQueueListener implements StreamListener {
+
+    // Indicates if a full sync on client tables was performed during subscription.  A full sync will not be
+    // performed if a snapshot sync is ongoing.
+    @Getter
+    private final AtomicBoolean clientFullSyncPending = new AtomicBoolean(false);
+
+    // This variable tracks if a snapshot sync is ongoing
+    @Getter
+    private final AtomicBoolean snapshotSyncInProgress = new AtomicBoolean(false);
+
+    // This variable tracks if the receiver side routing queue is registered with table registry.
+    @Getter
+    private final AtomicBoolean routingQRegistered = new AtomicBoolean(false);;
+
+    // Timestamp at which the client performed a full sync.  Any updates below this timestamp must be ignored.
+    // At the time of subscription, a full sync cannot be performed if LR Snapshot Sync is in progress.  Full Sync is
+    // performed when this ongoing snapshot sync completes.  The listener, however, can get updates before this full
+    // sync.  So we need to maintain this timestamp and ignore any updates below it.
+    @Getter
+    private final AtomicLong clientFullSyncTimestamp = new AtomicLong(Address.NON_ADDRESS);
+
+    private final CorfuStore corfuStore;
+    private final String namespace;
+
+    private final Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> routingQueue;
+
+    private CorfuStoreMetadata.Timestamp lastProcessedEntryTs;
+
+    /**
+     * Special LogReplication listener which a client creates to receive ordered updates for replicated data.
+     * @param corfuStore Corfu Store used on the client
+     * @param namespace Namespace of the client's tables
+     */
+    public LogReplicationRoutingQueueListener(CorfuStore corfuStore, @Nonnull String namespace) throws
+            InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        this.corfuStore = corfuStore;
+        this.namespace = namespace;
+        this.routingQueue =
+                corfuStore.openQueue(namespace, LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX,
+                        Queue.RoutingTableEntryMsg.class,
+                        TableOptions.builder().schemaOptions(
+                                        CorfuOptions.SchemaOptions.newBuilder()
+                                                .addStreamTag(LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX)
+                                                .build())
+                                .build());
+    }
+
+    /**
+     * This is an internal method of this abstract listener and not exposed to clients.
+     *
+     * @param results is a map of stream UUID -> list of entries of this stream.
+     */
+    public final void onNext(CorfuStreamEntries results) {
+
+        // If this update came before the client's full sync timestamp, ignore it.
+        if (results.getTimestamp().getSequence() <= clientFullSyncTimestamp.get()) {
+            return;
+        }
+
+        Set<String> tableNames =
+                results.getEntries().keySet().stream().map(schema -> schema.getTableName()).collect(Collectors.toSet());
+
+
+        if (tableNames.contains(REPLICATION_STATUS_TABLE_NAME)) {
+            Preconditions.checkState(results.getEntries().keySet().size() == 1,
+                    "Replication Status Table Update received with other tables");
+            processReplicationStatusUpdate(results);
+            return;
+        }
+
+        // Data Updates
+        if (clientFullSyncPending.get()) {
+            // If the listener started when snapshot sync was ongoing, ignore all data updates until it ends.  When
+            // it ends, the client will perform a full sync and build a consistent state containing these updates.
+            return;
+        }
+
+        // Delete the corfu stream entries from the queue when it is processed by the client.
+        boolean callbackResult = false;
+        List<Queue.RoutingTableEntryMsg> rqEntries = null;
+        Map<TableSchema, List<CorfuStreamEntry>> entries = results.getEntries();
+        List<CorfuStreamEntry> csEntries = entries.entrySet().stream().map(Map.Entry::getValue).findFirst().get();
+        for (CorfuStreamEntry entry : csEntries) {
+            rqEntries.add((Queue.RoutingTableEntryMsg) entry.getPayload());
+        }
+        if (snapshotSyncInProgress.get()) {
+            // For routing queue listener, we have only 1 entry inside corfuStreamEntries.
+            callbackResult = processUpdatesInSnapshotSync(rqEntries);
+        } else {
+            callbackResult = processUpdatesInLogEntrySync(rqEntries);
+        }
+        if (callbackResult) {
+            // When the client processed the entry successfully, delete the entry from the routing queue.
+            deleteEntryFromQueue(results);
+        }
+        this.lastProcessedEntryTs = results.getTimestamp();
+    }
+
+    private void deleteEntryFromQueue(CorfuStreamEntries results) {
+        Map<TableSchema, List<CorfuStreamEntry>> entries = results.getEntries();
+        List<CorfuStreamEntry> routingQueueTableEntries = entries.entrySet().stream().map(Map.Entry::getValue).findFirst().get();
+
+        for (CorfuStreamEntry entry : routingQueueTableEntries) {
+            Queue.CorfuGuidMsg key = (Queue.CorfuGuidMsg)entry.getKey();
+            // Only process updates where operation type == UPDATE.
+            if (entry.getOperation() == CorfuStreamEntry.OperationType.UPDATE) {
+                try (TxnContext tx = corfuStore.txn(namespace)) {
+                    tx.delete(routingQueue, key);
+                    tx.commit();
+                }
+            }
+        }
+    }
+
+    private void processReplicationStatusUpdate(CorfuStreamEntries results) {
+        Map<TableSchema, List<CorfuStreamEntry>> entries = results.getEntries();
+
+        List<CorfuStreamEntry> replicationStatusTableEntries =
+                entries.entrySet().stream().filter(e -> e.getKey().getTableName().equals(REPLICATION_STATUS_TABLE_NAME))
+                        .map(Map.Entry::getValue)
+                        .findFirst()
+                        .get();
+
+        // Check if receiver routing queue is registered now.
+        // Snapshot sync would cause the status table updates. Here, we're checking at every update that the routing
+        // queue is registered by the sink manager. Before first update, sink manager should have registered the
+        // routing queue with table registry.
+
+        if (!routingQRegistered.get() && LogReplicationUtils.checkIfRoutingQueueExists(corfuStore, namespace,
+                LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX)) {
+            // Unsubscribe the LR status table
+            corfuStore.unsubscribeListener(this);
+            // Re-subscribe the LR status table && Subscribe the routing queue.
+            // TODO: Add the buffer size.
+            LogReplicationUtils.subscribeRqListener(this, namespace, 5, corfuStore);
+            routingQRegistered.set(true);
+            return;
+        }
+
+        for (CorfuStreamEntry entry : replicationStatusTableEntries) {
+
+            LogReplication.LogReplicationSession session = (LogReplication.LogReplicationSession)entry.getKey();
+
+            // Only process updates where operation type == UPDATE, model == Routing Queues and the client name
+            // matches
+            if (entry.getOperation() == CorfuStreamEntry.OperationType.UPDATE &&
+                    session.getSubscriber().getModel().equals(LogReplication.ReplicationModel.ROUTING_QUEUES) &&
+                    Objects.equals(session.getSubscriber().getClientName(), getClientName())) {
+                LogReplication.ReplicationStatus status = (LogReplication.ReplicationStatus)entry.getPayload();
+
+                if (status.getSinkStatus().getDataConsistent()) {
+                    // getDataConsistent() == true means that snapshot sync has ended.
+                    if (snapshotSyncInProgress.get()) {
+                        if (clientFullSyncPending.get()) {
+                            // Snapshot sync which was ongoing when the listener was subscribed has ended.  Attempt to
+                            // perform a full sync now.
+                            // TODO: Trigger full sync
+                            //  LogReplicationUtils.attemptClientFullSync(corfuStore, this, namespace);
+                            return;
+                        }
+                        // Process snapshot sync completion in steady state, i.e., client full sync is already complete
+                        snapshotSyncInProgress.set(false);
+                        onSnapshotSyncComplete();
+                    }
+                } else {
+                    // getDataConsistent() == false.  Snapshot sync has started.
+                    snapshotSyncInProgress.set(true);
+                    onSnapshotSyncStart();
+                }
+            }
+        }
+    }
+
+    public void resumeSubscription() {
+        if (lastProcessedEntryTs == null) {
+            log.warn("Last processed entry timestamp has not been set, failed to resume RQ subscription." +
+                    " Default to fallback subscription.");
+            return;
+        }
+
+        try {
+            log.info("Resume RQ subscription on [tag:{}] {} from {}", LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX,
+                    namespace, lastProcessedEntryTs);
+
+            LogReplicationUtils.subscribeRqListenerWithTs(this, namespace, 5, corfuStore,
+                    lastProcessedEntryTs.getSequence());
+        } catch (StreamingException e) {
+            log.error("Failed to resume subscription [tag:{}] from last processed entry {}. Re-subscribe based on " +
+                    "implemented fallback.", LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX, lastProcessedEntryTs, e);
+        }
+    }
+
+    //      -------- Methods to be implemented on the client/application  ---------------
+
+    /**
+     * Invoked when a snapshot sync start has been detected.
+     */
+    protected abstract void onSnapshotSyncStart();
+
+    /**
+     * Invoked when an ongoing snapshot sync completes
+     */
+    protected abstract void onSnapshotSyncComplete();
+
+    /**
+     * Invoked when data updates are received during a snapshot sync.  These updates will be the writes
+     * received as part of the snapshot sync
+     * @param results Entries received in a single transaction as part of a snapshot sync
+     */
+
+    // TODO: Change the param type from CorfuStreamEntries to RoutingTableEntryMsg
+    protected abstract boolean processUpdatesInSnapshotSync(List<Queue.RoutingTableEntryMsg> results);
+
+    /**
+     * Corresponds to void receiveDeltaMessages(List<ReceivedDeltaMessage> messages);
+     *
+     * Invoked when data updates are received as part of a LogEntry Sync.
+     * @param results Entries received in a single transaction as part of a log entry sync
+     */
+    // TODO: Change the param type from CorfuStreamEntries to RoutingTableEntryMsg
+    protected abstract boolean processUpdatesInLogEntrySync(List<Queue.RoutingTableEntryMsg> results);
+
+    /**
+     * Invoked by the Corfu runtime when this listener is being subscribed.  This method should
+     * read all application tables which the client is interested in merging together and perform the merge.
+     * @param txnContext transaction context in which the operation must be performed
+     */
+    protected abstract void performFullSyncAndMerge(TxnContext txnContext);
+
+    /**
+     * Name with which this client was registered using the interfaces in LogReplicationLogicalGroupClient
+     * @return client name
+     */
+    protected abstract String getClientName();
+
+    /**
+     * Callback to indicate that an error or exception has occurred while streaming or that the stream is
+     * shutting down. Some exceptions can be handled by restarting the stream (TrimmedException) while
+     * some errors (SystemUnavailableError) are unrecoverable.
+     * To be implemented on the client/application
+     * @param throwable
+     */
+
+    // On error, they have to re-subscribe. In the subscribe methods, we do the processing
+    // Or, Processing the queue
+    public void onError(Throwable throwable) {
+        // Handle Trim exception
+        // 1. Create a txn. TODO: Change it to scoped txn
+        // 2. Read all entries
+        // 3. subscribe listener with the scoped txn timestamp
+
+        log.error("Exception caught during routing queue streaming processing. Re-subscribe this listener to latest timestamp. " +
+                "Error=", throwable);
+
+        if (throwable instanceof TrimmedException) {
+            corfuStore.unsubscribeListener(this);
+            try (TxnContext tx = corfuStore.txn(namespace)) {
+                List<Table.CorfuQueueRecord> records = routingQueue.entryList();
+                for (int i = 0; i < records.size(); i++) {
+                    log.debug("Entry:" + records.get(i).getRecordId());
+                    Queue.CorfuGuidMsg recordId = records.get(i).getRecordId();
+                    Queue.RoutingTableEntryMsg entry = tx.getRecord(routingQueue, recordId).getPayload();
+                    boolean callbackResult = false;
+                    if (entry.getReplicationType() == Queue.ReplicationType.SNAPSHOT_SYNC) {
+                        callbackResult = processUpdatesInSnapshotSync(Collections.singletonList(entry));
+                    } else if (entry.getReplicationType() == Queue.ReplicationType.LOG_ENTRY_SYNC) {
+                        callbackResult = processUpdatesInLogEntrySync(Collections.singletonList(entry));
+                    }
+                    if (callbackResult) {
+                        this.lastProcessedEntryTs =
+                                Timestamp.newBuilder().setEpoch(0L)
+                                        .setSequence(records.get(i).getTxSequence().getTxSequence()).build();
+                        // When the client processed the entry successfully, delete the entry from the routing queue.
+                        tx.delete(routingQueue, recordId);
+                    }
+                }
+                log.info("Resume routing queue subscribtion onError");
+                resumeSubscription();
+            }
+        } else {
+            resumeSubscription();
+        }
+    }
+}
+

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -66,7 +66,7 @@ public final class LogReplicationUtils {
     public static final String REPLICATED_QUEUE_NAME_PREFIX = "LRQ_Recv_";
 
     // Stream tag applied to the replicated queue on the receiver
-    public static final String REPLICATED_QUEUE_TAG_PREFIX = "lrq_recv_";
+    public static final String REPLICATED_QUEUE_TAG = "lrq_recv";
 
     public static final String SNAPSHOT_END_MARKER_TABLE_NAME = "SnapshotSyncEndMarker";
 
@@ -100,11 +100,11 @@ public final class LogReplicationUtils {
         // Open the routing queue from corfu store (Disk backed mode)
         // since the subscribe API will run in client jvm
         // TODO: Get client name as input params. For now, hard coding the stream tag. and expose this API via corfuStore.
-        if (checkIfRoutingQueueExists(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX)) {
+        if (checkIfRoutingQueueExists(corfuStore, namespace, REPLICATED_QUEUE_TAG)) {
             // Table registry contains the routing queue already.
             corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationRoutingQueueListener(
                     clientListener, namespace, subscriptionTimestamp, bufferSize,
-                    getRoutingQueue(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX));
+                    getRoutingQueue(corfuStore, namespace, REPLICATED_QUEUE_TAG));
             log.info("Routing queue client subscription at timestamp {} successful.", subscriptionTimestamp);
         } else {
             // Routing queue is not registered at the sink (receiver side) yet.
@@ -122,9 +122,9 @@ public final class LogReplicationUtils {
         // Open the routing queue from corfu store (Disk backed mode)
         // since the subscribe API will run in policy jvm
         // TODO: Get client name as input params. For now, hard coding the stream tag.
-        if (checkIfRoutingQueueExists(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX)) {
+        if (checkIfRoutingQueueExists(corfuStore, namespace, REPLICATED_QUEUE_TAG)) {
             // Table registry contains the routing queue already.
-            String routingQueueName = getRoutingQueue(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX);
+            String routingQueueName = getRoutingQueue(corfuStore, namespace, REPLICATED_QUEUE_TAG);
             corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationRoutingQueueListener(
                     clientListener, namespace, subscriptionTimestamp, bufferSize, routingQueueName);
             log.info("Routing queue client subscription at timestamp {} successful.", subscriptionTimestamp);

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -62,8 +62,7 @@ public final class LogReplicationUtils {
 
     // Prefix of the name of queue as it will appear on the receiver after replicated.  The suffix will be the Sender
     // (Source) cluster id Receiving queues per client name.
-    // Example: LRQ_Recv_<client_name>_<source_id>
-    public static final String REPLICATED_QUEUE_NAME_PREFIX = "LRQ_Recv_";
+    public static final String REPLICATED_QUEUE_NAME = "LRQ_Recv";
 
     // Stream tag applied to the replicated queue on the receiver
     public static final String REPLICATED_QUEUE_TAG = "lrq_recv";

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -6,25 +6,28 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
-import org.corfudb.runtime.collections.CorfuStore;
-import org.corfudb.runtime.collections.CorfuStoreEntry;
-import org.corfudb.runtime.collections.Table;
-import org.corfudb.runtime.collections.TableOptions;
-import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.runtime.exceptions.AbortCause;
-import org.corfudb.runtime.exceptions.StreamingException;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
 import org.corfudb.runtime.LogReplication.ReplicationStatus;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.collections.CorfuStoreEntry;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.StreamingException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
+
 import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -40,6 +43,41 @@ public final class LogReplicationUtils {
     // Retain the old name from LR v1 to avoid polluting the registry table with stale entries.
     public static final String REPLICATION_STATUS_TABLE_NAME = "LogReplicationStatus";
 
+    // /-------Constants specific to the RoutingQueue Model --------/
+
+    // Name of shared queue on the sender where log entry sync updates are placed transactionally
+    public static final String LOG_ENTRY_SYNC_QUEUE_NAME_SENDER = "LRQ_Send_LogEntries";
+
+    // Prefix of destination specific stream tag applied to entries on LOG_ENTRY_SYNC_QUEUE_NAME_SENDER
+    public static final String LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX = "lrq_logentry_";
+
+    // Name of shared queue on the sender where snapshot sync updates are placed
+    public static final String SNAPSHOT_SYNC_QUEUE_NAME_SENDER = "LRQ_Send_SnapSync";
+
+    // Prefix of destination specific stream tag applied to entries on SNAPSHOT_SYNC_QUEUE_NAME_SENDER
+    public static final String SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX = "lrq_snapsync_";
+
+    // Prefix of the name of queue as it will appear on the receiver after replicated.  The suffix will be the Sender
+    // (Source) cluster id Receiving queues per client name.
+    // Example: LRQ_Recv_<client_name>_<source_id>
+    public static final String REPLICATED_QUEUE_NAME_PREFIX = "LRQ_Recv_";
+
+    // Stream tag applied to the replicated queue on the receiver
+    public static final String REPLICATED_QUEUE_TAG_PREFIX = "lrq_recv_";
+
+    public static final String SNAPSHOT_END_MARKER_TABLE_NAME = "SnapshotSyncEndMarker";
+
+    // ---- End RoutingQueue Model constants -------/
+
+    public static final UUID lrLogEntrySendQId = CorfuRuntime.getStreamID(TableRegistry
+            .getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER));
+    public static final UUID lrFullSyncSendQId = CorfuRuntime.getStreamID(TableRegistry
+            .getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_SYNC_QUEUE_NAME_SENDER));
+
+    public static boolean skipCheckpointFor(UUID streamId) {
+        return streamId.equals(lrLogEntrySendQId) || streamId.equals(lrFullSyncSendQId);
+    }
+
     private LogReplicationUtils() { }
 
     public static void subscribe(@Nonnull LogReplicationListener clientListener, @Nonnull String namespace,
@@ -50,6 +88,51 @@ public final class LogReplicationUtils {
         corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationListener(
                 clientListener, namespace, streamTag, tablesOfInterest, subscriptionTimestamp, bufferSize);
         log.info("Client subscription at timestamp {} successful.", subscriptionTimestamp);
+    }
+
+    public static void subscribeRqListener(@Nonnull LogReplicationRoutingQueueListener clientListener, @Nonnull String namespace,
+                                           int bufferSize, CorfuStore corfuStore) {
+
+        long subscriptionTimestamp = getRoutingQueueSubscriptionTimestamp(corfuStore, namespace, clientListener);
+        // Open the routing queue from corfu store (Disk backed mode)
+        // since the subscribe API will run in client jvm
+        // TODO: Get client name as input params. For now, hard coding the stream tag. and expose this API via corfuStore.
+        if (checkIfRoutingQueueExists(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX)) {
+            // Table registry contains the routing queue already.
+            corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationRoutingQueueListener(
+                    clientListener, namespace, subscriptionTimestamp, bufferSize,
+                    getRoutingQueue(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX));
+            log.info("Routing queue client subscription at timestamp {} successful.", subscriptionTimestamp);
+        } else {
+            // Routing queue is not registered at the sink (receiver side) yet.
+            // Subscribe to LR status table and poll for routing queue registry
+            corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationLrStatusTableListener(
+                    clientListener, subscriptionTimestamp, bufferSize);
+            log.info("Subscribed to LR status table at timestamp {}.", subscriptionTimestamp);
+        }
+    }
+
+    public static void subscribeRqListenerWithTs(@Nonnull LogReplicationRoutingQueueListener clientListener,
+                                                 @Nonnull String namespace, int bufferSize, CorfuStore corfuStore,
+                                                 long subscriptionTimestamp) {
+
+        // Open the routing queue from corfu store (Disk backed mode)
+        // since the subscribe API will run in policy jvm
+        // TODO: Get client name as input params. For now, hard coding the stream tag.
+        if (checkIfRoutingQueueExists(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX)) {
+            // Table registry contains the routing queue already.
+            String routingQueueName = getRoutingQueue(corfuStore, namespace, REPLICATED_QUEUE_TAG_PREFIX);
+            corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationRoutingQueueListener(
+                    clientListener, namespace, subscriptionTimestamp, bufferSize, routingQueueName);
+            log.info("Routing queue client subscription at timestamp {} successful.", subscriptionTimestamp);
+        } else {
+            // Routing queue is not registered at the sink (receiver side) yet.
+            // Subscribe to LR status table and poll for routing queue registry
+            // TODO: Figure out the discovery way other than listening to status table.
+            corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationLrStatusTableListener(
+                    clientListener, subscriptionTimestamp, bufferSize);
+            log.info("Subscribed to LR status table at timestamp {}.", subscriptionTimestamp);
+        }
     }
 
 
@@ -155,6 +238,108 @@ public final class LogReplicationUtils {
             MicroMeterUtils.time(subscribeTimer, "logreplication.subscribe.duration");
         }
     }
+    private static long getRoutingQueueSubscriptionTimestamp(CorfuStore corfuStore, String namespace,
+                                                             LogReplicationRoutingQueueListener clientListener) {
+        Optional<Counter> mvoTrimCounter = MicroMeterUtils.counter("logreplication.subscribe.trim.count");
+        Optional<Counter> conflictCounter = MicroMeterUtils.counter("logreplication.subscribe.conflict.count");
+        Optional<Timer.Sample> subscribeTimer = MicroMeterUtils.startTimer();
+
+        Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable =
+                openReplicationStatusTable(corfuStore);
+
+        try {
+            return IRetry.build(IntervalRetry.class, () -> {
+                try (TxnContext txnContext = corfuStore.txn(namespace)) {
+                    // The transaction is started in the client's namespace and the Replication Status table resides in the
+                    // system namespace.  Corfu Store does not validate the cross-namespace access as long as there are no
+                    // writes on the table in the different namespace.  This hack is required here as we want client full
+                    // sync to happen in the same transaction which checks the status of a snapshot sync so that there is no
+                    // window between the check and full sync.
+                    List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
+                            txnContext.executeQuery(replicationStatusTable,
+                                    entry -> entry.getKey().getSubscriber().getModel()
+                                            .equals(LogReplication.ReplicationModel.ROUTING_QUEUES) &&
+                                            Objects.equals(entry.getKey().getSubscriber().getClientName(),
+                                                    clientListener.getClientName()));
+
+                    CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message> entry = null;
+
+                    // It is possible that there is no entry for the routing queue Model in the status table in
+                    // the following scenarios:
+                    // 1. Request to subscribe is received before the Log Replication JVM or pod starts and
+                    // initializes the table
+                    // 2. Topology change which removes this cluster from the status table.
+                    // We cannot differentiate between the two cases here so continue with the right
+                    // behavior for the 1st case, i.e., subscribe and wait for the initial Snapshot Sync to get
+                    // triggered.  If we are here because of the second case, the listener will not get any updates
+                    // from LR and subscription will be a no-op.
+                    if (entries.isEmpty()) {
+                        log.info("No record for client {} and Logical Group Model found in the Status Table.  " +
+                                "Subscription could have been attempted before LR startup.  Subscribe the listener and" +
+                                "wait for initial Snapshot Sync", clientListener.getClientName());
+                    } else {
+                        // For a given replication model and client, any Sink node will have a single session.
+                        Preconditions.checkState(entries.size() == 1);
+                        entry = entries.get(0);
+                    }
+
+                    boolean snapshotSyncInProgress = false;
+
+                    if (entry == null || entry.getPayload().getSinkStatus().getDataConsistent()) {
+                        // No snapshot sync is in progress
+                        log.info("No Snapshot Sync is in progress.  Request the client to perform a full sync on its " +
+                                "tables.");
+                        Optional<Timer.Sample> clientFullSyncTimer = MicroMeterUtils.startTimer();
+                        long clientFullSyncStartTime = System.currentTimeMillis();
+                        clientListener.performFullSyncAndMerge(txnContext);
+                        long clientFullSyncEndTime = System.currentTimeMillis();
+                        MicroMeterUtils.time(clientFullSyncTimer, "logreplication.client.fullsync.duration");
+                        log.info("Client Full Sync and Merge took {} ms",
+                                clientFullSyncEndTime - clientFullSyncStartTime);
+                    } else {
+                        // Snapshot sync is in progress.  Subscribe without performing a full sync on the tables.
+                        log.info("Snapshot Sync is in progress.  Subscribing without performing a full sync on client" +
+                                " tables.");
+                        snapshotSyncInProgress = true;
+                    }
+                    txnContext.commit();
+
+                    // Subscribe from the snapshot timestamp of this transaction, i.e., log tail when the transaction started.
+                    // Subscribing from the commit address will result in missed updates which took place between the start
+                    // and end of the transaction because reads in a transaction observe updates only till the snapshot when it
+                    // started.
+                    long subscriptionTimestamp = txnContext.getTxnSequence();
+
+                    // Update the flags and variables on the listener based on whether snapshot sync was in progress.
+                    // This must be done only after the transaction commits.
+                    setRoutingQueueListenerParamsForSnapshotSync(clientListener, subscriptionTimestamp, snapshotSyncInProgress);
+
+                    return subscriptionTimestamp;
+                } catch (TransactionAbortedException tae) {
+                    if (tae.getCause() instanceof TrimmedException) {
+                        // If the snapshot version where this transaction started has been evicted from the JVM's MVO
+                        // cache, a trimmed exception is thrown and requires a retry at a later timestamp.
+                        incrementCount(mvoTrimCounter);
+                        log.warn("Snapshot no longer available in the cache.  Retrying.", tae);
+                    } else if (tae.getAbortCause() == AbortCause.CONFLICT) {
+                        // Concurrent updates to the client's tables
+                        incrementCount(conflictCounter);
+                        log.warn("Concurrent updates to client tables.  Retrying.", tae);
+                    } else {
+                        log.error("Unexpected type of Transaction Aborted Exception", tae);
+                    }
+                    throw new RetryNeededException();
+                } catch (Exception e) {
+                    log.error("Unexpected exception type hit", e);
+                    throw new RetryNeededException();
+                }
+            }).run();
+        } catch (InterruptedException e) {
+            throw new StreamingException(e, StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
+        } finally {
+            MicroMeterUtils.time(subscribeTimer, "logreplication.subscribe.duration");
+        }
+    }
 
 
     private static Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(CorfuStore corfuStore) {
@@ -168,6 +353,21 @@ public final class LogReplicationUtils {
         }
     }
 
+    public static boolean checkIfRoutingQueueExists(CorfuStore corfuStore, String namespace, String streamTag) {
+        List<String> tablesOfInterest = corfuStore.getTablesOfInterest(namespace, streamTag);
+        return tablesOfInterest.size() != 0;
+    }
+    
+    public static String getRoutingQueue(CorfuStore corfuStore, String namespace, String streamTag) {
+        String routingQueueName = null;
+        List<String> tablesOfInterest = corfuStore.getTablesOfInterest(namespace, streamTag);
+        if (tablesOfInterest.size() != 0) {
+            // Currently, we have only 1 routing queue at sink side. So, return the first table.
+            routingQueueName = tablesOfInterest.get(0);
+        }
+        return routingQueueName;
+    }
+
     private static void setListenerParamsForSnapshotSync(LogReplicationListener listener, long subscriptionTimestamp,
                                                          boolean snapshotSyncInProgress) {
         updateListenerFlagsForSnapshotSync(listener, snapshotSyncInProgress);
@@ -178,8 +378,25 @@ public final class LogReplicationUtils {
         }
     }
 
+    private static void setRoutingQueueListenerParamsForSnapshotSync(LogReplicationRoutingQueueListener listener,
+                                                                     long subscriptionTimestamp,
+                                                                     boolean snapshotSyncInProgress) {
+        updateRoutingQueueListenerFlagsForSnapshotSync(listener, snapshotSyncInProgress);
+
+        // If client full sync was done, set its timestamp
+        if (!snapshotSyncInProgress) {
+            listener.getClientFullSyncTimestamp().set(subscriptionTimestamp);
+        }
+    }
+
     private static void updateListenerFlagsForSnapshotSync(LogReplicationListener clientListener,
                                                            boolean snapshotSyncInProgress) {
+        clientListener.getClientFullSyncPending().set(snapshotSyncInProgress);
+        clientListener.getSnapshotSyncInProgress().set(snapshotSyncInProgress);
+    }
+
+    private static void updateRoutingQueueListenerFlagsForSnapshotSync(LogReplicationRoutingQueueListener clientListener,
+                                                                       boolean snapshotSyncInProgress) {
         clientListener.getClientFullSyncPending().set(snapshotSyncInProgress);
         clientListener.getSnapshotSyncInProgress().set(snapshotSyncInProgress);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -38,6 +38,9 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
  */
 @Slf4j
 public final class LogReplicationUtils {
+    public static final String DEMO_NAMESPACE = "nsx";
+
+
     public static final String LR_STATUS_STREAM_TAG = "lr_status";
 
     // Retain the old name from LR v1 to avoid polluting the registry table with stale entries.
@@ -70,9 +73,9 @@ public final class LogReplicationUtils {
     // ---- End RoutingQueue Model constants -------/
 
     public static final UUID lrLogEntrySendQId = CorfuRuntime.getStreamID(TableRegistry
-            .getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER));
+            .getFullyQualifiedTableName(DEMO_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER));
     public static final UUID lrFullSyncSendQId = CorfuRuntime.getStreamID(TableRegistry
-            .getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_SYNC_QUEUE_NAME_SENDER));
+            .getFullyQualifiedTableName(DEMO_NAMESPACE, SNAPSHOT_SYNC_QUEUE_NAME_SENDER));
 
     public static boolean skipCheckpointFor(UUID streamId) {
         return streamId.equals(lrLogEntrySendQId) || streamId.equals(lrFullSyncSendQId);

--- a/runtime/src/main/java/org/corfudb/runtime/RoutingQueueReceiverClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RoutingQueueReceiverClient.java
@@ -1,0 +1,25 @@
+package org.corfudb.runtime;
+
+import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
+import org.corfudb.runtime.collections.FullStateMessage;
+
+import java.util.List;
+
+public class RoutingQueueReceiverClient {
+    /**
+     * Receives batch of the delta messages.
+     * Each message in the list represent one transaction. Processing of entire batch must be transient.
+     *
+     * @param messages list of transactional delta messages
+     */
+    void receiveDeltaMessages(List<RoutingTableEntryMsg> messages) {}
+
+    /**
+     * Asks application to receive new full state in synchronous mode.
+     * Application must implement one of receiveNewState methods and can throw UnsupportedOperationException
+     * if method is not supported.
+     * <p>
+     * Application must apply deltas to inconsistent set of full data to get consistent state.
+     */
+    void receiveNewState(String sourceSiteId, List<FullStateMessage> fullState) {}
+}

--- a/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
@@ -95,8 +95,12 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
         for (RoutingTableEntryMsg message : messages) {
             log.info("Enqueuing message to delta queue, message: {}", message);
             txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
-                    .map(destination -> TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE,
-                            LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination))
+                    .map(destination -> {
+                        log.info("Stream tag ID: {}", TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE,
+                                LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination));
+                        return TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE,
+                                LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination);
+                    })
                     .collect(Collectors.toList()), corfuStore);
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 @Slf4j
 public class RoutingQueueSenderClient extends LogReplicationClient implements LogReplicationRoutingQueueClient {
@@ -48,7 +48,7 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
         Preconditions.checkArgument(isValid(clientName), "clientName is null or empty.");
 
         this.corfuStore = new CorfuStore(runtime);
-        logEntryQ = corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER,
+        logEntryQ = corfuStore.openQueue(DEMO_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER,
                 RoutingTableEntryMsg.class, TableOptions.fromProtoSchema(RoutingTableEntryMsg.class));
 
         register(corfuStore, clientName, model);

--- a/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
@@ -1,0 +1,95 @@
+package org.corfudb.runtime;
+
+import com.google.common.base.Preconditions;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
+import org.corfudb.runtime.LogReplication.ReplicationModel;
+import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
+import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+public class RoutingQueueSenderClient extends LogReplicationClient implements LogReplicationRoutingQueueClient {
+    private static final ReplicationModel model = ReplicationModel.ROUTING_QUEUES;
+
+    // TODO (V2): This field should be removed after the rpc stream is added for Sink side session creation.
+    public static final String DEFAULT_ROUTING_QUEUE_CLIENT = "00000000-0000-0000-0000-0000000000002";
+
+    private Table<Queue.CorfuGuidMsg, RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> logEntryQ;
+    private CorfuStore corfuStore;
+
+    public RoutingQueueSenderClient() {
+        // TODO: This might be removed in the future. Temporary solution for bypassing providing a CorfuRuntime
+    }
+
+    /**
+     * Constructor for the log replication client for routing queues on sender.
+     *
+     * @param runtime Corfu Runtime.
+     * @param clientName String representation of the client name. This parameter is case-sensitive.
+     * @throws IllegalArgumentException If clientName is null or empty.
+     * @throws InvocationTargetException InvocationTargetException.
+     * @throws NoSuchMethodException NoSuchMethodException.
+     * @throws IllegalAccessException IllegalAccessException.
+     */
+    public RoutingQueueSenderClient(CorfuRuntime runtime, String clientName)
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        Preconditions.checkArgument(isValid(clientName), "clientName is null or empty.");
+
+        this.corfuStore = new CorfuStore(runtime);
+        logEntryQ = corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER,
+                RoutingTableEntryMsg.class, TableOptions.fromProtoSchema(RoutingTableEntryMsg.class));
+
+        register(corfuStore, clientName, model);
+    }
+
+    /**
+     * Enqueues message to be replicated onto the sender's delta queue.
+     *
+     * @param txn Transaction context in which the operation will be performed
+     * @param message RoutingTableEntryMsg
+     */
+    @Override
+    public void transmitDeltaMessage(TxnContext txn, RoutingTableEntryMsg message) {
+        txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
+                .map(x -> UUID.fromString(String.join("", LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX, x)))
+                .collect(Collectors.toList()), corfuStore);
+        log.debug("Enqueued message to delta queue, message: {}", message);
+    }
+
+    /**
+     * Enqueues messages to be replicated onto the sender's delta queue.
+     *
+     * @param txn Transaction context in which the operation will be performed
+     * @param messages List of RoutingTableEntryMsg
+     */
+    @Override
+    public void transmitDeltaMessages(TxnContext txn, List<RoutingTableEntryMsg> messages) {
+        for (RoutingTableEntryMsg message : messages) {
+            txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
+                    .map(x -> UUID.fromString(String.join("", LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX, x)))
+                    .collect(Collectors.toList()), corfuStore);
+            log.debug("Enqueued message to delta queue, message: {}", message);
+        }
+    }
+
+    /**
+     * Request LR to perform a forced snapshot sync.
+     *
+     * @param timestamp Timestamp from which recovery is possible.
+     */
+    public void requestSnapshotSync(Timestamp timestamp) {
+
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
@@ -9,10 +9,10 @@ import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.TableRegistry;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
@@ -62,10 +62,10 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
      */
     @Override
     public void transmitDeltaMessage(TxnContext txn, RoutingTableEntryMsg message) {
+        log.info("Enqueuing message to delta queue, message: {}", message);
         txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
-                .map(x -> UUID.fromString(String.join("", LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX, x)))
+                .map(destination -> TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination))
                 .collect(Collectors.toList()), corfuStore);
-        log.debug("Enqueued message to delta queue, message: {}", message);
     }
 
     /**
@@ -77,10 +77,10 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
     @Override
     public void transmitDeltaMessages(TxnContext txn, List<RoutingTableEntryMsg> messages) {
         for (RoutingTableEntryMsg message : messages) {
+            log.info("Enqueuing message to delta queue, message: {}", message);
             txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
-                    .map(x -> UUID.fromString(String.join("", LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX, x)))
+                    .map(destination -> TableRegistry.getStreamIdForStreamTag(DEMO_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination))
                     .collect(Collectors.toList()), corfuStore);
-            log.debug("Enqueued message to delta queue, message: {}", message);
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/TransmitterReplicationModule.java
+++ b/runtime/src/main/java/org/corfudb/runtime/TransmitterReplicationModule.java
@@ -1,0 +1,11 @@
+package org.corfudb.runtime;
+
+public interface TransmitterReplicationModule {
+    /**
+     * Full state data is requested for the application.
+     * It is expected that this call is non-blocking and data will be provided in different thread.
+     *
+     * @param context replication context
+     */
+    void provideFullStateData(FullStateReplicationContext context);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -447,7 +447,7 @@ public class CorfuStore {
      * @param streamTag
      * @return table names (without namespace prefix)
      */
-    private List<String> getTablesOfInterest(@Nonnull String namespace, @Nonnull String streamTag) {
+    public List<String> getTablesOfInterest(@Nonnull String namespace, @Nonnull String streamTag) {
         List<String> tablesOfInterest = runtime.getTableRegistry().listTables(namespace, streamTag);
         log.info("Tag[{}${}] :: Subscribing to {} tables - {}", namespace, streamTag, tablesOfInterest.size(), tablesOfInterest);
         return tablesOfInterest;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -313,6 +313,17 @@ public class CorfuStore {
     }
 
     /**
+     * TODO: Remove this!
+     * Temporary hack for subscribing simplified version of routing queue listener from trim mark
+     */
+    public void subscribeListenerFromTrimMark(@Nonnull StreamListener streamListener, @Nonnull String namespace,
+                                              @Nonnull String streamTag) {
+        Token token = runtime.getAddressSpaceView().getTrimMark();
+        Timestamp ts = Timestamp.newBuilder().setEpoch(token.getEpoch()).setSequence(token.getSequence()).build();
+        this.subscribeListener(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag), ts);
+    }
+
+    /**
      * Subscribe to transaction updates on specific tables with the streamTag in the namespace.
      * Objects returned will honor transactional boundaries.
      * <p>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/DataLocator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/DataLocator.java
@@ -1,0 +1,24 @@
+package org.corfudb.runtime.collections;
+
+import lombok.Getter;
+
+public class DataLocator {
+    /**
+     * Fully qualified corfu table name.
+     *
+     */
+    @Getter
+    private final String tableName;
+
+    /**
+     * Serialized key of the modified record.
+     *
+     */
+    @Getter
+    private final byte[] key;
+
+    public DataLocator(String tableName, byte[] key) {
+        this.tableName = tableName;
+        this.key = key;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/FullStateMessage.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/FullStateMessage.java
@@ -1,0 +1,21 @@
+package org.corfudb.runtime.collections;
+
+import lombok.Getter;
+import javax.annotation.Nullable;
+
+public class FullStateMessage {
+    @Getter
+    private final DataLocator dataLocator;
+
+    @Getter
+    private final byte[] payload;
+
+    @Getter
+    private final byte[] metaValue;
+
+    public FullStateMessage(DataLocator dataLocator, byte[] payload, @Nullable byte[] metaValue) {
+        this.dataLocator = dataLocator;
+        this.payload = payload;
+        this.metaValue = metaValue;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
+import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
 import org.corfudb.runtime.CorfuRuntime;
@@ -17,6 +18,7 @@ import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.ProtobufSerializer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -323,6 +325,61 @@ public class Table<K extends Message, V extends Message, M extends Message> {
     }
 
     /**
+     * Appends the specified element to the end of this unbounded queue, without materializing the queue in memory.
+     *
+     * @param e the element to add
+     * @param streamTags  - stream tags associated to the given stream id
+     * @param corfuStore CorfuStore that gets the runtime for the serializer.
+     * @throws IllegalArgumentException if some property of the specified
+     *                                  element prevents it from being added to the queue.
+     */
+    public K logUpdateEnqueue(V e, List<UUID> streamTags, CorfuStore corfuStore) {
+        /**
+         * This is a callback that is placed into the root transaction's context on
+         * the thread local stack which will be invoked right after this transaction
+         * is deemed successful and has obtained a final sequence number to write.
+         */
+        @AllArgsConstructor
+        class QueueEntryAddressGetter implements TransactionalContext.PreCommitListener {
+            private CorfuRecord<V, M> record;
+
+            /**
+             * If we are in a transaction, determine the commit address and fix it up in
+             * the queue entry's metadata.
+             * @param tokenResponse - the sequencer's token response returned.
+             */
+            @Override
+            public void preCommitCallback(TokenResponse tokenResponse) {
+                record.setMetadata((M) Queue.CorfuQueueMetadataMsg.newBuilder()
+                        .setTxSequence(tokenResponse.getSequence()).build());
+                log.trace("preCommitCallback for Queue: " + tokenResponse);
+            }
+        }
+
+        // Obtain a cluster-wide unique 64-bit id to identify this entry in the queue.
+        long entryId = guidGenerator.nextLong();
+        // Embed this key into a protobuf.
+        K keyOfQueueEntry = (K) Queue.CorfuGuidMsg.newBuilder().setInstanceId(entryId).build();
+
+        // Prepare a partial record with the queue's payload and temporary metadata that will be overwritten
+        // by the QueueEntryAddressGetter callback above when the transaction finally commits.
+        CorfuRecord<V, M> queueEntry = new CorfuRecord<>(e,
+                (M) Queue.CorfuQueueMetadataMsg.newBuilder().setTxSequence(0).build());
+
+        QueueEntryAddressGetter addressGetter = new QueueEntryAddressGetter(queueEntry);
+        log.trace("enqueue: Adding preCommitListener for Queue: " + e.toString());
+        TransactionalContext.getRootContext().addPreCommitListener(addressGetter);
+
+        Object[] smrArgs = new Object[2];
+        smrArgs[0] = keyOfQueueEntry;
+        smrArgs[1] = queueEntry;
+        TransactionalContext.getCurrentContext().logUpdate(this.getStreamUUID(), new SMREntry("put", smrArgs,
+                corfuStore.getRuntime().getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE)),
+                streamTags);
+        return keyOfQueueEntry;
+    }
+
+    /**
      * Returns a List of CorfuQueueRecords sorted by the order in which the enqueue materialized.
      * This is the primary method of consumption of entries enqueued into CorfuQueue.
      *
@@ -341,7 +398,6 @@ public class Table<K extends Message, V extends Message, M extends Message> {
                     long r2Sequence = ((Queue.CorfuQueueMetadataMsg) rec2.getValue().getMetadata()).getTxSequence();
                     return CorfuQueueRecord.compareTo(r1EntryId, r2EntryId, r1Sequence, r2Sequence);
                 };
-
         List<CorfuQueueRecord> copy = new ArrayList<>(corfuTable.size());
         for (Map.Entry<K, CorfuRecord<V, M>> entry : corfuTable.entryStream()
                 .sorted(queueComparator).collect(Collectors.toList())) {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -451,6 +451,27 @@ public class TxnContext implements AutoCloseable {
         return ret;
     }
 
+    /**
+     * This API is used to add an entry to the CorfuQueue without materializing the queue in memory.
+     *
+     * @param table  Table object to operate on the queue.
+     * @param record Record to be added.
+     * @param streamTags  - stream tags associated to the given stream id
+     * @param corfuStore CorfuStore that gets the runtime for the serializer.
+     * @param <K>    Type of Key.
+     * @param <V>    Type of Value.
+     * @param <M>    Type of Metadata.
+     * @return K the type of key this queue table was created with.
+     */
+    @Nonnull
+    public <K extends Message, V extends Message, M extends Message>
+    K logUpdateEnqueue(@Nonnull Table<K, V, M> table,
+                                    @Nonnull final V record, List<UUID> streamTags, CorfuStore corfuStore) {
+        K ret = table.logUpdateEnqueue(record, streamTags, corfuStore);
+        tablesUpdated.putIfAbsent(table.getStreamUUID(), table);
+        return ret;
+    }
+
     // *************************** READ API *****************************************
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingManager.java
@@ -133,7 +133,7 @@ public class StreamingManager {
         // TODO: Check if we need to modify the addLRTask for multiple tags per namespace
         Map<String, String> nsToStreamTags = new HashMap<>();
         nsToStreamTags.put(CORFU_SYSTEM_NAMESPACE, LR_STATUS_STREAM_TAG);
-        nsToStreamTags.put(namespace, REPLICATED_QUEUE_TAG_PREFIX);
+        nsToStreamTags.put(namespace, REPLICATED_QUEUE_TAG);
         this.scheduler.addLRTask(streamListener, nsToStreamTags, nsToTableName, lastAddress,
                 bufferSize == 0 ? defaultBufferSize : bufferSize);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -200,7 +200,8 @@ public class TableRegistry {
      * @throws InvocationTargetException If this is not a protobuf message.
      * @throws IllegalAccessException    If this is not a protobuf message.
      */
-    private <K extends Message, V extends Message, M extends Message>
+    // Exposing for PoC
+    public <K extends Message, V extends Message, M extends Message>
     void registerTable(@Nonnull String namespace,
                        @Nonnull String tableName,
                        @Nonnull Class<K> keyClass,

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -10,13 +10,22 @@ import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.CorfuOptions;
+import org.corfudb.runtime.LogReplicationRoutingQueueListener;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.Address;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
 
 /**
  * Tests the apis in LogReplicationUtils.
@@ -28,6 +37,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
     private CorfuRuntime corfuRuntime;
     private CorfuStore corfuStore;
     private LogReplicationListener lrListener;
+    private LogReplicationRoutingQueueListener lrRqListener;
     private Table<LogReplication.LogReplicationSession, LogReplication.ReplicationStatus, Message> replicationStatusTable;
     private String namespace = "test_namespace";
     private String client = "test_client";
@@ -37,6 +47,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         corfuRuntime = getDefaultRuntime();
         corfuStore = new CorfuStore(corfuRuntime);
         lrListener = new LogReplicationTestListener(corfuStore, namespace, client);
+        lrRqListener = new LogReplicationTestRoutingQueueListener(corfuStore, namespace, client);
         replicationStatusTable = TestUtils.openReplicationStatusTable(corfuStore);
     }
 
@@ -85,6 +96,11 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         testSubscribe(true, true);
     }
 
+    @Test
+    public void testRoutingQueueSubscribeSnapshotSyncComplete() {
+        testRoutingQueueSubscribe(true, false);
+    }
+
     /**
      * Test the behavior of subscribe() when LR Snapshot sync is complete.  The flags and variables on the listener
      * must be updated correctly.
@@ -112,6 +128,51 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         String streamTag = "test_tag";
         LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
         verifyListenerFlags((LogReplicationTestListener)lrListener, ongoing);
+    }
+
+    private void executeTxn(CorfuStore store, String namespace, Consumer<TxnContext> mutation) {
+        try (TxnContext tx = store.txn(namespace)) {
+            mutation.accept(tx);
+            tx.commit();
+        }
+    }
+
+    private void testRoutingQueueSubscribe(boolean initializeTable, boolean ongoing) {
+        if (initializeTable) {
+            TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, client, ongoing);
+        }
+
+        // Open routing queue before the subscribe call at the receiver.
+        String recvQueueName = LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+        Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> routingQueue;
+        try {
+            routingQueue =
+                    corfuStore.openQueue(namespace, recvQueueName,
+                            Queue.RoutingTableEntryMsg.class,
+                            TableOptions.builder().schemaOptions(
+                                            CorfuOptions.SchemaOptions.newBuilder()
+                                                    .addStreamTag(LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX)
+                                                    .build())
+                                    .build());
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Subscribe to the routing queue.
+        LogReplicationUtils.subscribeRqListener(lrRqListener, namespace, 5, corfuStore);
+
+        // Update the queue to verify the listener works
+        List<UUID> tags = new ArrayList<>();
+        tags.add(CorfuRuntime.getStreamID(LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX));
+        // TODO: tx.enqueue and logUpdateEnqueue complains on the remote UT for unable to get guid. Removing it for now.
+        // executeTxn(corfuStore, namespace, (TxnContext tx) -> tx.logUpdateEnqueue(routingQueue,
+        //        Queue.RoutingTableEntryMsg.newBuilder().addDestinations(tx.getNamespace()).build(),
+        //        tags, corfuStore));
+        verifyRoutingQueueListenerFlags((LogReplicationTestRoutingQueueListener)lrRqListener, ongoing);
     }
 
     @Test
@@ -172,6 +233,20 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         }
     }
 
+    private void verifyRoutingQueueListenerFlags(LogReplicationTestRoutingQueueListener listener, boolean snapshotSyncOngoing) {
+        if (snapshotSyncOngoing) {
+            Assert.assertTrue(listener.getClientFullSyncPending().get());
+            Assert.assertTrue(listener.getSnapshotSyncInProgress().get());
+            Assert.assertEquals(Address.NON_ADDRESS, listener.getClientFullSyncTimestamp().get());
+            Assert.assertFalse(listener.performFullSyncInvoked);
+        } else {
+            Assert.assertFalse(listener.getClientFullSyncPending().get());
+            Assert.assertFalse(listener.getSnapshotSyncInProgress().get());
+            Assert.assertFalse(listener.getRoutingQRegistered().get());
+            Assert.assertNotEquals(Address.NON_ADDRESS, listener.getClientFullSyncTimestamp().get());
+            Assert.assertTrue(listener.performFullSyncInvoked);
+        }
+    }
     @After
     public void cleanUp() {
         corfuRuntime.shutdown();
@@ -199,6 +274,50 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
 
         @Override
         protected void processUpdatesInLogEntrySync(CorfuStreamEntries results) {}
+
+        @Override
+        protected void performFullSyncAndMerge(TxnContext txnContext) {
+            performFullSyncInvoked = true;
+        }
+
+        @Override
+        protected String getClientName() {
+            return clientName;
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log.error("Error in Test Listener", throwable);
+        }
+    }
+
+    private class LogReplicationTestRoutingQueueListener extends LogReplicationRoutingQueueListener {
+
+        private boolean performFullSyncInvoked = false;
+
+        private String clientName;
+
+        LogReplicationTestRoutingQueueListener(CorfuStore corfuStore, String namespace, String clientName) throws
+                InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+            super(corfuStore, namespace);
+            this.clientName = clientName;
+        }
+
+        @Override
+        protected void onSnapshotSyncStart() {}
+
+        @Override
+        protected void onSnapshotSyncComplete() {}
+
+        @Override
+        protected boolean processUpdatesInSnapshotSync(List<Queue.RoutingTableEntryMsg> results) {
+            return true;
+        }
+
+        @Override
+        protected boolean processUpdatesInLogEntrySync(List<Queue.RoutingTableEntryMsg> results) {
+            return true;
+        }
 
         @Override
         protected void performFullSyncAndMerge(TxnContext txnContext) {

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -151,7 +151,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
                             Queue.RoutingTableEntryMsg.class,
                             TableOptions.builder().schemaOptions(
                                             CorfuOptions.SchemaOptions.newBuilder()
-                                                    .addStreamTag(LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX)
+                                                    .addStreamTag(LogReplicationUtils.REPLICATED_QUEUE_TAG)
                                                     .build())
                                     .build());
         } catch (NoSuchMethodException e) {
@@ -167,7 +167,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
 
         // Update the queue to verify the listener works
         List<UUID> tags = new ArrayList<>();
-        tags.add(CorfuRuntime.getStreamID(LogReplicationUtils.REPLICATED_QUEUE_TAG_PREFIX));
+        tags.add(CorfuRuntime.getStreamID(LogReplicationUtils.REPLICATED_QUEUE_TAG));
         // TODO: tx.enqueue and logUpdateEnqueue complains on the remote UT for unable to get guid. Removing it for now.
         // executeTxn(corfuStore, namespace, (TxnContext tx) -> tx.logUpdateEnqueue(routingQueue,
         //        Queue.RoutingTableEntryMsg.newBuilder().addDestinations(tx.getNamespace()).build(),

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -143,7 +143,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         }
 
         // Open routing queue before the subscribe call at the receiver.
-        String recvQueueName = LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+        String recvQueueName = LogReplicationUtils.REPLICATED_QUEUE_NAME;
         Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> routingQueue;
         try {
             routingQueue =

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
 import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_END_MARKER_TABLE_NAME;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -76,7 +77,7 @@ public class RoutingQueuesSnapshotReaderTest extends AbstractViewTest {
     private void generateData() throws Exception {
 
         String tableName = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
-        String namespace = CORFU_SYSTEM_NAMESPACE;
+        String namespace = DEMO_NAMESPACE;
 
         Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> q =
                 corfuStore.openQueue(namespace, tableName, Queue.RoutingTableEntryMsg.class,

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
@@ -1,0 +1,139 @@
+package org.corfudb.infrastructure.logreplication;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.BaseSnapshotReader;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.RoutingQueuesSnapshotReader;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.SnapshotReadMessage;
+import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.LogReplicationUtils;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.util.serializer.ProtobufSerializer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_END_MARKER_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+public class RoutingQueuesSnapshotReaderTest extends AbstractViewTest {
+
+    private UUID syncRequestId;
+    private BaseSnapshotReader snapshotReader;
+    private CorfuRuntime lrRuntime;
+    private CorfuRuntime clientRuntime;
+    private LogReplication.LogReplicationSession session;
+    private LogReplicationConfigManager configManager;
+    private LogReplicationContext replicationContext;
+    private CorfuStore corfuStore;
+    String streamTagFollowed;
+
+    @Before
+    public void setUp() {
+        syncRequestId = UUID.randomUUID();
+        lrRuntime = getDefaultRuntime();
+        clientRuntime = getNewRuntime(getDefaultNode()).connect();
+        corfuStore = new CorfuStore(clientRuntime);
+        session = DefaultClusterConfig.getRoutingQueueSessions().get(0);
+
+        configManager = new LogReplicationConfigManager(lrRuntime, session.getSourceClusterId());
+        replicationContext = new LogReplicationContext(configManager, 5, session.getSourceClusterId(),
+                true, new LogReplicationPluginConfig(""));
+        configManager.generateConfig(Collections.singleton(session));
+        snapshotReader = new RoutingQueuesSnapshotReader(lrRuntime, session, replicationContext);
+        snapshotReader.reset(lrRuntime.getAddressSpaceView().getLogTail());
+
+        streamTagFollowed = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
+    }
+
+    @Test
+    public void testRead() throws Exception {
+        generateData();
+        SnapshotReadMessage snapshotMessage = snapshotReader.read(syncRequestId);
+        Assert.assertTrue(snapshotMessage.isEndRead());
+    }
+
+    private void generateData() throws Exception {
+
+        String tableName = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
+        String namespace = CORFU_SYSTEM_NAMESPACE;
+
+        Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> q =
+                corfuStore.openQueue(namespace, tableName, Queue.RoutingTableEntryMsg.class,
+                    TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+
+        log.info("Stream UUID: {}", CorfuRuntime.getStreamID(streamTagFollowed));
+
+        for (int i = 0; i < 10; i++) {
+                ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE);
+                buffer.putInt(i);
+            Queue.RoutingTableEntryMsg val =
+                    Queue.RoutingTableEntryMsg.newBuilder().setOpaquePayload(ByteString.copyFrom(buffer.array()))
+                        .build();
+
+            try (TxnContext txnContext = corfuStore.txn(namespace)) {
+                txnContext.logUpdateEnqueue(q, val, Arrays.asList(CorfuRuntime.getStreamID(streamTagFollowed)),
+                    corfuStore);
+                log.info("Committed at {}", txnContext.commit());
+            } catch (Exception e) {
+                log.error("Failed to add data to the queue", e);
+            }
+        }
+        log.info("Queue Size = {}.  Stream tags = {}", q.count(), q.getStreamTags());
+
+        Table<Queue.RoutingTableSnapshotEndKeyMsg, Queue.RoutingTableSnapshotEndMarkerMsg, Message> endMarkerTable =
+            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_END_MARKER_TABLE_NAME,
+                Queue.RoutingTableSnapshotEndKeyMsg.class, Queue.RoutingTableSnapshotEndMarkerMsg.class, null,
+                TableOptions.fromProtoSchema(Queue.RoutingTableSnapshotEndMarkerMsg.class));
+
+        Queue.RoutingTableSnapshotEndKeyMsg snapshotSyncId =
+                Queue.RoutingTableSnapshotEndKeyMsg.newBuilder().setSnapshotSyncId(syncRequestId.toString()).build();
+
+        Queue.RoutingTableSnapshotEndMarkerMsg endMarker =
+            Queue.RoutingTableSnapshotEndMarkerMsg.newBuilder().setDestination(session.getSinkClusterId()).build();
+
+        CorfuRecord<Queue.RoutingTableSnapshotEndMarkerMsg, Message> record = new CorfuRecord<>(endMarker, null);
+
+        Object[] smrArgs = new Object[2];
+        smrArgs[0] = snapshotSyncId;
+        smrArgs[1] = record;
+
+        UUID endMarkerStreamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(
+            CORFU_SYSTEM_NAMESPACE, SNAPSHOT_END_MARKER_TABLE_NAME));
+
+        try (TxnContext txnContext = corfuStore.txn(namespace)) {
+            txnContext.logUpdate(endMarkerStreamId, new SMREntry("put", smrArgs,
+                corfuStore.getRuntime().getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE)),
+                Arrays.asList(CorfuRuntime.getStreamID(streamTagFollowed)));
+            txnContext.commit();
+        } catch (Exception e) {
+            log.error("Failed to add End Marker", e);
+        }
+    }
+
+    @After
+    public void cleanUp() {
+        lrRuntime.shutdown();
+        clientRuntime.shutdown();
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
@@ -1,0 +1,133 @@
+package org.corfudb.integration;
+
+import com.google.protobuf.ByteString;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.corfudb.runtime.CorfuOptions;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.LogReplicationUtils;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.LogReplicationUtils.*;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+public class LogReplicationRoutingQueueIT extends CorfuReplicationMultiSourceSinkIT {
+
+    private int numSource = 1;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp(1, 1, DefaultClusterManager.TP_SINGLE_SOURCE_SINK_ROUTING_QUEUE);
+        openLogReplicationStatusTable();
+    }
+
+    @Test
+    public void testLogEntrySync() throws Exception {
+
+        // Open queue on sink
+        Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> replicatedQueueSink = null;
+        try {
+            replicatedQueueSink = sinkCorfuStores.get(0).openQueue(CORFU_SYSTEM_NAMESPACE, String.join("",
+                REPLICATED_QUEUE_NAME_PREFIX,
+                DefaultClusterConfig.getSourceClusterIds().get(0)),
+                Queue.RoutingTableEntryMsg.class, TableOptions.builder().schemaOptions(CorfuOptions.SchemaOptions.newBuilder()
+                    .addStreamTag(REPLICATED_QUEUE_TAG_PREFIX).build()).build());
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        startReplicationServers();
+        generateData();
+        Thread.sleep(5000);
+        //verifySessionInLogEntrySyncState(0, LogReplicationConfigManager.getDefaultRoutingQueueSubscriber());
+    }
+
+    private void generateData() throws Exception {
+        String tableName = LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
+        String namespace = CORFU_SYSTEM_NAMESPACE;
+
+        Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> q =
+            sourceCorfuStores.get(0).openQueue(namespace, tableName, Queue.RoutingTableEntryMsg.class,
+                TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+
+        String streamTagFollowed =
+            LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + DefaultClusterConfig.getSinkClusterIds().get(0);
+        log.info("Stream UUID: {}", CorfuRuntime.getStreamID(streamTagFollowed));
+
+        for (int i = 0; i < 10; i++) {
+            ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE);
+            buffer.putInt(i);
+            Queue.RoutingTableEntryMsg val =
+                Queue.RoutingTableEntryMsg.newBuilder().setOpaquePayload(ByteString.copyFrom(buffer.array()))
+                    .build();
+
+            try (TxnContext txnContext = sourceCorfuStores.get(0).txn(namespace)) {
+                txnContext.logUpdateEnqueue(q, val, Arrays.asList(CorfuRuntime.getStreamID(streamTagFollowed)),
+                    sourceCorfuStores.get(0));
+                log.info("Committed at {}", txnContext.commit());
+            } catch (Exception e) {
+                log.error("Failed to add data to the queue", e);
+            }
+        }
+    }
+
+    /**
+     * Open replication status table on each Sink for verify replication status.
+     */
+    private void openLogReplicationStatusTable() throws Exception {
+        for (int i = 0; i < numSource; i++) {
+            sourceCorfuStores.get(i).openTable(
+                LogReplicationMetadataManager.NAMESPACE,
+                REPLICATION_STATUS_TABLE_NAME,
+                LogReplication.LogReplicationSession.class,
+                LogReplication.ReplicationStatus.class,
+                null,
+                TableOptions.fromProtoSchema(LogReplication.ReplicationStatus.class)
+            );
+        }
+    }
+
+    private void verifySessionInLogEntrySyncState(int sinkIndex, LogReplication.ReplicationSubscriber subscriber) {
+        LogReplication.LogReplicationSession session = LogReplication.LogReplicationSession.newBuilder()
+            .setSourceClusterId(DefaultClusterConfig.getSourceClusterIds().get(0))
+            .setSinkClusterId(DefaultClusterConfig.getSinkClusterIds().get(sinkIndex))
+            .setSubscriber(subscriber)
+            .build();
+
+        LogReplication.ReplicationStatus status = null;
+
+        while (status == null || !status.getSourceStatus().getReplicationInfo().getSyncType().equals(LogReplication.SyncType.LOG_ENTRY)
+            || !status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus()
+            .equals(LogReplication.SyncStatus.COMPLETED)) {
+            try (TxnContext txn = sourceCorfuStores.get(0).txn(LogReplicationMetadataManager.NAMESPACE)) {
+                status = (LogReplication.ReplicationStatus) txn.getRecord(REPLICATION_STATUS_TABLE_NAME, session).getPayload();
+                txn.commit();
+            }
+        }
+
+        // Snapshot sync should have completed and log entry sync is ongoing
+        assertThat(status.getSourceStatus().getReplicationInfo().getSyncType()).isEqualTo(LogReplication.SyncType.LOG_ENTRY);
+        assertThat(status.getSourceStatus().getReplicationInfo().getStatus())
+            .isEqualTo(LogReplication.SyncStatus.ONGOING);
+
+        assertThat(status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getType())
+            .isEqualTo(LogReplication.SnapshotSyncInfo.SnapshotSyncType.DEFAULT);
+        assertThat(status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus())
+            .isEqualTo(LogReplication.SyncStatus.COMPLETED);
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
@@ -5,11 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication;
-import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
@@ -46,7 +44,7 @@ public class LogReplicationRoutingQueueIT extends CorfuReplicationMultiSourceSin
                 REPLICATED_QUEUE_NAME_PREFIX,
                 DefaultClusterConfig.getSourceClusterIds().get(0)),
                 Queue.RoutingTableEntryMsg.class, TableOptions.builder().schemaOptions(CorfuOptions.SchemaOptions.newBuilder()
-                    .addStreamTag(REPLICATED_QUEUE_TAG_PREFIX).build()).build());
+                    .addStreamTag(REPLICATED_QUEUE_TAG).build()).build());
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.runtime.LogReplicationUtils.DEMO_NAMESPACE;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
@@ -1074,7 +1075,7 @@ public class StreamingIT extends AbstractIT {
     public void testSafeDataLossOnRoutingQs() throws Exception {
         // Run a corfu server & initialize CorfuStore
         CorfuRuntime runtime = initializeCorfu();
-        final String systemNamespace = TableRegistry.CORFU_SYSTEM_NAMESPACE;
+        final String systemNamespace = DEMO_NAMESPACE;
         final String logEntryQName = LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
         final String snapSyncQName = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
 

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -5,8 +5,11 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
+import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.MultiCheckpointWriter;
+import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
@@ -45,6 +48,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1063,7 +1067,66 @@ public class StreamingIT extends AbstractIT {
         assertThat(listener.getUpdates().size()).isEqualTo(totalUpdates*2);
     }
 
+    /**
+     * Test to ensure that LogReplicator's RoutingQs lose data safely on checkpointing.
+     */
+    @Test
+    public void testSafeDataLossOnRoutingQs() throws Exception {
+        // Run a corfu server & initialize CorfuStore
+        CorfuRuntime runtime = initializeCorfu();
+        final String systemNamespace = TableRegistry.CORFU_SYSTEM_NAMESPACE;
+        final String logEntryQName = LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
+        final String snapSyncQName = LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
 
+        final Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> logEntryQ =
+                store.openQueue(systemNamespace, logEntryQName,
+                        Queue.RoutingTableEntryMsg.class,
+                        TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+        final Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> fullSyncQ =
+                store.openQueue(systemNamespace, snapSyncQName,
+                        Queue.RoutingTableEntryMsg.class,
+                        TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+
+        final int numEntries = PARAMETERS.NUM_ITERATIONS_VERY_LOW;
+        for (int i = 0; i < numEntries; i++) {
+            try (TxnContext tx = store.txn(TableRegistry.CORFU_SYSTEM_NAMESPACE)) {
+                Queue.RoutingTableEntryMsg entry = Queue.RoutingTableEntryMsg.newBuilder()
+                        .addDestinations(tx.getNamespace()).build();
+                tx.enqueue(logEntryQ, entry);
+                tx.enqueue(fullSyncQ, entry);
+                tx.commit();
+            }
+        }
+        // Validate that the queues do have entries before checkpointing
+        try (TxnContext tx = store.txn(TableRegistry.CORFU_SYSTEM_NAMESPACE)) {
+            assertThat(tx.entryList(logEntryQ).size()).isEqualTo(numEntries);
+            assertThat(tx.entryList(fullSyncQ).size()).isEqualTo(numEntries);
+        } // This will load up the table's map with all entries
+
+        // Now run a round of checkpoint and trim (Queue's data will be purged)
+        List<String> allRegisteredTablesAndQs = runtime.getTableRegistry().listTables().stream().map(
+                CorfuStoreMetadata.TableName::getTableName
+        ).collect(Collectors.toList());
+        checkpointAndTrim(runtime, TableRegistry.CORFU_SYSTEM_NAMESPACE, allRegisteredTablesAndQs, false);
+
+        // Since the original data is cached in-memory, it should still be readable.
+        try (TxnContext tx = store.txn(TableRegistry.CORFU_SYSTEM_NAMESPACE)) {
+            assertThat(tx.entryList(logEntryQ).size()).isEqualTo(numEntries);
+            assertThat(tx.entryList(fullSyncQ).size()).isEqualTo(numEntries);
+        }
+
+        // Now release the memory occupied by the Queue
+        store.freeTableData(systemNamespace, logEntryQName);
+        store.freeTableData(systemNamespace, snapSyncQName);
+
+        // The next access will read from checkpoint but checkpoint has no data, so a safe data loss.
+        try (TxnContext tx = store.txn(TableRegistry.CORFU_SYSTEM_NAMESPACE)) {
+            // This operation should not throw a trimmed exception
+            assertThat(tx.entryList(logEntryQ).size()).isEqualTo(0);
+            // Yet all the entries should disappear
+            assertThat(tx.entryList(fullSyncQ).size()).isEqualTo(0);
+        }
+    }
 
     /**
      * Confirm client exceptions (during onNext processing) are not wrapped as corfu unrecoverable streaming exceptions.

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -2,25 +2,41 @@ package org.corfudb.runtime.collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.runtime.LogReplicationUtils.LR_STATUS_STREAM_TAG;
 
 import com.google.common.primitives.UnsignedBytes;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.units.qual.C;
+import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
 import com.google.common.reflect.TypeToken;
 import com.google.protobuf.ByteString;
 import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.MultiCheckpointWriter;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
 import org.corfudb.runtime.collections.CorfuQueue.CorfuQueueRecord;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.SMRObject;
+import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.util.serializer.ProtobufSerializer;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
@@ -58,6 +74,12 @@ public class CorfuQueueTest extends AbstractViewTest {
         rt.getObjectsView().TXBegin();
         runnable.run();
         rt.getObjectsView().TXEnd();
+    }
+    private void executeTxn(CorfuStore store, String namespace, Consumer<TxnContext> mutation) {
+        try (TxnContext tx = store.txn(namespace)) {
+            mutation.accept(tx);
+            tx.commit();
+        }
     }
 
     @Test
@@ -268,6 +290,35 @@ public class CorfuQueueTest extends AbstractViewTest {
                     .isEqualTo(String.valueOf(itemIdx));
             assertThat(instance2Reader.entryList().get(itemIdx).getEntry().toStringUtf8())
                     .isEqualTo(String.valueOf(itemIdx));
+        });
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void logUpdateThatLooksLikeEnqueue() {
+        final CorfuStore corfuStore = new CorfuStore(createDefaultRuntime());
+        final String namespace = "some_ns";
+        final String tableName = "some_table";
+        Table<Queue.CorfuGuidMsg, RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> q = null;
+        try {
+            q = corfuStore.openQueue(namespace, tableName, RoutingTableEntryMsg.class,
+                    TableOptions.fromProtoSchema(RoutingTableEntryMsg.class));
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        final Table<Queue.CorfuGuidMsg, RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> finalQ = q;
+        final byte[] payload = {'a', 'b', 'c'};
+        executeTxn(corfuStore, namespace, (TxnContext tx) -> tx.enqueue(finalQ,
+                RoutingTableEntryMsg.newBuilder().setOpaquePayload(ByteString.copyFrom(payload)).build()));
+        List<UUID> tags = new ArrayList<>();
+        tags.add(CorfuRuntime.getStreamID(LR_STATUS_STREAM_TAG));
+        executeTxn(corfuStore, namespace, (TxnContext tx) -> tx.logUpdateEnqueue(finalQ,
+                RoutingTableEntryMsg.newBuilder().setOpaquePayload(ByteString.copyFrom(payload)).build(),
+                tags, corfuStore));
+
+        // validate if logUpdate and enqueue produces same result
+        executeTxn(corfuStore, namespace, (TxnContext tx) -> {
+            assertThat(tx.entryList(finalQ).get(0).getEntry()).isEqualTo(tx.entryList(finalQ).get(1).getEntry());
         });
     }
 }


### PR DESCRIPTION
## Overview

1. Extend RoutingQueueEntryMsg to encode other needed info
2. TODO: Temporarily "disable" snapshot sync for ROUTING_QUEUE sessions and let those sessions come into Log Entry Sync directly
3. TODO: Have an IT to verify the workflow in 2.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
