### PR TITLE
Log the total message size sent in snapshot sync payload

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -64,6 +64,9 @@ public class SnapshotSender {
     // The max number of message can be sent over in burst for a snapshot cycle.
     private final int maxNumSnapshotMsgPerBatch;
 
+    // The total size of the messages sent as part of snapshot sync
+    private long messagesSentSize = 0;
+
     // This flag will indicate the start of a snapshot sync, so start snapshot marker is sent once.
     private boolean startSnapshotSync = true;
 
@@ -106,7 +109,6 @@ public class SnapshotSender {
         int messagesSent = 0;       // Limit the number of messages to maxNumSnapshotMsgPerBatch. The reason we need to limit
         // is because by design several state machines can share the same thread pool,
         // therefore, we need to hand the thread for other workers to execute.
-        long messagesSentSize = 0;
         SnapshotReadMessage snapshotReadMessage;
 
         // Skip if no data is present in the log
@@ -335,6 +337,7 @@ public class SnapshotSender {
 
         stopSnapshotSync.set(false);
         startSnapshotSync = true;
+        messagesSentSize = 0;
     }
 
     private void resetBaseSnapshotTimestamp(long timestamp) {


### PR DESCRIPTION
## Overview

Log the total message size sent in snapshot sync payload

Description:

Currently we print snapshot message size for each batch (shown below). But, lacking the total size sent. So, adding the support.

```
2023-07-31T17:22:25.437Z | INFO  | tate-machine-worker--363488543 | c.i.l.r.s.l.BaseSnapshotReader | Successfully generate a snapshot message for stream stream_tag$CorfuSystemlrq_snapsync_f2394ea8-5173-43d4-b20f-7c5f7d3ea17d with snapshotTimestamp=7511949, numEntries=20, entriesBytes=17697, streamId=add0db5a-6c9d-3cdf-bba8-dce08c7f55d3
2023-07-31T17:22:25.877Z | INFO  | tate-machine-worker--363488543 | c.i.l.r.s.l.BaseSnapshotReader | Successfully generate a snapshot message for stream stream_tag$CorfuSystemlrq_snapsync_f2394ea8-5173-43d4-b20f-7c5f7d3ea17d with snapshotTimestamp=7511949, numEntries=36, entriesBytes=31953, streamId=add0db5a-6c9d-3cdf-bba8-dce08c7f55d3

...
```

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
