### PR TITLE
Multiple fixes for routing queue log entry sync

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.view.TableRegistry;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -12,10 +13,10 @@ import java.util.HashSet;
 import java.util.UUID;
 
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
 import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
  * This class represents the Log Replication Configuration field(s) for ROUTING_QUEUES replication model.
@@ -58,9 +59,10 @@ public class LogReplicationRoutingQueueConfig extends LogReplicationConfig {
         super(session, new HashSet<>(), new HashMap<>(), serverContext);
         this.snapshotSyncStreamTag = SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
         this.logEntrySyncStreamTag = LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
-        this.sinkQueueName = REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId();
-        this.sinkQueueStreamId = CorfuRuntime.getStreamID(this.sinkQueueName);
-        this.sinkQueueStreamTag = CorfuRuntime.getStreamID(REPLICATED_QUEUE_TAG + DEFAULT_ROUTING_QUEUE_CLIENT);
+        this.sinkQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_NAME);
+        this.sinkQueueStreamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+                REPLICATED_QUEUE_NAME));
+        this.sinkQueueStreamTag = TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_TAG);
         getStreamsToReplicate().add(snapshotSyncStreamTag);
         getDataStreamToTagsMap().put(sinkQueueStreamId, Collections.singletonList(sinkQueueStreamTag));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -34,7 +34,14 @@ import org.corfudb.util.serializer.Serializers;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.corfudb.infrastructure.logreplication.config.LogReplicationConfig.MERGE_ONLY_STREAMS;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
@@ -13,19 +13,15 @@ import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
 import org.corfudb.runtime.collections.CorfuRecord;
-import org.corfudb.runtime.collections.CorfuStore;
-import org.corfudb.runtime.collections.TableOptions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
-import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
 
 
 /**
@@ -61,7 +57,7 @@ public class RoutingQueuesLogEntryReader extends BaseLogEntryReader {
             }
         }
         HashMap<UUID, List<SMREntry>> opaqueEntryMap = new HashMap<>();
-        opaqueEntryMap.put(CorfuRuntime.getStreamID(REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId()),
+        opaqueEntryMap.put(CorfuRuntime.getStreamID(REPLICATED_QUEUE_NAME),
                 filteredMsgs);
         return new OpaqueEntry(opaqueEntry.getVersion(), opaqueEntryMap);
     }
@@ -69,11 +65,6 @@ public class RoutingQueuesLogEntryReader extends BaseLogEntryReader {
     @Override
     protected boolean isValidTransactionEntry(@NonNull OpaqueEntry entry) {
         Set<UUID> txEntryStreamIds = new HashSet<>(entry.getEntries().keySet());
-        if (txEntryStreamIds.size() != 1) {
-            log.warn("Routing queue session's log entries should only come from the shared data queue " +
-                    "for log entry sync");
-            return false;
-        }
 
         return txEntryStreamIds.contains(LogReplicationUtils.lrLogEntrySendQId);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -86,7 +86,7 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
             "-poller-" + session.hashCode()).build());
 
         String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
-                LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX + session.getSourceClusterId());
+                LogReplicationUtils.REPLICATED_QUEUE_NAME);
         replicatedQueueId = CorfuRuntime.getStreamID(replicatedQueueName);
 
         // Open the marker table so that its entries can be deserialized

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -323,6 +323,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
             SnapshotSyncUtils.enforceSnapshotSync(fsm.getSession(), new CorfuStore(metadataManager.getRuntime()),
                 LogReplicationMetadata.ReplicationEvent.ReplicationEventType.RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC);
         }
+
         fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
             new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/SnapshotSyncUtils.java
@@ -50,7 +50,7 @@ public final class SnapshotSyncUtils {
                                            ReplicationEventType eventType) {
         UUID forceSyncId = UUID.randomUUID();
 
-        log.info("Forced snapshot sync will be triggered because of group destination change, session={}, sync_id={}",
+        log.info("Forced snapshot sync will be triggered, session={}, sync_id={}",
                 session, forceSyncId);
 
         // Write a force sync event to the logReplicationEventTable

--- a/runtime/src/main/java/org/corfudb/runtime/FullStateReplicationContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/FullStateReplicationContext.java
@@ -1,0 +1,65 @@
+package org.corfudb.runtime;
+
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
+import org.corfudb.runtime.LogReplication.ReplicationEvent.ReplicationEventType;
+import org.corfudb.runtime.collections.FullStateMessage;
+import org.corfudb.runtime.collections.TxnContext;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
+
+public interface FullStateReplicationContext {
+    /**
+     * LR starts this transaction and the callback must use the same to do its full table scans
+     *
+     */
+     TxnContext getTxn();
+
+     /**
+      * Returns destination site ID.
+      * Data is transmitted from this site.
+      *
+      */
+    String getDestinationSiteId();
+
+    /**
+     * Returns unique ID for the full state sync request.
+     *
+     */
+    UUID getRequestId();
+
+    /**
+     * Returns reason for full state sync request.
+     *
+     */
+    @Nullable
+    ReplicationEventType getReason();
+
+    /**
+     * Transmits one message for full sync.
+     *
+     */
+    void transmit(FullStateMessage message) throws CancellationException;
+
+    /**
+     * Transmits one message for full sync.
+     *
+     * @param message message to transmit.
+     * @param progress indicates progress of transmission, value between 0 and 100.
+     */
+    void transmit(FullStateMessage message, int progress) throws CancellationException;
+
+    /**
+     * Indicates that all data was transmitted from application to client.
+     *
+     */
+    void markCompleted(Timestamp timestamp) throws CancellationException;
+
+    /**
+     * Cancels this full sync replication.
+     * Application cannot continue and full sync has to be restarted.
+     *
+     */
+    void cancel();
+}

