### PR TITLE
close futures before shutting down event loop groups

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -197,13 +197,14 @@ public class CorfuServerNode implements AutoCloseable {
         }
 
         log.info("close: Shutting down Corfu server and cleaning resources");
-        serverContext.close();
+
         if (bindFuture != null) {
             bindFuture.channel().close().syncUninterruptibly();
         }
         if (httpServerFuture != null) {
             httpServerFuture.channel().close().syncUninterruptibly();
         }
+        serverContext.close();
 
         // A executor service to create the shutdown threads
         // plus name the threads correctly.


### PR DESCRIPTION
## Overview

Description:

There is a race bug where the reset sometimes does not complete fully because the worker group executor is getting shutdown before the future that uses it to run requests closes:

`java.util.concurrent.RejectedExecutionException: event executor terminated`

Corfu is never brought up after the botched reset as the main thread awaits the latch. 

Submit the close tasks for the futures before shutting down the associated executors. 


