### PR TITLE
Decouple LR listener subscribe and full sync

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
@@ -12,15 +12,12 @@ import org.corfudb.runtime.collections.CorfuStreamEntry;
 import org.corfudb.runtime.collections.StreamListener;
 import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.runtime.view.Address;
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
@@ -40,24 +37,9 @@ import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_N
  */
 @Slf4j
 public abstract class LogReplicationListener implements StreamListener {
-
-    // Indicates if a full sync on client tables was performed during subscription.  A full sync will not be
-    // performed if a snapshot sync is ongoing.
-    @Getter
-    private final AtomicBoolean clientFullSyncPending = new AtomicBoolean(true);
-
     // This variable tracks if a snapshot sync is ongoing
     @Getter
     private final AtomicBoolean snapshotSyncInProgress = new AtomicBoolean(false);
-
-    // Timestamp at which the client performed a full sync.  Any updates below this timestamp must be ignored.
-    // At the time of subscription, a full sync cannot be performed if LR Snapshot Sync is in progress.  Full Sync is
-    // performed when this ongoing snapshot sync completes.  The listener, however, can get updates before this full
-    // sync.  So we need to maintain this timestamp and ignore any updates below it.
-    @Getter
-    private final AtomicLong clientFullSyncTimestamp = new AtomicLong(Address.NON_ADDRESS);
-
-    private ExecutorService fullSyncExecutorService;
 
     private final CorfuStore corfuStore;
     private final String namespace;
@@ -66,13 +48,10 @@ public abstract class LogReplicationListener implements StreamListener {
      * Special LogReplication listener which a client creates to receive ordered updates for replicated data.
      * @param corfuStore Corfu Store used on the client
      * @param namespace Namespace of the client's tables
-     * @param fullSyncExecutorService An executor service/thread where client full sync will run
      */
-    public LogReplicationListener(CorfuStore corfuStore, @Nonnull String namespace,
-                                  @Nonnull ExecutorService fullSyncExecutorService) {
+    public LogReplicationListener(CorfuStore corfuStore, @Nonnull String namespace) {
         this.corfuStore = corfuStore;
         this.namespace = namespace;
-        this.fullSyncExecutorService = fullSyncExecutorService;
     }
 
     /**
@@ -81,16 +60,6 @@ public abstract class LogReplicationListener implements StreamListener {
      * @param results is a map of stream UUID -> list of entries of this stream.
      */
     public final void onNext(CorfuStreamEntries results) {
-        // Ignore any updates which arrive before the client's full sync completes
-        if (clientFullSyncPending.get()) {
-            return;
-        }
-
-        // If this update came before the client's full sync timestamp, ignore it.
-        if (results.getTimestamp().getSequence() <= clientFullSyncTimestamp.get()) {
-            return;
-        }
-
         Set<String> tableNames =
                 results.getEntries().keySet().stream().map(schema -> schema.getTableName()).collect(Collectors.toSet());
 

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationListener.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -31,7 +32,7 @@ import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_N
  * listener will observe the writes and apply them to the merged table based on the client implementation.
  *
  *
- * This interface sees ordered updates from :
+ * This interface sees ordered updates from:
  * 1. client-streams from client-Namespace, and,
  * 2. LrStatusTable from corfuSystem-Namespace.
  *
@@ -43,7 +44,7 @@ public abstract class LogReplicationListener implements StreamListener {
     // Indicates if a full sync on client tables was performed during subscription.  A full sync will not be
     // performed if a snapshot sync is ongoing.
     @Getter
-    private final AtomicBoolean clientFullSyncPending = new AtomicBoolean(false);
+    private final AtomicBoolean clientFullSyncPending = new AtomicBoolean(true);
 
     // This variable tracks if a snapshot sync is ongoing
     @Getter
@@ -56,6 +57,8 @@ public abstract class LogReplicationListener implements StreamListener {
     @Getter
     private final AtomicLong clientFullSyncTimestamp = new AtomicLong(Address.NON_ADDRESS);
 
+    private ExecutorService fullSyncExecutorService;
+
     private final CorfuStore corfuStore;
     private final String namespace;
 
@@ -63,10 +66,13 @@ public abstract class LogReplicationListener implements StreamListener {
      * Special LogReplication listener which a client creates to receive ordered updates for replicated data.
      * @param corfuStore Corfu Store used on the client
      * @param namespace Namespace of the client's tables
+     * @param fullSyncExecutorService An executor service/thread where client full sync will run
      */
-    public LogReplicationListener(CorfuStore corfuStore, @Nonnull String namespace) {
+    public LogReplicationListener(CorfuStore corfuStore, @Nonnull String namespace,
+                                  @Nonnull ExecutorService fullSyncExecutorService) {
         this.corfuStore = corfuStore;
         this.namespace = namespace;
+        this.fullSyncExecutorService = fullSyncExecutorService;
     }
 
     /**
@@ -75,6 +81,10 @@ public abstract class LogReplicationListener implements StreamListener {
      * @param results is a map of stream UUID -> list of entries of this stream.
      */
     public final void onNext(CorfuStreamEntries results) {
+        // Ignore any updates which arrive before the client's full sync completes
+        if (clientFullSyncPending.get()) {
+            return;
+        }
 
         // If this update came before the client's full sync timestamp, ignore it.
         if (results.getTimestamp().getSequence() <= clientFullSyncTimestamp.get()) {
@@ -88,13 +98,6 @@ public abstract class LogReplicationListener implements StreamListener {
             Preconditions.checkState(results.getEntries().keySet().size() == 1,
                 "Replication Status Table Update received with other tables");
             processReplicationStatusUpdate(results);
-            return;
-        }
-
-        // Data Updates
-        if (clientFullSyncPending.get()) {
-            // If the listener started when snapshot sync was ongoing, ignore all data updates until it ends.  When
-            // it ends, the client will perform a full sync and build a consistent state containing these updates.
             return;
         }
 
@@ -115,7 +118,6 @@ public abstract class LogReplicationListener implements StreamListener {
             .get();
 
         for (CorfuStreamEntry entry : replicationStatusTableEntries) {
-
             LogReplicationSession session = (LogReplicationSession)entry.getKey();
 
             // Only process updates where operation type == UPDATE, model == Logical Groups and the client name
@@ -128,13 +130,7 @@ public abstract class LogReplicationListener implements StreamListener {
                 if (status.getSinkStatus().getDataConsistent()) {
                     // getDataConsistent() == true means that snapshot sync has ended.
                     if (snapshotSyncInProgress.get()) {
-                        if (clientFullSyncPending.get()) {
-                            // Snapshot sync which was ongoing when the listener was subscribed has ended.  Attempt to
-                            // perform a full sync now.
-                            LogReplicationUtils.attemptClientFullSync(corfuStore, this, namespace);
-                            return;
-                        }
-                        // Process snapshot sync completion in steady state, i.e., client full sync is already complete
+                        // Process snapshot sync completion
                         snapshotSyncInProgress.set(false);
                         onSnapshotSyncComplete();
                     }

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -6,25 +6,33 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.runtime.exceptions.AbortCause;
-import org.corfudb.runtime.exceptions.StreamingException;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
 import org.corfudb.runtime.LogReplication.ReplicationStatus;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.RetryExhaustedException;
+import org.corfudb.runtime.exceptions.StreamingException;
+import org.corfudb.runtime.exceptions.SubscribeMaxRetryException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.util.retry.ExponentialBackoffRetry;
 import org.corfudb.util.retry.IRetry;
-import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
+
 import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -42,120 +50,158 @@ public final class LogReplicationUtils {
 
     private LogReplicationUtils() { }
 
-    public static void subscribe(@Nonnull LogReplicationListener clientListener, @Nonnull String namespace,
+    public static void subscribe(@Nonnull LogReplicationListener listener, @Nonnull String namespace,
                           @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest, int bufferSize,
-                          CorfuStore corfuStore) {
-
-        long subscriptionTimestamp = getSubscriptionTimestamp(corfuStore, namespace, clientListener);
-        corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationListener(
-                clientListener, namespace, streamTag, tablesOfInterest, subscriptionTimestamp, bufferSize);
-        log.info("Client subscription at timestamp {} successful.", subscriptionTimestamp);
+                          CorfuStore corfuStore, ExecutorService clientExecutorService) {
+        log.info("Client subscription process has started at timestamp: {}", getTimestamp(corfuStore).getSequence());
+        attemptClientFullSync(listener, corfuStore, namespace, streamTag,
+                tablesOfInterest, bufferSize, clientExecutorService);
     }
 
 
-    private static long getSubscriptionTimestamp(CorfuStore corfuStore, String namespace,
-                                                 LogReplicationListener clientListener) {
-        Optional<Counter> mvoTrimCounter = MicroMeterUtils.counter("logreplication.subscribe.trim.count");
-        Optional<Counter> conflictCounter = MicroMeterUtils.counter("logreplication.subscribe.conflict.count");
-        Optional<Timer.Sample> subscribeTimer = MicroMeterUtils.startTimer();
+    private static class ClientFullSyncTask implements Callable<Void> {
 
-        Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable =
-            openReplicationStatusTable(corfuStore);
+        private LogReplicationListener listener;
+        private CorfuStore corfuStore;
+        private String namespace;
+        private String streamTag;
+        private List<String> tablesOfInterest;
+        private int bufferSize;
+        private final Duration retryThreshold = Duration.ofMinutes(2);
 
-        try {
-            return IRetry.build(IntervalRetry.class, () -> {
-                try (TxnContext txnContext = corfuStore.txn(namespace)) {
-                    // The transaction is started in the client's namespace and the Replication Status table resides in the
-                    // system namespace.  Corfu Store does not validate the cross-namespace access as long as there are no
-                    // writes on the table in the different namespace.  This hack is required here as we want client full
-                    // sync to happen in the same transaction which checks the status of a snapshot sync so that there is no
-                    // window between the check and full sync.
-                    List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
-                        txnContext.executeQuery(replicationStatusTable,
-                                entry -> entry.getKey().getSubscriber().getModel()
-                                    .equals(LogReplication.ReplicationModel.LOGICAL_GROUPS) &&
-                                    Objects.equals(entry.getKey().getSubscriber().getClientName(),
-                                        clientListener.getClientName()));
+        // Settings for the subscription retries
+        Consumer<ExponentialBackoffRetry> retrySettings = settings -> {
+            settings.setMaxRetryThreshold(retryThreshold);
+        };
 
-                    CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message> entry = null;
+        ClientFullSyncTask(LogReplicationListener listener, CorfuStore corfuStore, String namespace,
+                           @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest, int bufferSize) {
+            this.listener = listener;
+            this.corfuStore = corfuStore;
+            this.namespace = namespace;
+            this.streamTag = streamTag;
+            this.tablesOfInterest = tablesOfInterest;
+            this.bufferSize = bufferSize;
+        }
 
-                    // It is possible that there is no entry for the Logical Group Model in the status table in
-                    // the following scenarios:
-                    // 1. Request to subscribe is received before the Log Replication JVM or pod starts and
-                    // initializes the table
-                    // 2. Topology change which removes this cluster from the status table.
-                    // We cannot differentiate between the two cases here so continue with the right
-                    // behavior for the 1st case, i.e., subscribe and wait for the initial Snapshot Sync to get
-                    // triggered.  If we are here because of the second case, the listener will not get any updates
-                    // from LR and subscription will be a no-op.
-                    if (entries.isEmpty()) {
-                        log.info("No record for client {} and Logical Group Model found in the Status Table.  " +
-                                "Subscription could have been attempted before LR startup.  Subscribe the listener and" +
-                                "wait for initial Snapshot Sync", clientListener.getClientName());
-                    } else {
-                        // For a given replication model and client, any Sink node will have a single session.
-                        Preconditions.checkState(entries.size() == 1);
-                        entry = entries.get(0);
+        @Override
+        public Void call() {
+            Optional<Counter> mvoTrimCounter = MicroMeterUtils.counter("logreplication.subscribe.trim.count");
+            Optional<Counter> conflictCounter = MicroMeterUtils.counter("logreplication.subscribe.conflict.count");
+
+            Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable =
+                    openReplicationStatusTable(corfuStore);
+
+            try {
+                IRetry.build(ExponentialBackoffRetry.class, RetryExhaustedException.class, () -> {
+
+                    try (TxnContext txnContext = corfuStore.txn(namespace)) {
+                        // The transaction is started in the client's namespace and the Replication Status table resides in the
+                        // system namespace.  Corfu Store does not validate the cross-namespace access as long as there are no
+                        // writes on the table in the different namespace.  This hack is required here as we want client full
+                        // sync to happen in the same transaction which checks the status of a snapshot sync so that there is no
+                        // window between the check and full sync.
+                        List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
+                                txnContext.executeQuery(replicationStatusTable,
+                                        entry -> entry.getKey().getSubscriber().getModel()
+                                                .equals(LogReplication.ReplicationModel.LOGICAL_GROUPS) &&
+                                                Objects.equals(entry.getKey().getSubscriber().getClientName(),
+                                                        listener.getClientName()));
+
+                        CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message> entry = null;
+
+                        // It is possible that there is no entry for the Logical Group Model in the status table in
+                        // the following scenarios:
+                        // 1. Request to subscribe is received before the Log Replication JVM or pod starts and
+                        // initializes the table
+                        // 2. Topology change which removes this cluster from the status table.
+                        // We cannot differentiate between the two cases here so continue with the right
+                        // behavior for the 1st case, i.e., subscribe and wait for the initial Snapshot Sync to get
+                        // triggered.  If we are here because of the second case, the listener will not get any updates
+                        // from LR and subscription will be a no-op.
+                        if (entries.isEmpty()) {
+                            log.warn("No record for client {} and Logical Group Model found in the Status Table.  " +
+                                    "Subscription could have been attempted before LR startup.  Subscribe the listener and" +
+                                    "wait for initial Snapshot Sync", listener.getClientName());
+                        } else {
+                            // For a given replication model and client, any Sink node will have a single session.
+                            Preconditions.checkState(entries.size() == 1);
+                            entry = entries.get(0);
+                        }
+
+                        if (entry == null || entry.getPayload().getSinkStatus().getDataConsistent()) {
+                            // No snapshot sync is in progress
+                            log.info("No Snapshot Sync is in progress.  Request the client to perform a full sync on its " +
+                                    "tables.");
+                            Optional<Timer.Sample> clientFullSyncTimer = MicroMeterUtils.startTimer();
+                            long clientFullSyncStartTime = System.currentTimeMillis();
+                            listener.performFullSyncAndMerge(txnContext);
+                            long clientFullSyncEndTime = System.currentTimeMillis();
+                            MicroMeterUtils.time(clientFullSyncTimer, "logreplication.client.fullsync.duration");
+                            log.info("Client Full Sync and Merge took {} ms",
+                                    clientFullSyncEndTime - clientFullSyncStartTime);
+                            txnContext.commit();
+                        } else {
+                            // Snapshot sync is in progress.  Retry the operation
+                            log.info("Snapshot Sync is in progress.  Retrying the operation");
+                            throw new RetryNeededException();
+                        }
+
+                        // Subscribe from the snapshot timestamp of this transaction, i.e., log tail when the transaction started.
+                        // Subscribing from the commit address will result in missed updates which took place between the start
+                        // and end of the transaction because reads in a transaction observe updates only till the snapshot when it
+                        // started.
+                        long fullSyncTimestamp = txnContext.getTxnSequence();
+                        corfuStore.getRuntime().getTableRegistry().getStreamingManager().subscribeLogReplicationListener(
+                                listener, namespace, streamTag, tablesOfInterest, fullSyncTimestamp, bufferSize);
+
+                        // Update the flags and variables on the listener based on whether snapshot sync was in progress.
+                        // This must be done only after the transaction commits.
+                        setListenerParamsForSnapshotSync(listener, fullSyncTimestamp);
+                        return null;
+                    } catch (TransactionAbortedException tae) {
+                        if (tae.getCause() instanceof TrimmedException) {
+                            // If the snapshot version where this transaction started has been evicted from the JVM's MVO
+                            // cache, a trimmed exception is thrown and requires a retry at a later timestamp.
+                            incrementCount(mvoTrimCounter);
+                            log.warn("Snapshot no longer available in the cache.  Retrying.", tae);
+                        } else if (tae.getAbortCause() == AbortCause.CONFLICT) {
+                            // Concurrent updates to the client's tables
+                            incrementCount(conflictCounter);
+                            log.warn("Concurrent updates to client tables.  Retrying.", tae);
+                        } else {
+                            log.error("Unexpected type of Transaction Aborted Exception", tae);
+                        }
+                        throw new RetryNeededException();
+                    } catch (Exception e) {
+                        log.error("Unexpected exception type hit", e);
+                        throw new RetryNeededException();
                     }
-
-                    boolean snapshotSyncInProgress = false;
-
-                    if (entry == null || entry.getPayload().getSinkStatus().getDataConsistent()) {
-                        // No snapshot sync is in progress
-                        log.info("No Snapshot Sync is in progress.  Request the client to perform a full sync on its " +
-                            "tables.");
-                        Optional<Timer.Sample> clientFullSyncTimer = MicroMeterUtils.startTimer();
-                        long clientFullSyncStartTime = System.currentTimeMillis();
-                        clientListener.performFullSyncAndMerge(txnContext);
-                        long clientFullSyncEndTime = System.currentTimeMillis();
-                        MicroMeterUtils.time(clientFullSyncTimer, "logreplication.client.fullsync.duration");
-                        log.info("Client Full Sync and Merge took {} ms",
-                                clientFullSyncEndTime - clientFullSyncStartTime);
-                    } else {
-                        // Snapshot sync is in progress.  Subscribe without performing a full sync on the tables.
-                        log.info("Snapshot Sync is in progress.  Subscribing without performing a full sync on client" +
-                            " tables.");
-                        snapshotSyncInProgress = true;
-                    }
-                    txnContext.commit();
-
-                    // Subscribe from the snapshot timestamp of this transaction, i.e., log tail when the transaction started.
-                    // Subscribing from the commit address will result in missed updates which took place between the start
-                    // and end of the transaction because reads in a transaction observe updates only till the snapshot when it
-                    // started.
-                    long subscriptionTimestamp = txnContext.getTxnSequence();
-
-                    // Update the flags and variables on the listener based on whether snapshot sync was in progress.
-                    // This must be done only after the transaction commits.
-                    setListenerParamsForSnapshotSync(clientListener, subscriptionTimestamp, snapshotSyncInProgress);
-
-                    return subscriptionTimestamp;
-                } catch (TransactionAbortedException tae) {
-                    if (tae.getCause() instanceof TrimmedException) {
-                        // If the snapshot version where this transaction started has been evicted from the JVM's MVO
-                        // cache, a trimmed exception is thrown and requires a retry at a later timestamp.
-                        incrementCount(mvoTrimCounter);
-                        log.warn("Snapshot no longer available in the cache.  Retrying.", tae);
-                    } else if (tae.getAbortCause() == AbortCause.CONFLICT) {
-                        // Concurrent updates to the client's tables
-                        incrementCount(conflictCounter);
-                        log.warn("Concurrent updates to client tables.  Retrying.", tae);
-                    } else {
-                        log.error("Unexpected type of Transaction Aborted Exception", tae);
-                    }
-                    throw new RetryNeededException();
-                } catch (Exception e) {
-                    log.error("Unexpected exception type hit", e);
-                    throw new RetryNeededException();
-                }
-            }).run();
-        } catch (InterruptedException e) {
-            throw new StreamingException(e, StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
-        } finally {
-            MicroMeterUtils.time(subscribeTimer, "logreplication.subscribe.duration");
+                }).setOptions(retrySettings).run();
+            } catch (InterruptedException e) {
+                throw new StreamingException(e, StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
+                // TODO pankti: Unsubscribe the listener
+            } catch (RetryExhaustedException re) {
+                listener.onError(new SubscribeMaxRetryException());
+            }
+            return null;
         }
     }
 
+    private static CorfuStoreMetadata.Timestamp getTimestamp(CorfuStore corfuStore) {
+        Token token = corfuStore.getRuntime().getSequencerView().query().getToken();
+        return CorfuStoreMetadata.Timestamp.newBuilder()
+                .setEpoch(token.getEpoch())
+                .setSequence(token.getSequence())
+                .build();
+    }
+
+    public static void attemptClientFullSync(LogReplicationListener listener, CorfuStore corfuStore, String namespace,
+                                             @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest,
+                                             int bufferSize, ExecutorService clientExecutorService) {
+        clientExecutorService.submit(new ClientFullSyncTask(listener, corfuStore, namespace,
+                streamTag, tablesOfInterest, bufferSize));
+    }
 
     private static Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(CorfuStore corfuStore) {
         try {
@@ -168,35 +214,12 @@ public final class LogReplicationUtils {
         }
     }
 
-    private static void setListenerParamsForSnapshotSync(LogReplicationListener listener, long subscriptionTimestamp,
-                                                         boolean snapshotSyncInProgress) {
-        updateListenerFlagsForSnapshotSync(listener, snapshotSyncInProgress);
-
-        // If client full sync was done, set its timestamp
-        if (!snapshotSyncInProgress) {
-            listener.getClientFullSyncTimestamp().set(subscriptionTimestamp);
-        }
-    }
-
-    private static void updateListenerFlagsForSnapshotSync(LogReplicationListener clientListener,
-                                                           boolean snapshotSyncInProgress) {
-        clientListener.getClientFullSyncPending().set(snapshotSyncInProgress);
-        clientListener.getSnapshotSyncInProgress().set(snapshotSyncInProgress);
-    }
-
     private static void incrementCount(Optional<Counter> counter) {
         counter.ifPresent(Counter::increment);
     }
 
-    /**
-     * If full sync on client tables was not performed during subscription, attempt to perform it now and complete
-     * the subscription.
-     * @param corfuStore
-     * @param clientListener
-     * @param namespace
-     */
-    public static void attemptClientFullSync(CorfuStore corfuStore, LogReplicationListener clientListener,
-                                             String namespace) {
-        getSubscriptionTimestamp(corfuStore, namespace, clientListener);
+    private static void setListenerParamsForSnapshotSync(LogReplicationListener listener, long fullSyncTimestamp) {
+        listener.getClientFullSyncTimestamp().set(fullSyncTimestamp);
+        listener.getClientFullSyncPending().set(false);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -30,6 +30,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 
 /**
  * CorfuStore is a protobuf API layer that provides all the features of CorfuDB.
@@ -413,10 +414,11 @@ public class CorfuStore {
      * @param streamTag      stream tag of the replicated tables
      */
     public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
-                                                @Nonnull String namespace, @Nonnull String streamTag) {
+                                                @Nonnull String namespace, @Nonnull String streamTag,
+                                                ExecutorService executorService) {
         int uninitializedBufferSize = 0;
         LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
-                uninitializedBufferSize, this);
+                uninitializedBufferSize, this, executorService);
     }
 
     /**
@@ -435,9 +437,10 @@ public class CorfuStore {
      * @param bufferSize       maximum size of buffered transaction entries
      */
     public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
-                                                @Nonnull String namespace, @Nonnull String streamTag, int bufferSize) {
+                                                @Nonnull String namespace, @Nonnull String streamTag,
+                                                int bufferSize, ExecutorService executorService) {
         LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
-                bufferSize, this);
+                bufferSize, this, executorService);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -30,7 +30,6 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
 
 /**
  * CorfuStore is a protobuf API layer that provides all the features of CorfuDB.
@@ -409,16 +408,15 @@ public class CorfuStore {
      * Note: If memory is a consideration, consider using the other version of this API which takes a custom buffer
      * size for updates.
      *
-     * @param streamListener log replication client listener
-     * @param namespace      namespace of the replicated tables
-     * @param streamTag      stream tag of the replicated tables
+     * @param streamListener  log replication client listener
+     * @param namespace       namespace of the replicated tables
+     * @param streamTag       stream tag of the replicated tables
      */
     public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
-                                                @Nonnull String namespace, @Nonnull String streamTag,
-                                                ExecutorService executorService) {
+                                                @Nonnull String namespace, @Nonnull String streamTag) {
         int uninitializedBufferSize = 0;
         LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
-                uninitializedBufferSize, this, executorService);
+                uninitializedBufferSize, this);
     }
 
     /**
@@ -437,10 +435,9 @@ public class CorfuStore {
      * @param bufferSize       maximum size of buffered transaction entries
      */
     public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener,
-                                                @Nonnull String namespace, @Nonnull String streamTag,
-                                                int bufferSize, ExecutorService executorService) {
+                                                @Nonnull String namespace, @Nonnull String streamTag, int bufferSize) {
         LogReplicationUtils.subscribe(streamListener, namespace, streamTag, getTablesOfInterest(namespace, streamTag),
-                bufferSize, this, executorService);
+                bufferSize, this);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/LRStreamingTask.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/LRStreamingTask.java
@@ -7,7 +7,6 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.StreamListener;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableSchema;
-import org.corfudb.runtime.exceptions.StreamingException;
 import org.corfudb.runtime.view.TableRegistry;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -57,27 +56,12 @@ public class LRStreamingTask<K extends Message, V extends Message, M extends Mes
             for (String tableName : nsToTableNamesEntry.getValue()) {
                 UUID streamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(
                         nsToTableNamesEntry.getKey(), tableName));
-                Table<K, V, M> table;
-                try {
-                    table = registry.getTable(nsToTableNamesEntry.getKey(), tableName);
-                } catch (IllegalArgumentException e) {
-                    // The table was not opened using the client's runtime
-                    log.error("Replicated Table {} was not opened using the client runtime.  Please open the table " +
-                            "before subscribing", nsToTableNamesEntry.getKey(), tableName);
-                    throw new StreamingException(String.format("Please open the replicated table [%s:%s] using the " +
-                            "client runtime.", nsToTableNamesEntry.getKey(), tableName),
-                            StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
-                }
-                String streamTag = nsToStreamTag.get(nsToTableNamesEntry.getKey());
-                UUID streamTagId = TableRegistry.getStreamIdForStreamTag(nsToTableNamesEntry.getKey(), streamTag);
-                if (!table.getStreamTags().contains(streamTagId)) {
-                    throw new IllegalArgumentException(String.format("Interested table: %s does not " +
-                        "have specified stream tag: %s", table.getFullyQualifiedTableName(), streamTag));
-                }
+                Table<K, V, M> table = registry.getTable(nsToTableNamesEntry.getKey(), tableName);
                 tableSchemas.put(streamId, new TableSchema<>(tableName, table.getKeyClass(), table.getValueClass(),
                         table.getMetadataClass()));
             }
         }
+
         status.set(StreamStatus.RUNNABLE);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
@@ -180,6 +180,16 @@ public class StreamPollingScheduler {
         }
     }
 
+    /**
+     * Checks if the buffer size of a stream is greater than or equal to the minimum required.
+     *
+     * @param bufferSize bufferSize
+     * @return true if bufferSize is greater than or equal to the poll threshold
+     */
+    public boolean hasEnoughBuffer(int bufferSize) {
+        return bufferSize >= pollThreshold;
+    }
+
     public boolean containsTask(@Nonnull StreamListener streamListener) {
         synchronized (allTasks) {
             return allTasks.containsKey(streamListener);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
@@ -166,6 +166,12 @@ public class StreamPollingScheduler {
                         int bufferSize) {
         Preconditions.checkArgument(bufferSize >= pollThreshold);
         synchronized (allTasks) {
+            if (allTasks.containsKey(streamListener)) {
+                // Multiple subscribers subscribing to same namespace and table is allowed
+                // as long as the hashcode() and equals() method of the listeners are different.
+                throw new StreamingException("StreamingManager::subscribe: listener already registered "
+                        + streamListener, StreamingException.ExceptionCause.LISTENER_SUBSCRIBED);
+            }
             StreamingTask task = new LRStreamingTask(runtime, workers, nsToStreamTags, nsToTables, streamListener,
                     lastAddress, bufferSize);
             allTasks.put(streamListener, task);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamPollingScheduler.java
@@ -166,17 +166,17 @@ public class StreamPollingScheduler {
                         int bufferSize) {
         Preconditions.checkArgument(bufferSize >= pollThreshold);
         synchronized (allTasks) {
-            if (allTasks.containsKey(streamListener)) {
-                // Multiple subscribers subscribing to same namespace and table is allowed
-                // as long as the hashcode() and equals() method of the listeners are different.
-                throw new StreamingException("StreamingManager::subscribe: listener already registered "
-                        + streamListener, StreamingException.ExceptionCause.LISTENER_SUBSCRIBED);
-            }
             StreamingTask task = new LRStreamingTask(runtime, workers, nsToStreamTags, nsToTables, streamListener,
                     lastAddress, bufferSize);
             allTasks.put(streamListener, task);
             log.info("addTask: added {} for {} address {}", streamListener, nsToStreamTags, lastAddress);
             allTasks.notifyAll();
+        }
+    }
+
+    public boolean containsTask(@Nonnull StreamListener streamListener) {
+        synchronized (allTasks) {
+            return allTasks.containsKey(streamListener);
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingManager.java
@@ -96,10 +96,10 @@ public class StreamingManager {
      * 'streamTag' within the application namespace.
      *
      * @param streamListener   client listener for callback
-     * @param namespace       namespace of application tables on which updates should be received
-     * @param streamTag       only updates of application tables with the stream tag will be polled
-     * @param tablesOfInterest only updates from these tables will be returned
+     * @param nsToTableName    map of table namespace to list of tables of interest
+     * @param nsToStreamTags   map of table namespace to the stream tag polled
      * @param lastAddress      last processed address, new notifications start from lastAddress + 1
+     * @param bufferSize       maximum size of buffered transaction entries
      */
     public void subscribeLogReplicationListener(@Nonnull LogReplicationListener streamListener, Map<String, List<String>> nsToTableName,
                                                 Map<String, String> nsToStreamTags, long lastAddress, int bufferSize) {
@@ -143,11 +143,21 @@ public class StreamingManager {
     /**
      * Checks if a listener has already been subscribed.
      *
-     * @param streamListener client listener to validate subscription.
-     * @return true if listener has already been subscribed.
+     * @param streamListener client listener to validate subscription
+     * @return true if listener has already been subscribed
      */
     public boolean isListenerSubscribed(@Nonnull StreamListener streamListener) {
         return this.scheduler.containsTask(streamListener);
+    }
+
+    /**
+     * Validates the buffer size of a stream.
+     *
+     * @param bufferSize bufferSize
+     * @return true if stream has a sufficiently large buffer size
+     */
+    public boolean validateBufferSize(int bufferSize) {
+        return this.scheduler.hasEnoughBuffer(bufferSize == 0 ? defaultBufferSize : bufferSize);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/SubscribeMaxRetryException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/SubscribeMaxRetryException.java
@@ -1,0 +1,7 @@
+package org.corfudb.runtime.exceptions;
+
+public class SubscribeMaxRetryException extends RuntimeException {
+    public SubscribeMaxRetryException() {
+        super("Max number of subscription retries reached.");
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -1,9 +1,7 @@
 package org.corfudb.infrastructure.logreplication;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.integration.LogReplicationListenerIT;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplicationListener;
@@ -14,16 +12,17 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Tests the apis in LogReplicationUtils.
+ * TODO (Shreay): Needs refactoring to properly test behavior of LR listener subscription
+ *
  */
 @Slf4j
 @SuppressWarnings("checkstyle:magicnumber")
@@ -31,58 +30,20 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
 
     private CorfuRuntime corfuRuntime;
     private CorfuStore corfuStore;
-    private LogReplicationListener lrListener;
+    private LogReplicationTestListener lrListener;
     private Table<LogReplication.LogReplicationSession, LogReplication.ReplicationStatus, Message> replicationStatusTable;
     private String namespace = "test_namespace";
     private String client = "test_client";
     private String streamTag = "test_tag";
-    private ExecutorService executorService = null;
+    private CountDownLatch performedFullSync;
 
     @Before
     public void setUp() throws Exception {
         corfuRuntime = getDefaultRuntime();
         corfuStore = new CorfuStore(corfuRuntime);
-        lrListener = new LogReplicationTestListener(corfuStore, namespace, client);
+        performedFullSync = new CountDownLatch(1);
+        lrListener = new LogReplicationTestListener(corfuStore, namespace, client, performedFullSync);
         replicationStatusTable = TestUtils.openReplicationStatusTable(corfuStore);
-        executorService = Executors.newFixedThreadPool(1, new ThreadFactoryBuilder()
-                .setNameFormat(LogReplicationListenerIT.class.getName() + "-worker-%d")
-                .build());
-    }
-
-    /**
-     * Test the behavior of attemptClientFullSync() when LR Snapshot sync is ongoing.  The flags and variables on the
-     * listener must be updated correctly.
-     */
-    @Test
-    public void testAttemptClientFullSyncSnapshotSyncOngoing() {
-        testAttemptClientFullSync(true,true);
-    }
-
-    /**
-     * Test the behavior of attemptClientFullSync() when LR Snapshot sync is complete.  The flags and variables on
-     * the listener must be updated correctly.
-     */
-    @Test
-    public void testAttemptClientFullSyncSnapshotSyncComplete() {
-        testAttemptClientFullSync(true,false);
-    }
-
-    /**
-     * Test the behavior of attemptClientFullSync() when the LR Status table does not have any entry for the Logical
-     * Group Replication Model.  The expected behavior is that no ongoing Snapshot Sync is detected and client full
-     * sync succeeds.
-     */
-    @Test
-    public void testAttemptClientFullSyncStatusNotFound() {
-        testAttemptClientFullSync(false, false);
-    }
-
-    private void testAttemptClientFullSync(boolean initializeTable, boolean ongoing) {
-        if (initializeTable) {
-            TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, client, ongoing);
-        }
-        LogReplicationUtils.attemptClientFullSync(lrListener, corfuStore, namespace, new HashMap<>(), new HashMap<>(), 5, executorService);
-        verifyListenerFlags((LogReplicationTestListener)lrListener, ongoing);
     }
 
     /**
@@ -90,7 +51,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
      * must be updated correctly.
      */
     @Test
-    public void testSubscribeSnapshotSyncOngoing() {
+    public void testSubscribeSnapshotSyncOngoing() throws Exception{
         testSubscribe(true, true);
     }
 
@@ -99,7 +60,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
      * must be updated correctly.
      */
     @Test
-    public void testSubscribeSnapshotSyncComplete() {
+    public void testSubscribeSnapshotSyncComplete() throws Exception{
         testSubscribe(true, false);
     }
 
@@ -109,74 +70,60 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
      * subscription succeeds.
      */
     @Test
-    public void testSubscribeSyncStatusNotFound() {
+    public void testSubscribeSyncStatusNotFound() throws Exception {
         testSubscribe(false, false);
     }
 
-    private void testSubscribe(boolean initializeTable, boolean ongoing) {
+    private void testSubscribe(boolean initializeTable, boolean ongoing) throws Exception{
         if (initializeTable) {
             TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, client, ongoing);
         }
 
-        LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore, executorService);
-        verifyListenerFlags((LogReplicationTestListener)lrListener, ongoing);
-    }
-
-    @Test
-    public void testAttemptClientFullSyncMultipleClients() {
-        testMultipleClients(false);
-    }
-
-    @Test
-    public void testSubscribeMultipleClients() {
-        testMultipleClients(true);
+        LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
+        verifyListenerFlags(lrListener, ongoing);
     }
 
     /**
      * Verify that the client name is matched correctly.
      * 1) Set snapshot sync ongoing to false on the session corresponding to test_client
      * 2) Set snapshot sync ongoing to true on the session corresponding to new_client
-     * 3) Invoke subscribe() or attemptClientFullSync() on test_client's listener
+     * 3) Invoke subscribe() on test_client's listener
      * 4) Verify that full sync finished and snapshot sync was not considered ongoing for test_client
      * 5) Verify that full sync was not attempted and snapshot sync was ongoing for new_client
      */
-    private void testMultipleClients(boolean subscribe) {
+    @Test
+    public void testMultipleClients() throws Exception{
 
         // Snapshot sync is not in progress on test_client
         TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, client, false);
 
         // Create the listener for new_client and set snapshot sync to be in progress
         String newClient = "new_client";
-        LogReplicationListener newListener = new LogReplicationTestListener(corfuStore, namespace, newClient);
+        CountDownLatch newClientFullSyncPerformed = new CountDownLatch(1);
+        LogReplicationTestListener newListener = new LogReplicationTestListener(corfuStore,
+                namespace, newClient, newClientFullSyncPerformed);
         TestUtils.setSnapshotSyncOngoing(corfuStore, replicationStatusTable, newClient, true);
 
-        if (subscribe) {
-            LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore, executorService);
-            LogReplicationUtils.subscribe(newListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore, executorService);
-        } else {
-            LogReplicationUtils.attemptClientFullSync(lrListener, corfuStore, namespace, new HashMap<>(), new HashMap<>(), 5, executorService);
-            LogReplicationUtils.attemptClientFullSync(newListener, corfuStore, namespace, new HashMap<>(), new HashMap<>(), 5, executorService);
-        }
+        LogReplicationUtils.subscribe(lrListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
+        LogReplicationUtils.subscribe(newListener, namespace, streamTag, new ArrayList<>(), 5, corfuStore);
 
         // Verify that full sync finished and snapshot sync was not considered ongoing for test_client
-        verifyListenerFlags((LogReplicationTestListener)lrListener, false);
+        verifyListenerFlags(lrListener, false);
 
         // Verify that full sync was not attempted and snapshot sync was ongoing for new_client
-        verifyListenerFlags((LogReplicationTestListener)newListener, true);
+        verifyListenerFlags(newListener, true);
     }
 
-    private void verifyListenerFlags(LogReplicationTestListener listener, boolean snapshotSyncOngoing) {
-        while (true) {
-            if (snapshotSyncOngoing) {
-                // snapshotSyncInProgress is never set since client full sync will wait indefinitely.
-                if (!listener.performFullSyncInvoked) {
-                    break;
-                }
-            } else {
-                if (!listener.getSnapshotSyncInProgress().get() && listener.performFullSyncInvoked) {
-                    break;
-                }
-            }
+    private void verifyListenerFlags(LogReplicationTestListener listener, boolean snapshotSyncOngoing) throws InterruptedException {
+        if (snapshotSyncOngoing) {
+            // We need to insert delay here to let listener workflow run before validating the latch.
+            Thread.sleep(1000);
+
+            // Validate that performFullSyncAndMerge() was not ran as snapshot sync was ongoing.
+            Assert.assertEquals(1, listener.performedFullSync.getCount());
+        } else {
+            // performFullSyncAndMerge() should have ran.
+            listener.performedFullSync.await();
         }
     }
 
@@ -185,15 +132,15 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         corfuRuntime.shutdown();
     }
 
-    private class LogReplicationTestListener extends LogReplicationListener {
+    private static class LogReplicationTestListener extends LogReplicationListener {
 
-        private boolean performFullSyncInvoked = false;
+        private final CountDownLatch performedFullSync;
+        private final String clientName;
 
-        private String clientName;
-
-        LogReplicationTestListener(CorfuStore corfuStore, String namespace, String clientName) {
+        LogReplicationTestListener(CorfuStore corfuStore, String namespace, String clientName, CountDownLatch performedFullSync) {
             super(corfuStore, namespace);
             this.clientName = clientName;
+            this.performedFullSync = performedFullSync;
         }
 
         @Override
@@ -210,7 +157,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
 
         @Override
         protected void performFullSyncAndMerge(TxnContext txnContext) {
-            performFullSyncInvoked = true;
+            performedFullSync.countDown();
         }
 
         @Override

--- a/test/src/test/java/org/corfudb/integration/LogReplicationListenerIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationListenerIT.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
@@ -60,6 +61,7 @@ public class LogReplicationListenerIT extends AbstractIT {
 
     // Regular(non-LR) listener for the data table
     private TestListener listener;
+    private ExecutorService executorService = null;
 
     Table<SampleSchema.Uuid, SampleSchema.SampleTableAMsg, SampleSchema.Uuid> userDataTable;
     Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable;
@@ -110,10 +112,10 @@ public class LogReplicationListenerIT extends AbstractIT {
 
         final int numUpdates = 10;
         CountDownLatch countDownLatch = new CountDownLatch(numUpdates);
-        lrListener = new LRTestListener(store, namespace, countDownLatch);
+        lrListener = new LRTestListener(store, namespace, countDownLatch, executorService);
 
         // Subscribe the listener
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, executorService);
 
         // End snapshot sync if it had been requested
         if (startInSnapshotSync) {
@@ -174,9 +176,9 @@ public class LogReplicationListenerIT extends AbstractIT {
         // As all updates are written in the same transaction, set this countdown latch to 1
         CountDownLatch numTxLatch = new CountDownLatch(1);
 
-        lrListener = new LRTestListener(store, namespace, countDownLatch);
+        lrListener = new LRTestListener(store, namespace, countDownLatch, executorService);
         lrListener.setNumTxLatch(numTxLatch);
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, executorService);
 
         // End snapshot sync if it had been requested
         if (startInSnapshotSync) {
@@ -227,10 +229,10 @@ public class LogReplicationListenerIT extends AbstractIT {
         final int numUpdates = 50;
 
         CountDownLatch countDownLatch = new CountDownLatch(numUpdates);
-        lrListener = new LRTestListener(store, namespace, countDownLatch);
+        lrListener = new LRTestListener(store, namespace, countDownLatch, executorService);
 
         // Subscribe a listener with a buffer size of 10
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag, bufferSize);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, bufferSize, executorService);
 
         // End snapshot sync if it had been requested
         if (startInSnapshotSync) {
@@ -274,8 +276,8 @@ public class LogReplicationListenerIT extends AbstractIT {
         final int numExpectedStreamingUpdates = numIterations * numWritesToDataTable;
 
         CountDownLatch countDownLatch = new CountDownLatch(numExpectedStreamingUpdates);
-        lrListener = new LRTestListener(store, namespace, countDownLatch);
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+        lrListener = new LRTestListener(store, namespace, countDownLatch, executorService);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, executorService);
 
         log.info("Write data concurrently on both tables");
         writeDataAndToggleDataConsistentConcurrently(numIterations, numWritesToDataTable, testClientName);
@@ -323,10 +325,10 @@ public class LogReplicationListenerIT extends AbstractIT {
         final int newUpdates = 5;
         final int totalUpdates = numUpdates + newUpdates;
         CountDownLatch countDownLatch = new CountDownLatch(totalUpdates);
-        lrListener = new LRTestListener(store, namespace, countDownLatch);
+        lrListener = new LRTestListener(store, namespace, countDownLatch, executorService);
 
         // Subscribe the listener at the obtained timestamp
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, executorService);
 
         // End snapshot sync if it had been requested
         if (startInSnapshotSync) {
@@ -363,8 +365,8 @@ public class LogReplicationListenerIT extends AbstractIT {
         initializeCorfu();
         openAndInitializeTables(testClientName);
 
-        lrListener = new LRTestListener(store, namespace, new CountDownLatch(0));
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+        lrListener = new LRTestListener(store, namespace, new CountDownLatch(0), executorService);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, executorService);
 
         // Write to a redundant table to which the listener has not subscribed
         writeToNonSubscribedSystemTable();
@@ -391,10 +393,10 @@ public class LogReplicationListenerIT extends AbstractIT {
         listener = new TestListener(countDownLatch);
 
         CountDownLatch lrCountDownLatch = new CountDownLatch(numUpdates);
-        lrListener = new LRTestListener(store, namespace, lrCountDownLatch);
+        lrListener = new LRTestListener(store, namespace, lrCountDownLatch, executorService);
 
         store.subscribeListener(listener, namespace, userTag, Arrays.asList(userTableName));
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, executorService);
 
         writeToDataTable(numUpdates, 0);
 
@@ -440,17 +442,17 @@ public class LogReplicationListenerIT extends AbstractIT {
         CountDownLatch countDownLatch = new CountDownLatch(numUpdates);
 
         // Create a listener for test_client
-        lrListener = new LRTestListener(store, namespace, countDownLatch);
+        lrListener = new LRTestListener(store, namespace, countDownLatch, executorService);
 
         // Create a listener for new_client
-        newListener = new LRTestListener(store, namespace, null);
+        newListener = new LRTestListener(store, namespace, null, executorService);
         newListener.setClientName(newClientName);
 
         // Subscribe both the listeners
-        store.subscribeLogReplicationListener(lrListener, namespace, userTag);
+        store.subscribeLogReplicationListener(lrListener, namespace, userTag, executorService);
 
         final String newTag = "new_tag";
-        store.subscribeLogReplicationListener(newListener, namespace, newTag);
+        store.subscribeLogReplicationListener(newListener, namespace, newTag, executorService);
 
         // Write numUpdates records
         writeToDataTable(numUpdates, 0);
@@ -728,8 +730,9 @@ public class LogReplicationListenerIT extends AbstractIT {
         private final List<CorfuStoreEntry<SampleSchema.Uuid, SampleSchema.SampleTableAMsg, SampleSchema.Uuid>>
                 existingEntries = new ArrayList<>();
 
-        LRTestListener(CorfuStore corfuStore, String namespace, CountDownLatch countDownLatch) {
-            super(corfuStore, namespace);
+        LRTestListener(CorfuStore corfuStore, String namespace, CountDownLatch countDownLatch,
+                       ExecutorService executorService) {
+            super(corfuStore, namespace, executorService);
             this.countDownLatch = countDownLatch;
         }
 

--- a/test/src/test/resources/transport/pluginConfig.properties
+++ b/test/src/test/resources/transport/pluginConfig.properties
@@ -24,4 +24,3 @@ snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.1-SNAP
 snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin
 
 saas_endpoint=corfu:9000
-subscribe_retry_threshold_min=2

--- a/test/src/test/resources/transport/pluginConfig.properties
+++ b/test/src/test/resources/transport/pluginConfig.properties
@@ -24,3 +24,4 @@ snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.1-SNAP
 snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin
 
 saas_endpoint=corfu:9000
+subscribe_retry_threshold_min=2


### PR DESCRIPTION
## Overview

Description:

Currently the subscription of an LR Listener involves a prerequisite full sync, this PR moves the full sync operation to a separate thread so the client can continue while the sync completes asynchronously.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
