### PR TITLE
Fix the flakiness in LogReplicationFSMTest.cancelSnapshotSyncInProgressAndRetry

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestDataSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestDataSender.java
@@ -27,6 +27,14 @@ public class TestDataSender implements DataSender {
 
     private long snapshotSyncBaseSnapshot = 0;
 
+    // Flag which prevents this sender from replying with ACKs so that the test can wait in IN_SNAPSHOT_SYNC state
+    // for any operation or validation
+    private boolean waitInSnapshotSync;
+
+    public TestDataSender(boolean waitInSnapshotSync) {
+        this.waitInSnapshotSync = waitInSnapshotSync;
+    }
+
     @Override
     public CompletableFuture<LogReplicationEntryMsg> send(LogReplicationEntryMsg message) {
         if (message != null && !message.getData().isEmpty() &&
@@ -37,6 +45,12 @@ public class TestDataSender implements DataSender {
         }
 
         CompletableFuture<LogReplicationEntryMsg> cf = new CompletableFuture<>();
+
+        // Do not send an ACK if the test needs to wait in IN_SNAPSHOT_SYNC state.
+        if (waitInSnapshotSync) {
+            return cf;
+        }
+
         LogReplicationEntryMetadataMsg.Builder ackMetadata =
                 LogReplicationEntryMetadataMsg.newBuilder().mergeFrom(message.getMetadata());
 
@@ -97,6 +111,7 @@ public class TestDataSender implements DataSender {
 
     public void reset() {
         entryQueue.clear();
+        waitInSnapshotSync = false;
     }
 
     @Override


### PR DESCRIPTION
## Overview
Cherry-pick of #3662 

Description:

Why should this be merged: 

Related issue(s) (if applicable): #3662 


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
