### PR TITLE
Add payload size based metrics in write path 

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -58,6 +58,10 @@
 *   **stream\_sub.queueDuration.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to wait in the queue.
 *   **corfu\_table.read.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to read from the corfu table's map.
 *   **corfu\_table.write.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to write to the corfu table's map.
+*   **logdata.decompress.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to decompress the payload.
+*   **logdata.compress.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to compress the payload.
+*   **logdata.compression.ratio**: A distribution summary (mean, max, 0.50p, 0.99p) of the payload's compression ratio.
+*   **logdata.decompressed.size**: A size estimate distribution (mean, max, 0.5p, 0.99p) of the decompressed payload.
 
 ### Current metrics collected for Corfu Server:
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -107,7 +107,7 @@ public class LogData implements IMetadata, ILogData {
                             Supplier<ByteBuf> bufSupplier = () -> Unpooled.wrappedBuffer(getPayloadCodecType()
                                     .getInstance().decompress(ByteBuffer.wrap(compressedArrayBuf)));
                             serializedBuf = MicroMeterUtils.time(bufSupplier,
-                                    "logdata.decompress");
+                                    "logdata.decompress.timer");
                         }
 
                         final Object actualValue;
@@ -344,7 +344,7 @@ public class LogData implements IMetadata, ILogData {
     private void doCompressInternal(ByteBuf bufData, ByteBuf buf) {
         ByteBuffer wrappedByteBuf = ByteBuffer.wrap(bufData.array(), 0, bufData.readableBytes());
         Supplier<ByteBuffer> compressSupplier = () -> getPayloadCodecType().getInstance().compress(wrappedByteBuf);
-        ByteBuffer compressedBuf = MicroMeterUtils.time(compressSupplier, "logdata.compress");
+        ByteBuffer compressedBuf = MicroMeterUtils.time(compressSupplier, "logdata.compress.timer");
         CorfuProtocolCommon.serialize(buf, Unpooled.wrappedBuffer(compressedBuf));
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
@@ -160,6 +161,8 @@ public class StreamsView extends AbstractView {
                 payloadSize = ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
             }
 
+            MicroMeterUtils.measure(payloadSize, "logdata.payload.bytes", "clientId",
+                    runtime.getParameters().getClientId().toString());
             for (int retry = 0; retry < runtime.getParameters().getWriteRetry(); retry++) {
                 // Go to the sequencer, grab a token to write.
                 tokenResponse = conflictInfo == null


### PR DESCRIPTION
## Overview

Description:
Add new metrics in write path. These can be used for tuning maxWriteSize value and compactor's memory.
Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