--- a/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
@@ -1,0 +1,69 @@
+package org.corfudb.runtime;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.TableOptions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+public abstract class LiteRoutingQueueListener implements StreamListener {
+
+    private final CorfuStore corfuStore;
+
+
+    public LiteRoutingQueueListener(CorfuStore corfuStore) {
+        this.corfuStore = corfuStore;
+        try {
+            corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LogReplicationUtils.REPLICATED_QUEUE_NAME,
+                    Queue.RoutingTableEntryMsg.class,
+                    TableOptions.builder().schemaOptions(
+                                    CorfuOptions.SchemaOptions.newBuilder()
+                                            .addStreamTag(LogReplicationUtils.REPLICATED_QUEUE_TAG)
+                                            .build())
+                            .build());
+        } catch (Exception e) {
+            log.error("Failed to open replicated queue due to exception!", e);
+        }
+    }
+
+    @Override
+    public void onNext(CorfuStreamEntries results) {
+        log.info("LR LiteRoutingQueueListener received updates!");
+        List<CorfuStreamEntry> entries = results.getEntries().entrySet().stream()
+                .map(Map.Entry::getValue).findFirst().get();
+        for (CorfuStreamEntry entry : entries) {
+            if (entry.getOperation().equals(CorfuStreamEntry.OperationType.CLEAR)) {
+                log.warn("CLEAR_ENTRY received, snapshot sync is ongoing, skip this entry");
+                continue;
+            }
+            Queue.RoutingTableEntryMsg msg = (Queue.RoutingTableEntryMsg) entry.getPayload();
+            if (msg.getReplicationType()
+                    .equals(Queue.ReplicationType.LOG_ENTRY_SYNC)) {
+                log.info("Process log entry sync msg: {}", msg);
+                processUpdatesInLogEntrySync(Collections.singletonList(msg));
+            } else {
+                log.info("Process snapshot sync msg: {}", msg);
+                processUpdatesInSnapshotSync(Collections.singletonList(msg));
+            }
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        log.error("onError:: resubscribing LiteRoutingQueueListener ", throwable);
+        corfuStore.subscribeListenerFromTrimMark(this, CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_TAG);
+    }
+
+    protected abstract boolean processUpdatesInSnapshotSync(List<Queue.RoutingTableEntryMsg> updates);
+
+    protected abstract boolean processUpdatesInLogEntrySync(List<Queue.RoutingTableEntryMsg> updates);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
@@ -75,7 +75,7 @@ public abstract class LogReplicationRoutingQueueListener implements StreamListen
         this.corfuStore = corfuStore;
         this.namespace = namespace;
         this.routingQueue =
-                corfuStore.openQueue(namespace, LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX,
+                corfuStore.openQueue(namespace, LogReplicationUtils.REPLICATED_QUEUE_NAME,
                         Queue.RoutingTableEntryMsg.class,
                         TableOptions.builder().schemaOptions(
                                         CorfuOptions.SchemaOptions.newBuilder()

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -60,8 +60,7 @@ public final class LogReplicationUtils {
 
     // Prefix of the name of queue as it will appear on the receiver after replicated.  The suffix will be the Sender
     // (Source) cluster id Receiving queues per client name.
-    // Example: LRQ_Recv_<client_name>_<source_id>
-    public static final String REPLICATED_QUEUE_NAME_PREFIX = "LRQ_Recv_";
+    public static final String REPLICATED_QUEUE_NAME = "LRQ_Recv";
 
     // Stream tag applied to the replicated queue on the receiver
     public static final String REPLICATED_QUEUE_TAG = "lrq_recv";
@@ -362,7 +361,7 @@ public final class LogReplicationUtils {
         List<String> tablesOfInterest = corfuStore.getTablesOfInterest(namespace, streamTag);
         return tablesOfInterest.size() != 0;
     }
-    
+
     public static String getRoutingQueue(CorfuStore corfuStore, String namespace, String streamTag) {
         String routingQueueName = null;
         List<String> tablesOfInterest = corfuStore.getTablesOfInterest(namespace, streamTag);

--- a/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
@@ -1,265 +1,33 @@
 package org.corfudb.runtime;
 
-import com.google.common.base.Preconditions;
-import com.google.protobuf.Message;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
-import org.corfudb.runtime.LogReplication.ReplicationEvent;
-import org.corfudb.runtime.Queue.RoutingQSnapStartEndKeyMsg;
+import org.corfudb.runtime.LogReplication.ReplicationModel;
 import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
-import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
-import org.corfudb.runtime.collections.CorfuStreamEntries;
-import org.corfudb.runtime.collections.CorfuStreamEntry;
-import org.corfudb.runtime.collections.StreamListenerResumeOrDefault;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
-import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.runtime.exceptions.StreamingException;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.TableRegistry;
-import org.corfudb.util.serializer.ProtobufSerializer;
 
-import javax.annotation.Nullable;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CancellationException;
 import java.util.stream.Collectors;
 
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_NAME_SENDER;
-import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.LogReplicationUtils.SNAP_SYNC_START_END_Q_NAME;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 @Slf4j
 public class RoutingQueueSenderClient extends LogReplicationClient implements LogReplicationRoutingQueueClient {
+    private static final ReplicationModel model = ReplicationModel.ROUTING_QUEUES;
+
     // TODO (V2): This field should be removed after the rpc stream is added for Sink side session creation.
     public static final String DEFAULT_ROUTING_QUEUE_CLIENT = "00000000-0000-0000-0000-0000000000002";
 
-    // TODO: Find a way to use these from a common location (they are in infrastructure currently)
-    private static final String REPLICATION_EVENT_TABLE_NAME = "LogReplicationEventTable";
-    private static final String LR_STREAM_TAG = "log_replication";
-    private final CorfuStore corfuStore;
-    private final String clientName;
-
     private Table<Queue.CorfuGuidMsg, RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> logEntryQ;
-    private Table<Queue.CorfuGuidMsg, RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> snapSyncQ;
-    private Table<RoutingQSnapStartEndKeyMsg, Queue.RoutingQSnapStartEndMarkerMsg, Message> snapStartEndTable;
 
-    private FullSyncRequestor fullSyncRequestor;
-    /**
-     * Constructor for the log replication client for routing queues on sender.
-     *
-     * @param corfuStore CorfuStore instance used by the jvm
-     * @param clientName String representation of the client name. This parameter is case-sensitive.
-     * @throws IllegalArgumentException If clientName is null or empty.
-     * @throws NoSuchMethodException NoSuchMethodException.
-     * @throws IllegalAccessException IllegalAccessException.
-     */
-    public RoutingQueueSenderClient(CorfuStore corfuStore, String clientName)
-            throws NoSuchMethodException, IllegalAccessException {
-        Preconditions.checkArgument(isValid(clientName), "clientName is null or empty.");
-
-        this.corfuStore = corfuStore;
-        this.clientName = clientName;
-
-        int numOpenQueueRetries = 8;
-        Table<Queue.CorfuGuidMsg, RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> logEntryQ_local = null;
-        Table<Queue.CorfuGuidMsg, RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> snapSyncQ_local = null;
-        Table<RoutingQSnapStartEndKeyMsg, Queue.RoutingQSnapStartEndMarkerMsg, Message> snapStartEnd_local = null;
-        while ((numOpenQueueRetries--) > 0) {
-            try {
-                logEntryQ_local = corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER,
-                        RoutingTableEntryMsg.class, TableOptions.fromProtoSchema(RoutingTableEntryMsg.class));
-                snapSyncQ_local = corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_SYNC_QUEUE_NAME_SENDER,
-                        RoutingTableEntryMsg.class, TableOptions.fromProtoSchema(RoutingTableEntryMsg.class));
-                snapStartEnd_local = corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, SNAP_SYNC_START_END_Q_NAME,
-                        RoutingQSnapStartEndKeyMsg.class, Queue.RoutingQSnapStartEndMarkerMsg.class, null,
-                        TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
-
-                break;
-            } catch (InvocationTargetException e) {
-                throw new RuntimeException("InvocationTargetException in fromProtoSchema"+ e.getMessage());
-            } catch (TransactionAbortedException e) {
-                log.warn("OpenQueue in RoutingQSender hit TAE: retry"+numOpenQueueRetries);
-            } catch (StreamingException se) {
-                log.warn("RoutingQSender subscription hit a Streaming Exception retrying "+numOpenQueueRetries);
-            }
-        }
-        this.logEntryQ = logEntryQ_local;
-        this.snapSyncQ = snapSyncQ_local;
-        this.snapStartEndTable = snapStartEnd_local;
-
-        // TODO: Register this client once the DEFAULT CLIENT implementation is no longer needed
-        // register(corfuStore, clientName);
-    }
-
-    public void startLRSnapshotTransmitter(LRTransmitterReplicationModule snapSyncProvider) {
-        this.fullSyncRequestor = new FullSyncRequestor(
-                corfuStore, snapSyncProvider, CORFU_SYSTEM_NAMESPACE,
-                LR_STREAM_TAG, Collections.singletonList(REPLICATION_EVENT_TABLE_NAME));
-
-        corfuStore.subscribeListener(fullSyncRequestor, CORFU_SYSTEM_NAMESPACE,
-                LR_STREAM_TAG, Collections.singletonList(REPLICATION_EVENT_TABLE_NAME));
-    }
-
-    public void stopLRSnapshotTransmitter() {
-        corfuStore.unsubscribeListener(fullSyncRequestor);
-    }
-
-    public interface LRTransmitterReplicationModule {
-        /**
-         * Full state data is requested for the application.
-         * It is expected that this call is non blocking and data will be provided in different thread.
-         *
-         * @param context replication context
-         */
-        void provideFullStateData(LRFullStateReplicationContext context);
-        void cancel(LRFullStateReplicationContext context);
-    }
-
-    private class FullSyncRequestor extends StreamListenerResumeOrDefault {
-
-        private final LRTransmitterReplicationModule snapSyncProvider;
-        public FullSyncRequestor(CorfuStore store, LRTransmitterReplicationModule snapSyncProvider,
-                                 String namespace, String streamTag, List<String> tablesOfInterest) {
-            super(store, namespace, streamTag, tablesOfInterest);
-            this.snapSyncProvider = snapSyncProvider;
-        }
-
-        @Override
-        public void onNext(CorfuStreamEntries results) {
-            log.info("onNext[{}] :: got updates on RoutingQSender for tables {}", results.getTimestamp(),
-                    results.getEntries().keySet().stream().map(TableSchema::getTableName).collect(Collectors.toList()));
-            ReplicationEvent fullSyncEvent = null;
-            // Any notification here indicates a full sync request
-            for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {
-                for (CorfuStreamEntry entry : entryList) {
-                    if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
-                        log.warn("RoutingQEventListener ignoring a CLEAR operation");
-                        continue;
-                    }
-                    LogReplication.ReplicationEventInfoKey key = (LogReplication.ReplicationEventInfoKey) entry.getKey();
-                    fullSyncEvent = (ReplicationEvent) entry.getPayload();
-                    log.info("Full Sync requested due to event :: id={}, type={}, session={}, ts={}",
-                            fullSyncEvent.getEventId(), fullSyncEvent.getType(),
-                            key.getSession(), fullSyncEvent.getEventTimestamp());
-                }
-            }
-            if (fullSyncEvent != null) {
-                SnapshotSyncDataTransmitter snapshotSyncDataTransmitter = new SnapshotSyncDataTransmitter(
-                        fullSyncEvent);
-                snapSyncProvider.provideFullStateData(snapshotSyncDataTransmitter);
-            }
-        }
-    }
-
-    private class SnapshotSyncDataTransmitter implements LRFullStateReplicationContext {
-        private boolean baseSnapshotSent;
-
-        private final ReplicationEvent requestingEvent;
-        public SnapshotSyncDataTransmitter(ReplicationEvent requestingEvent) {
-            this.requestingEvent = requestingEvent;
-            this.baseSnapshotSent = false;
-        }
-
-        @Override
-        public TxnContext getTxn() {
-            if (TransactionalContext.isInTransaction()) {
-                return TransactionalContext.getRootContext().getTxnContext();
-            }
-            return null;
-        }
-
-        @Override
-        public String getDestinationSiteId() {
-            return requestingEvent.getClusterId();
-        }
-
-        @Override
-        public UUID getRequestId() {
-            return UUID.fromString(requestingEvent.getEventId());
-        }
-
-        @Nullable
-        @Override
-        public ReplicationEvent.ReplicationEventType getReason() {
-            return requestingEvent.getType();
-        }
-
-        @Override
-        public void transmit(RoutingTableEntryMsg message) throws CancellationException {
-            transmit(message, 0);
-        }
-
-        @Override
-        public void transmit(RoutingTableEntryMsg message, int progress) throws CancellationException {
-            log.info("Enqueuing message to full sync queue, message: {}", message);
-            getTxn().logUpdateEnqueue(snapSyncQ, message, message.getDestinationsList().stream()
-                    .map(destination -> TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
-                            SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + destination))
-                    .collect(Collectors.toList()), corfuStore);
-            if (!baseSnapshotSent) { // Set the FIRST FULL SYNC TRANSACTION's snapshot as base snapshot for LR sync
-                RoutingQSnapStartEndKeyMsg keyOfStartMarker = RoutingQSnapStartEndKeyMsg.newBuilder()
-                        .setSnapshotSyncId(requestingEvent.getEventId()).build();
-                Queue.RoutingQSnapStartEndMarkerMsg startMarker = Queue.RoutingQSnapStartEndMarkerMsg.newBuilder()
-                        .setSnapshotStartTimestamp(getTxn().getTxnSequence())
-                        .setDestination(requestingEvent.getClusterId()).build();
-
-                CorfuRecord<RoutingQSnapStartEndKeyMsg, Queue.RoutingQSnapStartEndMarkerMsg> markerEntry =
-                        new CorfuRecord<>(keyOfStartMarker, startMarker);
-
-                Object[] smrArgs = new Object[2];
-                smrArgs[0] = keyOfStartMarker;
-                smrArgs[1] = markerEntry;
-                getTxn().logUpdate(LogReplicationUtils.lrSnapStartEndQId,
-                        new SMREntry("put", smrArgs,
-                                corfuStore.getRuntime().getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE)),
-                        message.getDestinationsList().stream()
-                                .map(destination -> TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
-                                        SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + destination))
-                                .collect(Collectors.toList())
-                        );
-                baseSnapshotSent = true;
-            }
-        }
-
-        @Override
-        public void markCompleted() throws CancellationException {
-            log.info("Got completion marker");
-            RoutingQSnapStartEndKeyMsg keyOfStartMarker = RoutingQSnapStartEndKeyMsg.newBuilder()
-                    .setSnapshotSyncId(requestingEvent.getEventId()).build();
-            Queue.RoutingQSnapStartEndMarkerMsg startMarker = Queue.RoutingQSnapStartEndMarkerMsg.newBuilder()
-                    .setDestination(requestingEvent.getClusterId()).build();
-
-            CorfuRecord<RoutingQSnapStartEndKeyMsg, Queue.RoutingQSnapStartEndMarkerMsg> markerEntry =
-                    new CorfuRecord<>(keyOfStartMarker, startMarker);
-
-            Object[] smrArgs = new Object[2];
-            smrArgs[0] = keyOfStartMarker;
-            smrArgs[1] = markerEntry;
-            getTxn().logUpdate(LogReplicationUtils.lrSnapStartEndQId,
-                    new SMREntry("put", smrArgs,
-                            corfuStore.getRuntime().getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE)),
-                    Arrays.asList(TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
-                            SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + requestingEvent.getClusterId()))
-            );
-        }
-
-        @Override
-        public void cancel() {
-            // TODO: Need to figure out what might be LR's equivalent of a full sync cancellation?
-        }
+    public RoutingQueueSenderClient() {
+        // TODO: This might be removed in the future. Temporary solution for bypassing providing a CorfuRuntime
     }
 
     /**
@@ -271,6 +39,15 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
     @Override
     public void transmitDeltaMessage(TxnContext txn, RoutingTableEntryMsg message, CorfuStore corfuStore) throws Exception {
         log.info("Enqueuing message to delta queue, message: {}", message);
+        try {
+            log.info("Get log entry sync queue: {}", LOG_ENTRY_SYNC_QUEUE_NAME_SENDER);
+            logEntryQ = txn.getTable(LOG_ENTRY_SYNC_QUEUE_NAME_SENDER);
+        } catch (IllegalStateException e) {
+            log.info("Log entry sync queue not opened yet, opening it now!");
+            logEntryQ = corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER,
+                    RoutingTableEntryMsg.class, TableOptions.fromProtoSchema(RoutingTableEntryMsg.class));
+        }
+
         txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
                 .map(destination -> TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
                         LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination))
@@ -285,11 +62,24 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
      */
     @Override
     public void transmitDeltaMessages(TxnContext txn, List<RoutingTableEntryMsg> messages, CorfuStore corfuStore) throws Exception {
+        try {
+            log.info("Get log entry sync queue: {}", LOG_ENTRY_SYNC_QUEUE_NAME_SENDER);
+            logEntryQ = txn.getTable(LOG_ENTRY_SYNC_QUEUE_NAME_SENDER);
+        } catch (IllegalStateException e) {
+            log.info("Log entry sync queue not opened yet, opening it now!");
+            logEntryQ = corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER,
+                    RoutingTableEntryMsg.class, TableOptions.fromProtoSchema(RoutingTableEntryMsg.class));
+        }
+
         for (RoutingTableEntryMsg message : messages) {
             log.info("Enqueuing message to delta queue, message: {}", message);
             txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
-                    .map(destination -> TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
-                            LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination))
+                    .map(destination -> {
+                        log.info("Stream tag ID: {}", TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
+                                LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination));
+                        return TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
+                                LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination);
+                    })
                     .collect(Collectors.toList()), corfuStore);
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/TransmitterReplicationModule.java
+++ b/runtime/src/main/java/org/corfudb/runtime/TransmitterReplicationModule.java
@@ -1,0 +1,11 @@
+package org.corfudb.runtime;
+
+public interface TransmitterReplicationModule {
+    /**
+     * Full state data is requested for the application.
+     * It is expected that this call is non-blocking and data will be provided in different thread.
+     *
+     * @param context replication context
+     */
+    void provideFullStateData(FullStateReplicationContext context);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -313,6 +313,17 @@ public class CorfuStore {
     }
 
     /**
+     * TODO: Remove this!
+     * Temporary hack for subscribing simplified version of routing queue listener from trim mark
+     */
+    public void subscribeListenerFromTrimMark(@Nonnull StreamListener streamListener, @Nonnull String namespace,
+                                              @Nonnull String streamTag) {
+        Token token = runtime.getAddressSpaceView().getTrimMark();
+        Timestamp ts = Timestamp.newBuilder().setEpoch(token.getEpoch()).setSequence(token.getSequence()).build();
+        this.subscribeListener(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag), ts);
+    }
+
+    /**
      * Subscribe to transaction updates on specific tables with the streamTag in the namespace.
      * Objects returned will honor transactional boundaries.
      * <p>

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -143,7 +143,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         }
 
         // Open routing queue before the subscribe call at the receiver.
-        String recvQueueName = LogReplicationUtils.REPLICATED_QUEUE_NAME_PREFIX;
+        String recvQueueName = LogReplicationUtils.REPLICATED_QUEUE_NAME;
         Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> routingQueue;
         try {
             routingQueue =

--- a/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
@@ -1,0 +1,160 @@
+package org.corfudb.integration;
+
+import com.google.protobuf.ByteString;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.CorfuOptions;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LiteRoutingQueueListener;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.RoutingQueueSenderClient;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_NAME_SENDER;
+import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+public class LogReplicationRoutingQueueIT extends CorfuReplicationMultiSourceSinkIT {
+
+    private int numSource = 1;
+
+    /**
+     * Get the client runtime that connects to Source cluster node.
+     *
+     * @return CorfuRuntime for client
+     */
+    private CorfuRuntime getClientRuntime() {
+        return CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
+                .parseConfigurationString(DEFAULT_HOST + ":" + DEFAULT_PORT)
+                .connect();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp(1, 1, DefaultClusterManager.TP_SINGLE_SOURCE_SINK_ROUTING_QUEUE);
+        openLogReplicationStatusTable();
+    }
+
+    @Test
+    public void testLogEntrySync() throws Exception {
+
+        // Register client and setup initial group destinations mapping
+        CorfuRuntime clientRuntime = getClientRuntime();
+        CorfuStore clientCorfuStore = new CorfuStore(clientRuntime);
+        RoutingQueueSenderClient queueSenderClient = new RoutingQueueSenderClient();
+
+        // Open queue on sink
+        try {
+            log.info("Sink Queue name: {}", REPLICATED_QUEUE_NAME);
+            Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> replicatedQueueSink
+                    = sinkCorfuStores.get(0).openQueue(CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_NAME,
+                    Queue.RoutingTableEntryMsg.class, TableOptions.builder().schemaOptions(CorfuOptions.SchemaOptions.newBuilder()
+                            .addStreamTag(REPLICATED_QUEUE_TAG).build()).build());
+
+            RoutingQueueListener listener = new RoutingQueueListener(sinkCorfuStores.get(0));
+            sinkCorfuStores.get(0).subscribeListenerFromTrimMark(listener, CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_TAG);
+
+            startReplicationServers();
+            generateData(clientCorfuStore, queueSenderClient);
+            Thread.sleep(5000);
+
+            int sinkQueueSize = replicatedQueueSink.count();
+            while (sinkQueueSize != 10) {
+                Thread.sleep(5000);
+                sinkQueueSize = replicatedQueueSink.count();
+                log.info("Sink replicated queue size: {}", sinkQueueSize);
+            }
+            assertThat(listener.logEntryMsgCnt).isEqualTo(10);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void generateData(CorfuStore corfuStore, RoutingQueueSenderClient client) throws Exception {
+        String namespace = CORFU_SYSTEM_NAMESPACE;
+
+        Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> q =
+            corfuStore.openQueue(namespace, LOG_ENTRY_SYNC_QUEUE_NAME_SENDER, Queue.RoutingTableEntryMsg.class,
+                TableOptions.fromProtoSchema(Queue.RoutingTableEntryMsg.class));
+
+        String streamTagFollowed =
+            LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + DefaultClusterConfig.getSinkClusterIds().get(0);
+        log.info("Stream UUID: {}", CorfuRuntime.getStreamID(streamTagFollowed));
+
+        for (int i = 0; i < 10; i++) {
+            ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE);
+            buffer.putInt(i);
+            Queue.RoutingTableEntryMsg val =
+                Queue.RoutingTableEntryMsg.newBuilder()
+                        .setSourceClusterId(DefaultClusterConfig.getSourceClusterIds().get(0))
+                        .addAllDestinations(Arrays.asList(DefaultClusterConfig.getSinkClusterIds().get(0),
+                                DefaultClusterConfig.getSinkClusterIds().get(1)))
+                        .setOpaquePayload(ByteString.copyFrom(buffer.array()))
+                        .setReplicationType(Queue.ReplicationType.LOG_ENTRY_SYNC)
+                        .build();
+
+            try (TxnContext txnContext = corfuStore.txn(namespace)) {
+                client.transmitDeltaMessages(txnContext, Collections.singletonList(val), corfuStore);
+                log.info("Committed at {}", txnContext.commit());
+            } catch (Exception e) {
+                log.error("Failed to add data to the queue", e);
+            }
+        }
+    }
+
+    /**
+     * Open replication status table on each Sink for verify replication status.
+     */
+    private void openLogReplicationStatusTable() throws Exception {
+        for (int i = 0; i < numSource; i++) {
+            sourceCorfuStores.get(i).openTable(
+                LogReplicationMetadataManager.NAMESPACE,
+                REPLICATION_STATUS_TABLE_NAME,
+                LogReplication.LogReplicationSession.class,
+                LogReplication.ReplicationStatus.class,
+                null,
+                TableOptions.fromProtoSchema(LogReplication.ReplicationStatus.class)
+            );
+        }
+    }
+
+    static class RoutingQueueListener extends LiteRoutingQueueListener {
+        public int logEntryMsgCnt;
+
+        public RoutingQueueListener(CorfuStore corfuStore) {
+            super(corfuStore);
+            logEntryMsgCnt = 0;
+        }
+
+        @Override
+        protected boolean processUpdatesInSnapshotSync(List<Queue.RoutingTableEntryMsg> updates) {
+            return false;
+        }
+
+        @Override
+        protected boolean processUpdatesInLogEntrySync(List<Queue.RoutingTableEntryMsg> updates) {
+            log.info("LiteRoutingQueueListener::processUpdatesInLogEntrySync::{}", updates);
+            logEntryMsgCnt++;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
* RoutingTableEntryMsg extension
* Fix for client sender stream tag and transmit methods
* Fix sink side routing queue stream tag + log msgs
* Fix Routing Queue LogEntryWriter stream id
* Log entry end-to-end IT + fix for replicated queue name
* Fix LogEntryReader isValidTxnEntry number of tables touched
* LiteRoutingQueueListener Imple + replicated name revise

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
