### PR TITLE
Do not set batch read size to 1 when cache is disabled or 0 (#3693)

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -109,7 +109,6 @@ public class AddressSpaceView extends AbstractView implements AutoCloseable {
         if (maxCacheEntries == 0) {
             log.warn("Since AddressSpaceView readCache size is 0, " +
                     "overriding CorfuRuntime bulkReadSize and checkpointReadBatchSize to 1.");
-            runtime.getParameters().setBulkReadSize(1);
             runtime.getParameters().setCheckpointReadBatchSize(1);
         }
 


### PR DESCRIPTION
When AddressSpaceView readCache is 0, do not reset batch read size to 1 as it will make the state transfer include only 1 address per batch partition instead of 100.

1 address per batch adds CPU and network overhead due to the increased number of threads and network calls across nodes. This further causes cluster instability and delay in join node operation which involves state transfer.


## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
