### PR TITLE
Support Bi-Directional RoutingQueue Replication

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationRoutingQueueConfig.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.UUID;
 
 import static org.corfudb.runtime.LogReplicationUtils.LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_RECV_Q_PREFIX;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
 import static org.corfudb.runtime.LogReplicationUtils.SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
@@ -59,9 +59,9 @@ public class LogReplicationRoutingQueueConfig extends LogReplicationConfig {
         super(session, new HashSet<>(), new HashMap<>(), serverContext);
         this.snapshotSyncStreamTag = SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
         this.logEntrySyncStreamTag = LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + session.getSinkClusterId();
-        this.sinkQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_NAME);
-        this.sinkQueueStreamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
-                REPLICATED_QUEUE_NAME));
+        this.sinkQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+                REPLICATED_RECV_Q_PREFIX+session.getSourceClusterId());
+        this.sinkQueueStreamId = CorfuRuntime.getStreamID(sinkQueueName);
         this.sinkQueueStreamTag = TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_TAG);
         getStreamsToReplicate().add(snapshotSyncStreamTag);
         getDataStreamToTagsMap().put(sinkQueueStreamId, Collections.singletonList(sinkQueueStreamTag));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLrEntryAckMsg;
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_RECV_Q_PREFIX;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -242,7 +242,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      */
     private void insertQInRegistryTable() {
         TableRegistry tableRegistry = runtime.getTableRegistry();
-        String replicatedQName = REPLICATED_QUEUE_NAME;
+        String replicatedQName = REPLICATED_RECV_Q_PREFIX+session.getSourceClusterId();
         if (!tableRegistry.getRegistryTable().containsKey(replicatedQName)) {
             try {
                 TableOptions tableOptions = TableOptions.builder()
@@ -258,7 +258,6 @@ public class LogReplicationSinkManager implements DataReceiver {
                 throw new RuntimeException(e);
             }
         }
-
     }
 
     private ISnapshotSyncPlugin getOnSnapshotSyncPlugin() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
@@ -13,6 +13,7 @@ import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.Queue.RoutingTableEntryMsg;
 import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.view.TableRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,7 +22,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_NAME;
+import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_RECV_Q_PREFIX;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 
 /**
@@ -57,7 +59,9 @@ public class RoutingQueuesLogEntryReader extends BaseLogEntryReader {
             }
         }
         HashMap<UUID, List<SMREntry>> opaqueEntryMap = new HashMap<>();
-        opaqueEntryMap.put(CorfuRuntime.getStreamID(REPLICATED_QUEUE_NAME),
+        String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+                LogReplicationUtils.REPLICATED_RECV_Q_PREFIX +session.getSourceClusterId());
+        opaqueEntryMap.put(CorfuRuntime.getStreamID(replicatedQueueName),
                 filteredMsgs);
         return new OpaqueEntry(opaqueEntry.getVersion(), opaqueEntryMap);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -90,7 +90,7 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
             "-poller-" + session.hashCode()).build());
 
         String replicatedQueueName = TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
-                LogReplicationUtils.REPLICATED_QUEUE_NAME);
+                LogReplicationUtils.REPLICATED_RECV_Q_PREFIX +session.getSourceClusterId());
         replicatedQueueId = CorfuRuntime.getStreamID(replicatedQueueName);
 
         // Open the marker table so that its entries can be deserialized
@@ -180,9 +180,13 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
         }
         msg = read(currentStreamInfo, syncRequestId);
         if (msg != null) {
+            pruneAndTransformMsg(msg);
             messages.add(msg);
         }
         return new SnapshotReadMessage(messages, endMarkerReached);
+    }
+
+    public void pruneAndTransformMsg(LogReplication.LogReplicationEntryMsg lrMsg) {
     }
 
     public void requestClientForSnapshotData(UUID snapshotRequestId) {

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationRoutingQueueListener.java
@@ -75,7 +75,7 @@ public abstract class LogReplicationRoutingQueueListener implements StreamListen
         this.corfuStore = corfuStore;
         this.namespace = namespace;
         this.routingQueue =
-                corfuStore.openQueue(namespace, LogReplicationUtils.REPLICATED_QUEUE_NAME,
+                corfuStore.openQueue(namespace, LogReplicationUtils.REPLICATED_RECV_Q_PREFIX,
                         Queue.RoutingTableEntryMsg.class,
                         TableOptions.builder().schemaOptions(
                                         CorfuOptions.SchemaOptions.newBuilder()

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -60,7 +60,7 @@ public final class LogReplicationUtils {
 
     // Prefix of the name of queue as it will appear on the receiver after replicated.  The suffix will be the Sender
     // (Source) cluster id Receiving queues per client name.
-    public static final String REPLICATED_QUEUE_NAME = "LRQ_Recv";
+    public static final String REPLICATED_RECV_Q_PREFIX = "LRQ_Recv_";
 
     // Stream tag applied to the replicated queue on the receiver
     public static final String REPLICATED_QUEUE_TAG = "lrq_recv";

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -395,7 +395,7 @@ public class CorfuStore {
     public void subscribeRoutingQListener(@Nonnull LiteRoutingQueueListener routingQueueListener) {
         Timestamp ts = routingQueueListener.performFullSync();
         this.subscribeListener(routingQueueListener, CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_TAG,
-                Arrays.asList(LogReplicationUtils.REPLICATED_QUEUE_NAME), ts);
+                Arrays.asList(LogReplicationUtils.REPLICATED_RECV_Q_PREFIX+routingQueueListener.getSourceSiteId()), ts);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationUtilsTest.java
@@ -143,7 +143,7 @@ public class LogReplicationUtilsTest extends AbstractViewTest {
         }
 
         // Open routing queue before the subscribe call at the receiver.
-        String recvQueueName = LogReplicationUtils.REPLICATED_QUEUE_NAME;
+        String recvQueueName = LogReplicationUtils.REPLICATED_RECV_Q_PREFIX;
         Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> routingQueue;
         try {
             routingQueue =


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Supports full bi-directional replication by suffixing the source cluster id to the replicated received stream name.
This allows multiple sources and multiple sinks to co-exist

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
