### PR TITLE
Set stream batch size to 1 if readCache is disabled

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -108,7 +108,8 @@ public class AddressSpaceView extends AbstractView implements AutoCloseable {
 
         if (maxCacheEntries == 0) {
             log.warn("Since AddressSpaceView readCache size is 0, " +
-                    "overriding CorfuRuntime bulkReadSize and checkpointReadBatchSize to 1.");
+                    "overriding CorfuRuntime streamBatchSize and checkpointReadBatchSize to 1.");
+            runtime.getParameters().setStreamBatchSize(1);
             runtime.getParameters().setCheckpointReadBatchSize(1);
         }
 


### PR DESCRIPTION
Stream batch read only works when readCache is enabled. If readCache is disabled, stream batch read introduces wasteful reads because the results can't be cached.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
