### PR TITLE
Cloud Deployment: multi (jdk) version deployment

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -8,9 +8,19 @@ jobs:
 
   could-deployment-test:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        jdk_base_image_version: ['openjdk:8-jdk-bullseye', 'openjdk:11-jdk-bullseye']
+
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v2
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '11'
+          check-latest: true
 
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -26,7 +36,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: build docker image
-        run: .ci/infrastructure-docker-build.sh docker
+        run: .ci/infrastructure-docker-build.sh docker ${{ matrix.jdk_base_image }}
 
       - uses: actions/checkout@v2
         with:
@@ -56,24 +66,29 @@ jobs:
         working-directory: ./cloud/corfu
         run: |
           helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.8.0 --set installCRDs=true
-          helm install corfu corfu --set persistence.enabled=true --set global.replicas=3 
+          
+          helm install corfu corfu --set persistence.enabled=true --set global.replicas=3 --set image.pullPolicy=IfNotPresent --set image.registry=""
           
           sleep 120
-          
+
+      - name: check deployment status
+        working-directory: ./cloud/corfu
+        run: |
+          echo check deployment status:
           if kubectl wait --for=condition=complete --timeout=180s job/configure-corfu | grep "job.batch/configure-corfu condition met"; then
-            echo "Successfull deployment!"
+            echo "Successful deployment!"
             exit 0
           else
             echo "Failed deployment!"
-            
+
             echo pods:
             kubectl get pods
-          
+
             echo corfu job:
             kubectl describe job/configure-corfu
-            
+
             echo corfu pod:
             kubectl describe pod corfu-0
-          
+
             exit 1
           fi


### PR DESCRIPTION
## Overview

Description:
Cloud Deployment: multi (jdk) version deployment.

Corfu master branch can be compiled with jdk-11 (the language level is still defined as java 8 in maven pom.xml, but we can use jdk-11 to compile corfu and use jdk-11 to run corfu).
With the changes from the pr we can easily check if corfu can be compiled against multiple versions of jdk and if it can be deployed and run on k8s right away during pre commit checks with github actions

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
