### PR TITLE
Ability to trigger cloud deployment manually

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -1,6 +1,8 @@
 name: Cloud Deployment Test
 
-on: pull_request
+on:
+  workflow_dispatch:
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION

## Overview
Ability to trigger cloud deployment manually alone with automatic triggers

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
