### PR TITLE
LogReplicationEventListener fix of using runtime event protos than infra events

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -13,6 +13,7 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationEvent;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationEventInfoKey;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.ReplicationStatus;
 import org.corfudb.runtime.LogReplication.ReplicationInfo;
 import org.corfudb.runtime.LogReplication.SyncType;
@@ -598,8 +599,10 @@ public class LogReplicationMetadataManager {
      * Get all replication events from the Event table.
      * @return list of all replication events
      */
-    public List<CorfuStoreEntry<ReplicationEventInfoKey, ReplicationEvent, Message>> getReplicationEvents() {
-        List<CorfuStoreEntry<ReplicationEventInfoKey, ReplicationEvent, Message>> events = new ArrayList<>();
+    public List<CorfuStoreEntry<LogReplication.ReplicationEventInfoKey, LogReplication.ReplicationEvent,
+            Message>> getReplicationEvents() {
+        List<CorfuStoreEntry<LogReplication.ReplicationEventInfoKey, LogReplication.ReplicationEvent,
+                Message>> events = new ArrayList<>();
 
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
              events = txn.executeQuery(REPLICATION_EVENT_TABLE_NAME, p -> true);


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
