### PR TITLE
[WIP] Client full sync to be done asynchronously in a separate thread.  Alternate implementation

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -22,7 +22,6 @@
 *   **logreplication.opaque.count\_valid**: Number of valid opaque entries (rate, mean, max).
 *   **logreplication.subscribe.trim.count**: Number of times a Trimmed Exception was thrown from the MVO layer when subscribing to LogReplication listener.
 *   **logreplication.subscribe.conflict.count**: Number of times a Transaction Aborted Exception was thrown due to conflicting updates when subscribing to LogReplication listener.
-*   **logreplication.subscribe.duration**: Time taken to subscribe the LogReplication listener.
 *   **logreplication.client.fullsync.duration**: Time taken by the client subscribing to LogReplication listener to perform a full sync on its tables.
 
 ### Current metrics collected for Corfu Runtime:

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -40,10 +41,9 @@ import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_N
 @Slf4j
 public abstract class LogReplicationListener implements StreamListener {
 
-    // Indicates if a full sync on client tables was performed during subscription.  A full sync will not be
-    // performed if a snapshot sync is ongoing.
+    // Indicates if a full sync on client tables is pending
     @Getter
-    private final AtomicBoolean clientFullSyncPending = new AtomicBoolean(false);
+    private final AtomicBoolean clientFullSyncPending = new AtomicBoolean(true);
 
     // This variable tracks if a snapshot sync is ongoing
     @Getter
@@ -56,6 +56,8 @@ public abstract class LogReplicationListener implements StreamListener {
     @Getter
     private final AtomicLong clientFullSyncTimestamp = new AtomicLong(Address.NON_ADDRESS);
 
+    private ExecutorService fullSyncExecutorService;
+
     private final CorfuStore corfuStore;
     private final String namespace;
 
@@ -63,10 +65,13 @@ public abstract class LogReplicationListener implements StreamListener {
      * Special LogReplication listener which a client creates to receive ordered updates for replicated data.
      * @param corfuStore Corfu Store used on the client
      * @param namespace Namespace of the client's tables
+     * @param fullSyncExecutorService An executor service/thread where client full sync will run
      */
-    public LogReplicationListener(CorfuStore corfuStore, @Nonnull String namespace) {
+    public LogReplicationListener(@Nonnull CorfuStore corfuStore, @Nonnull String namespace,
+                                  @Nonnull ExecutorService fullSyncExecutorService) {
         this.corfuStore = corfuStore;
         this.namespace = namespace;
+        this.fullSyncExecutorService = fullSyncExecutorService;
     }
 
     /**
@@ -75,6 +80,11 @@ public abstract class LogReplicationListener implements StreamListener {
      * @param results is a map of stream UUID -> list of entries of this stream.
      */
     public final void onNext(CorfuStreamEntries results) {
+
+        // Ignore any updates which arrive before the client's full sync completes
+        if (clientFullSyncPending.get()) {
+            return;
+        }
 
         // If this update came before the client's full sync timestamp, ignore it.
         if (results.getTimestamp().getSequence() <= clientFullSyncTimestamp.get()) {
@@ -88,13 +98,6 @@ public abstract class LogReplicationListener implements StreamListener {
             Preconditions.checkState(results.getEntries().keySet().size() == 1,
                 "Replication Status Table Update received with other tables");
             processReplicationStatusUpdate(results);
-            return;
-        }
-
-        // Data Updates
-        if (clientFullSyncPending.get()) {
-            // If the listener started when snapshot sync was ongoing, ignore all data updates until it ends.  When
-            // it ends, the client will perform a full sync and build a consistent state containing these updates.
             return;
         }
 
@@ -126,7 +129,6 @@ public abstract class LogReplicationListener implements StreamListener {
                 ReplicationStatus status = (ReplicationStatus)entry.getPayload();
 
                 if (status.getSinkStatus().getDataConsistent()) {
-                    // getDataConsistent() == true means that snapshot sync has ended.
                     if (snapshotSyncInProgress.get()) {
                         if (clientFullSyncPending.get()) {
                             // Snapshot sync which was ongoing when the listener was subscribed has ended.  Attempt to

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.Table;
@@ -25,6 +26,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -43,119 +46,17 @@ public final class LogReplicationUtils {
     private LogReplicationUtils() { }
 
     public static void subscribe(@Nonnull LogReplicationListener clientListener, @Nonnull String namespace,
-                          @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest, int bufferSize,
-                          CorfuStore corfuStore) {
+                                 @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest, int bufferSize,
+                                 CorfuStore corfuStore, ExecutorService clientExcecutorService) {
 
-        long subscriptionTimestamp = getSubscriptionTimestamp(corfuStore, namespace, clientListener);
+        long subscriptionTimestamp = getTimestamp(corfuStore).getSequence();
         corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationListener(
-                clientListener, namespace, streamTag, tablesOfInterest, subscriptionTimestamp, bufferSize);
+            clientListener, namespace, streamTag, tablesOfInterest, subscriptionTimestamp, bufferSize);
         log.info("Client subscription at timestamp {} successful.", subscriptionTimestamp);
+
+        // Asynchronously run performFullSyncAndMerge
+        clientExcecutorService.submit(new ClientFullSyncTask(clientListener, corfuStore, namespace));
     }
-
-
-    private static long getSubscriptionTimestamp(CorfuStore corfuStore, String namespace,
-                                                 LogReplicationListener clientListener) {
-        Optional<Counter> mvoTrimCounter = MicroMeterUtils.counter("logreplication.subscribe.trim.count");
-        Optional<Counter> conflictCounter = MicroMeterUtils.counter("logreplication.subscribe.conflict.count");
-        Optional<Timer.Sample> subscribeTimer = MicroMeterUtils.startTimer();
-
-        Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable =
-            openReplicationStatusTable(corfuStore);
-
-        try {
-            return IRetry.build(IntervalRetry.class, () -> {
-                try (TxnContext txnContext = corfuStore.txn(namespace)) {
-                    // The transaction is started in the client's namespace and the Replication Status table resides in the
-                    // system namespace.  Corfu Store does not validate the cross-namespace access as long as there are no
-                    // writes on the table in the different namespace.  This hack is required here as we want client full
-                    // sync to happen in the same transaction which checks the status of a snapshot sync so that there is no
-                    // window between the check and full sync.
-                    List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
-                        txnContext.executeQuery(replicationStatusTable,
-                                entry -> entry.getKey().getSubscriber().getModel()
-                                    .equals(LogReplication.ReplicationModel.LOGICAL_GROUPS) &&
-                                    Objects.equals(entry.getKey().getSubscriber().getClientName(),
-                                        clientListener.getClientName()));
-
-                    CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message> entry = null;
-
-                    // It is possible that there is no entry for the Logical Group Model in the status table in
-                    // the following scenarios:
-                    // 1. Request to subscribe is received before the Log Replication JVM or pod starts and
-                    // initializes the table
-                    // 2. Topology change which removes this cluster from the status table.
-                    // We cannot differentiate between the two cases here so continue with the right
-                    // behavior for the 1st case, i.e., subscribe and wait for the initial Snapshot Sync to get
-                    // triggered.  If we are here because of the second case, the listener will not get any updates
-                    // from LR and subscription will be a no-op.
-                    if (entries.isEmpty()) {
-                        log.info("No record for client {} and Logical Group Model found in the Status Table.  " +
-                                "Subscription could have been attempted before LR startup.  Subscribe the listener and" +
-                                "wait for initial Snapshot Sync", clientListener.getClientName());
-                    } else {
-                        // For a given replication model and client, any Sink node will have a single session.
-                        Preconditions.checkState(entries.size() == 1);
-                        entry = entries.get(0);
-                    }
-
-                    boolean snapshotSyncInProgress = false;
-
-                    if (entry == null || entry.getPayload().getSinkStatus().getDataConsistent()) {
-                        // No snapshot sync is in progress
-                        log.info("No Snapshot Sync is in progress.  Request the client to perform a full sync on its " +
-                            "tables.");
-                        Optional<Timer.Sample> clientFullSyncTimer = MicroMeterUtils.startTimer();
-                        long clientFullSyncStartTime = System.currentTimeMillis();
-                        clientListener.performFullSyncAndMerge(txnContext);
-                        long clientFullSyncEndTime = System.currentTimeMillis();
-                        MicroMeterUtils.time(clientFullSyncTimer, "logreplication.client.fullsync.duration");
-                        log.info("Client Full Sync and Merge took {} ms",
-                                clientFullSyncEndTime - clientFullSyncStartTime);
-                    } else {
-                        // Snapshot sync is in progress.  Subscribe without performing a full sync on the tables.
-                        log.info("Snapshot Sync is in progress.  Subscribing without performing a full sync on client" +
-                            " tables.");
-                        snapshotSyncInProgress = true;
-                    }
-                    txnContext.commit();
-
-                    // Subscribe from the snapshot timestamp of this transaction, i.e., log tail when the transaction started.
-                    // Subscribing from the commit address will result in missed updates which took place between the start
-                    // and end of the transaction because reads in a transaction observe updates only till the snapshot when it
-                    // started.
-                    long subscriptionTimestamp = txnContext.getTxnSequence();
-
-                    // Update the flags and variables on the listener based on whether snapshot sync was in progress.
-                    // This must be done only after the transaction commits.
-                    setListenerParamsForSnapshotSync(clientListener, subscriptionTimestamp, snapshotSyncInProgress);
-
-                    return subscriptionTimestamp;
-                } catch (TransactionAbortedException tae) {
-                    if (tae.getCause() instanceof TrimmedException) {
-                        // If the snapshot version where this transaction started has been evicted from the JVM's MVO
-                        // cache, a trimmed exception is thrown and requires a retry at a later timestamp.
-                        incrementCount(mvoTrimCounter);
-                        log.warn("Snapshot no longer available in the cache.  Retrying.", tae);
-                    } else if (tae.getAbortCause() == AbortCause.CONFLICT) {
-                        // Concurrent updates to the client's tables
-                        incrementCount(conflictCounter);
-                        log.warn("Concurrent updates to client tables.  Retrying.", tae);
-                    } else {
-                        log.error("Unexpected type of Transaction Aborted Exception", tae);
-                    }
-                    throw new RetryNeededException();
-                } catch (Exception e) {
-                    log.error("Unexpected exception type hit", e);
-                    throw new RetryNeededException();
-                }
-            }).run();
-        } catch (InterruptedException e) {
-            throw new StreamingException(e, StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
-        } finally {
-            MicroMeterUtils.time(subscribeTimer, "logreplication.subscribe.duration");
-        }
-    }
-
 
     private static Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(CorfuStore corfuStore) {
         try {
@@ -168,26 +69,6 @@ public final class LogReplicationUtils {
         }
     }
 
-    private static void setListenerParamsForSnapshotSync(LogReplicationListener listener, long subscriptionTimestamp,
-                                                         boolean snapshotSyncInProgress) {
-        updateListenerFlagsForSnapshotSync(listener, snapshotSyncInProgress);
-
-        // If client full sync was done, set its timestamp
-        if (!snapshotSyncInProgress) {
-            listener.getClientFullSyncTimestamp().set(subscriptionTimestamp);
-        }
-    }
-
-    private static void updateListenerFlagsForSnapshotSync(LogReplicationListener clientListener,
-                                                           boolean snapshotSyncInProgress) {
-        clientListener.getClientFullSyncPending().set(snapshotSyncInProgress);
-        clientListener.getSnapshotSyncInProgress().set(snapshotSyncInProgress);
-    }
-
-    private static void incrementCount(Optional<Counter> counter) {
-        counter.ifPresent(Counter::increment);
-    }
-
     /**
      * If full sync on client tables was not performed during subscription, attempt to perform it now and complete
      * the subscription.
@@ -196,7 +77,152 @@ public final class LogReplicationUtils {
      * @param namespace
      */
     public static void attemptClientFullSync(CorfuStore corfuStore, LogReplicationListener clientListener,
-                                             String namespace) {
-        getSubscriptionTimestamp(corfuStore, namespace, clientListener);
+                                          String namespace,
+                                      ExecutorService clientExecutorService) {
+        clientExecutorService.submit(new ClientFullSyncTask(clientListener, corfuStore, namespace));
+    }
+
+    private static CorfuStoreMetadata.Timestamp getTimestamp(CorfuStore corfuStore) {
+        Token token = corfuStore.getRuntime().getSequencerView().query().getToken();
+        return CorfuStoreMetadata.Timestamp.newBuilder()
+            .setEpoch(token.getEpoch())
+            .setSequence(token.getSequence())
+            .build();
+    }
+
+    private static class ClientFullSyncTask implements Callable<Void> {
+
+        private LogReplicationListener listener;
+
+        private CorfuStore corfuStore;
+
+        private String namespace;
+
+        ClientFullSyncTask(LogReplicationListener listener, CorfuStore corfuStore, String namespace) {
+            this.listener = listener;
+            this.corfuStore = corfuStore;
+            this.namespace = namespace;
+        }
+
+        @Override
+        public Void call() {
+            Optional<Counter> mvoTrimCounter = MicroMeterUtils.counter("logreplication.subscribe.trim.count");
+            Optional<Counter> conflictCounter = MicroMeterUtils.counter("logreplication.subscribe.conflict.count");
+
+            Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable =
+                openReplicationStatusTable(corfuStore);
+
+            try {
+                IRetry.build(IntervalRetry.class, () -> {
+                    try (TxnContext txnContext = corfuStore.txn(namespace)) {
+                        // The transaction is started in the client's namespace and the Replication Status table resides in the
+                        // system namespace.  Corfu Store does not validate the cross-namespace access as long as there are no
+                        // writes on the table in the different namespace.  This hack is required here as we want client full
+                        // sync to happen in the same transaction which checks the status of a snapshot sync so that there is no
+                        // window between the check and full sync.
+                        List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
+                            txnContext.executeQuery(replicationStatusTable,
+                                entry -> entry.getKey().getSubscriber().getModel()
+                                    .equals(LogReplication.ReplicationModel.LOGICAL_GROUPS) &&
+                                    Objects.equals(entry.getKey().getSubscriber().getClientName(),
+                                        listener.getClientName()));
+
+                        CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message> entry = null;
+
+                        // It is possible that there is no entry for the Logical Group Model in the status table in
+                        // the following scenarios:
+                        // 1. Request to subscribe is received before the Log Replication JVM or pod starts and
+                        // initializes the table
+                        // 2. Topology change which removes this cluster from the status table.
+                        // We cannot differentiate between the two cases here so continue with the right
+                        // behavior for the 1st case, i.e., subscribe and wait for the initial Snapshot Sync to get
+                        // triggered.  If we are here because of the second case, the listener will not get any updates
+                        // from LR and subscription will be a no-op.
+                        if (entries.isEmpty()) {
+                            log.warn("No record for client {} and Logical Group Model found in the Status Table.  " +
+                                "Subscription could have been attempted before LR startup.  Subscribe the listener and" +
+                                "wait for initial Snapshot Sync", listener.getClientName());
+                        } else {
+                            // For a given replication model and client, any Sink node will have a single session.
+                            Preconditions.checkState(entries.size() == 1);
+                            entry = entries.get(0);
+                        }
+
+                        boolean snapshotSyncInProgress = false;
+
+                        if (entry == null || entry.getPayload().getSinkStatus().getDataConsistent()) {
+                            // No snapshot sync is in progress
+                            log.info("No Snapshot Sync is in progress.  Request the client to perform a full sync on its " +
+                                "tables.");
+                            Optional<Timer.Sample> clientFullSyncTimer = MicroMeterUtils.startTimer();
+                            long clientFullSyncStartTime = System.currentTimeMillis();
+                            listener.performFullSyncAndMerge(txnContext);
+                            long clientFullSyncEndTime = System.currentTimeMillis();
+                            MicroMeterUtils.time(clientFullSyncTimer, "logreplication.client.fullsync.duration");
+                            log.info("Client Full Sync and Merge took {} ms",
+                                clientFullSyncEndTime - clientFullSyncStartTime);
+                        } else {
+                            // Snapshot sync is in progress.  Retry the operation
+                            log.info("Snapshot Sync is in progress.  Retrying the operation");
+                            snapshotSyncInProgress = true;
+                        }
+
+                        txnContext.commit();
+                        // Subscribe from the snapshot timestamp of this transaction, i.e., log tail when the transaction started.
+                        // Subscribing from the commit address will result in missed updates which took place between the start
+                        // and end of the transaction because reads in a transaction observe updates only till the snapshot when it
+                        // started.
+                        long fullSyncTimestamp = txnContext.getTxnSequence();
+
+                        // Update the flags and variables on the listener based on whether snapshot sync was in progress.
+                        // This must be done only after the transaction commits.
+                        setListenerParamsForSnapshotSync(listener, fullSyncTimestamp, snapshotSyncInProgress);
+                        return null;
+                    } catch (TransactionAbortedException tae) {
+                        if (tae.getCause() instanceof TrimmedException) {
+                            // If the snapshot version where this transaction started has been evicted from the JVM's MVO
+                            // cache, a trimmed exception is thrown and requires a retry at a later timestamp.
+                            incrementCount(mvoTrimCounter);
+                            log.warn("Snapshot no longer available in the cache.  Retrying.", tae);
+                        } else if (tae.getAbortCause() == AbortCause.CONFLICT) {
+                            // Concurrent updates to the client's tables
+                            incrementCount(conflictCounter);
+                            log.warn("Concurrent updates to client tables.  Retrying.", tae);
+                        } else {
+                            log.error("Unexpected type of Transaction Aborted Exception", tae);
+                        }
+                        throw new RetryNeededException();
+                    } catch (Exception e) {
+                        log.error("Unexpected exception type hit", e);
+                        throw new RetryNeededException();
+                    }
+                }).run();
+            } catch (InterruptedException e) {
+                throw new StreamingException(e, StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
+                // TODO pankti: Unsubscribe the listener
+            }
+            return null;
+        }
+
+        private void incrementCount(Optional<Counter> counter) {
+            counter.ifPresent(Counter::increment);
+        }
+
+        private void setListenerParamsForSnapshotSync(LogReplicationListener listener, long fullSyncTimestamp,
+                                                      boolean snapshotSyncInProgress) {
+
+            updateListenerFlagsForSnapshotSync(listener, snapshotSyncInProgress);
+
+            // If client full sync was done, set its timestamp
+            if (!snapshotSyncInProgress) {
+                listener.getClientFullSyncTimestamp().set(fullSyncTimestamp);
+            }
+        }
+
+        private void updateListenerFlagsForSnapshotSync(LogReplicationListener clientListener,
+                                                               boolean snapshotSyncInProgress) {
+            clientListener.getClientFullSyncPending().set(snapshotSyncInProgress);
+            clientListener.getSnapshotSyncInProgress().set(snapshotSyncInProgress);
+        }
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -30,6 +30,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 
 /**
  * CorfuStore is a protobuf API layer that provides all the features of CorfuDB.
@@ -413,10 +414,11 @@ public class CorfuStore {
      * @param streamTag      stream tag of the replicated tables
      */
     public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
-                                                @Nonnull String namespace, @Nonnull String streamTag) {
+                                                @Nonnull String namespace, @Nonnull String streamTag,
+                                                ExecutorService executorService) {
         int uninitializedBufferSize = 0;
-        LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
-                uninitializedBufferSize, this);
+        LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace,
+                streamTag), uninitializedBufferSize, this, executorService);
     }
 
     /**
@@ -435,9 +437,10 @@ public class CorfuStore {
      * @param bufferSize       maximum size of buffered transaction entries
      */
     public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
-                                                @Nonnull String namespace, @Nonnull String streamTag, int bufferSize) {
+                                                @Nonnull String namespace, @Nonnull String streamTag, int bufferSize,
+                                                ExecutorService executorService) {
         LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
-                bufferSize, this);
+                bufferSize, this, executorService);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Tests the apis in LogReplicationUtils.
@@ -36,7 +37,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
     public void setUp() throws Exception {
         corfuRuntime = getDefaultRuntime();
         corfuStore = new CorfuStore(corfuRuntime);
-        lrListener = new LogReplicationTestListener(corfuStore, namespace, client);
+        lrListener = new LogReplicationTestListener(corfuStore, namespace, client, null);
         replicationStatusTable = TestUtils.openReplicationStatusTable(corfuStore);
     }
 
@@ -72,7 +73,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         if (initializeTable) {
             TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, client, ongoing);
         }
-        LogReplicationUtils.attemptClientFullSync(corfuStore, lrListener, namespace);
+        LogReplicationUtils.attemptClientFullSync(corfuStore, lrListener, namespace, null);
         verifyListenerFlags((LogReplicationTestListener)lrListener, ongoing);
     }
 
@@ -110,7 +111,8 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         }
 
         String streamTag = "test_tag";
-        LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
+        LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore,
+            null);
         verifyListenerFlags((LogReplicationTestListener)lrListener, ongoing);
     }
 
@@ -139,16 +141,19 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
 
         // Create the listener for new_client and set snapshot sync to be in progress
         String newClient = "new_client";
-        LogReplicationListener newListener = new LogReplicationTestListener(corfuStore, namespace, newClient);
+        LogReplicationListener newListener = new LogReplicationTestListener(corfuStore, namespace, newClient,
+            null);
         TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, newClient, true);
 
         if (subscribe) {
             String streamTag = "test_tag";
-            LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
-            LogReplicationUtils.subscribe(newListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
+            LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore,
+                null);
+            LogReplicationUtils.subscribe(newListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore,
+                null);
         } else {
-            LogReplicationUtils.attemptClientFullSync(corfuStore, lrListener, namespace);
-            LogReplicationUtils.attemptClientFullSync(corfuStore, newListener, namespace);
+            LogReplicationUtils.attemptClientFullSync(corfuStore, lrListener, namespace, null);
+            LogReplicationUtils.attemptClientFullSync(corfuStore, newListener, namespace, null);
         }
 
         // Verify that full sync finished and snapshot sync was not considered ongoing for test_client
@@ -183,8 +188,9 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
 
         private String clientName;
 
-        LogReplicationTestListener(CorfuStore corfuStore, String namespace, String clientName) {
-            super(corfuStore, namespace);
+        LogReplicationTestListener(CorfuStore corfuStore, String namespace, String clientName,
+                                   ExecutorService executorService) {
+            super(corfuStore, namespace, executorService);
             this.clientName = clientName;
         }
 


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
