### PR TITLE
Add LogMetadataRecorder

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.TextFormat;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.infrastructure.BatchWriterOperation.Type;
@@ -57,6 +58,7 @@ public class BatchProcessor implements AutoCloseable {
      * is completed exceptionally with a WrongEpochException.
      * This is persisted in the ServerContext by the LogUnitServer to withstand restarts.
      */
+    @Getter
     private long sealEpoch;
 
     private final BatchProcessorContext context;
@@ -196,6 +198,9 @@ public class BatchProcessor implements AutoCloseable {
                                 break;
                             case RESET:
                                 streamLog.reset();
+                                break;
+                            case DUMP_LOG_METADATA:
+                                streamLog.persistLogMetadata();
                                 break;
                             case TAILS_QUERY:
                                 final TailsResponse tails;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -20,6 +20,7 @@ public class BatchWriterOperation<T> {
         PREFIX_TRIM,
         SEAL,
         RESET,
+        DUMP_LOG_METADATA,
         TAILS_QUERY,
         LOG_ADDRESS_SPACE_QUERY
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -45,7 +45,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -8,6 +8,8 @@ import static org.corfudb.common.util.URLUtils.getVersionFormattedHostAddress;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.google.protobuf.ByteString;
 import io.netty.channel.EventLoopGroup;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -84,6 +86,8 @@ public class ServerContext implements AutoCloseable {
     // LogUnit Server
     private static final String PREFIX_LOGUNIT = "LOGUNIT";
     private static final String EPOCH_WATER_MARK = "EPOCH_WATER_MARK";
+    private static final String PREFIX_LOG_METADATA = "LOGUNIT_METADATA";
+    private static final String KEY_LOG_METADATA = "CURRENT";
 
     // Corfu Replication Server
     public static final String PLUGIN_CONFIG_FILE_PATH = "../resources/corfu_plugin_config.properties";
@@ -111,6 +115,10 @@ public class ServerContext implements AutoCloseable {
 
     private static final KvRecord<Long> LOG_UNIT_WATERMARK_RECORD = KvRecord.of(
             PREFIX_LOGUNIT, EPOCH_WATER_MARK, Long.class
+    );
+
+    private static final KvRecord<Map> LOG_UNIT_METADATA_RECORD = KvRecord.of(
+            PREFIX_LOG_METADATA, KEY_LOG_METADATA, new TypeToken<Map<UUID, String>>(){}.getType()
     );
 
 
@@ -653,6 +661,14 @@ public class ServerContext implements AutoCloseable {
     public synchronized long getLogUnitEpochWaterMark() {
         Long resetEpoch = dataStore.get(LOG_UNIT_WATERMARK_RECORD);
         return resetEpoch == null ? Layout.INVALID_EPOCH : resetEpoch;
+    }
+
+    public synchronized void setLogUnitMetadata(Map<UUID, String> streamAddressSpace) {
+        dataStore.put(LOG_UNIT_METADATA_RECORD, streamAddressSpace);
+    }
+
+    public synchronized Map<UUID, String> getLogUnitMetadata() {
+        return (Map<UUID, String>)dataStore.get(LOG_UNIT_METADATA_RECORD);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -9,7 +9,6 @@ import static org.corfudb.common.util.URLUtils.getVersionFormattedHostAddress;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.reflect.TypeToken;
-import com.google.protobuf.ByteString;
 import io.netty.channel.EventLoopGroup;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
@@ -18,6 +18,7 @@ import org.corfudb.util.JsonUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.CopyOption;
@@ -124,7 +125,7 @@ public class DataStore implements KvDataStore {
                 .build();
     }
 
-    private <T> T load(Class<T> tClass, String key) {
+    private <T> T load(Type type, String key) {
         try {
             Path path = Paths.get(logDirPath, key + EXTENSION);
             if (!Files.isReadable(path)) {
@@ -138,7 +139,7 @@ public class DataStore implements KvDataStore {
             }
 
             String json = new String(bytes, 4, bytes.length - 4);
-            return JsonUtils.parser.fromJson(json, tClass);
+            return JsonUtils.parser.fromJson(json, type);
         } catch (IOException e) {
             throw new DataCorruptionException(e);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/KvDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/KvDataStore.java
@@ -4,6 +4,7 @@ package org.corfudb.infrastructure.datastore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.lang.reflect.Type;
 import java.util.Optional;
 
 /**
@@ -79,7 +80,7 @@ public interface KvDataStore {
         /**
          * The class of the value in a data store
          */
-        private final Class<T> dataType;
+        private final Type dataType;
 
         /**
          * Build kv record
@@ -89,7 +90,7 @@ public interface KvDataStore {
          * @param <R> class type
          * @return kv record
          */
-        public static <R> KvRecord<R> of(String prefix, String key, Class<R> dataType) {
+        public static <R> KvRecord<R> of(String prefix, String key, Type dataType) {
             return new KvRecord<>(prefix, key, dataType);
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -235,4 +235,9 @@ public class InMemoryStreamLog implements StreamLog {
         // Clearing all data from the cache.
         logCache.clear();
     }
+
+    @Override
+    public void persistLogMetadata() {
+        // no-op
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -165,12 +165,16 @@ public class LogMetadata {
     }
 
     public void syncTailSegment(long address) {
+        syncTailSegment(address, false);
+    }
+
+    public void syncTailSegment(long address, boolean force) {
         // TODO(Maithem) since writing a record and setting the tail segment is not
         // an atomic operation, it is possible to set an incorrect tail segment. In
         // that case we will need to scan more than one segment
         updateGlobalTail(address);
         long segment = address / RECORDS_PER_LOG_FILE;
 
-        dataStore.updateTailSegment(segment);
+        dataStore.updateTailSegment(segment, force);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadataRecorder.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadataRecorder.java
@@ -1,0 +1,56 @@
+package org.corfudb.infrastructure.log;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.BatchProcessor;
+import org.corfudb.infrastructure.BatchWriterOperation;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+import org.corfudb.util.LambdaUtils;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class LogMetadataRecorder {
+
+    private final BatchProcessor batchProcessor;
+
+    private final ScheduledExecutorService recorder;
+
+    private static final Duration LOG_METADATA_RECORDER_INTERVAL = Duration.ofSeconds(30);
+
+    public LogMetadataRecorder(BatchProcessor batchProcessor) {
+        this.batchProcessor = batchProcessor;
+        this.recorder = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("LogMetadataRecorder")
+                .build());
+        start();
+    }
+
+    private void start() {
+        recorder.scheduleAtFixedRate(
+            () -> LambdaUtils.runSansThrow(this::triggerDump),
+            LogMetadataRecorder.LOG_METADATA_RECORDER_INTERVAL.toMillis() / 2,
+            LogMetadataRecorder.LOG_METADATA_RECORDER_INTERVAL.toMillis(),
+            TimeUnit.MILLISECONDS
+        );
+    }
+
+    public void shutdown() {
+        recorder.shutdownNow();
+        log.info("LogMetadataRecorder shutting down.");
+    }
+
+    private void triggerDump() {
+        batchProcessor.addTask(BatchWriterOperation.Type.DUMP_LOG_METADATA,
+            CorfuMessage.RequestMsg.newBuilder()
+                .setHeader(CorfuMessage.HeaderMsg.newBuilder()
+                        .setEpoch(batchProcessor.getSealEpoch())
+                        .build()).build());
+    }
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -124,6 +124,8 @@ public interface StreamLog {
      */
     void reset();
 
+    void persistLogMetadata();
+
     /**
      * Get overwrite cause for a given address.
      *

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
@@ -82,7 +82,11 @@ public class StreamLogDataStore {
      * @param newTailSegment updated tail segment
      */
     public void updateTailSegment(long newTailSegment) {
-        if (tailSegment.get() >= newTailSegment) {
+        updateTailSegment(newTailSegment, false);
+    }
+
+    public void updateTailSegment(long newTailSegment, boolean force) {
+        if (!force && tailSegment.get() >= newTailSegment) {
             log.trace("New tail segment {} less than or equals to the old one. Ignore", newTailSegment);
             return;
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -10,13 +10,21 @@ import org.corfudb.infrastructure.ResourceQuota;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.LogUnitException;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.SerializerException;
 import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -25,7 +33,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -151,27 +161,51 @@ public class StreamLogFiles implements StreamLog {
         log.info("initStreamLogDirectory: initialized {}", logDir);
     }
 
+    private void initializeLogMetadata() {
+        initializeLogMetadata(false);
+    }
+
     /**
-     * This method will scan the log (i.e. read all log segment files)
-     * on this LU and create a map of stream offsets and the global
-     * addresses seen.
+     * This method will scan the log (i.e. persisted log metadata and
+     * read all log segment files) on this LU and create a map of stream
+     * offsets and the global addresses seen.
      * <p>
      * consecutive segments from [startSegment, endSegment]
+     *
+     * @param reset if this part of a LU reset
      */
-    private void initializeLogMetadata() {
+
+    private void initializeLogMetadata(boolean reset) {
+        long start = System.currentTimeMillis();
+
         long startingSegment = getStartingSegment();
         long tailSegment = dataStore.getTailSegment();
+        long maxAddress = Address.MAX;
+        if (reset) {
+            // Only initialized LU can be reset, so global tail is available.
+            // In LU reset, the global tail has been rewound back to the committed tail.
+            maxAddress = logMetadata.getGlobalTail();
+        }
+        long highestTailLoaded = loadPersistedLogMetadata(maxAddress);
+        if (highestTailLoaded != Address.NON_ADDRESS) {
+            // Update global tail in case the persisted log metadata covers the entire address space
+            // of the log files, meaning that the following 'file scanning' will be skipped.
+            logMetadata.updateGlobalTail(highestTailLoaded);
 
-        long start = System.currentTimeMillis();
+            long highestSegmentLoaded = getSegmentId(highestTailLoaded);
+            startingSegment = Math.max(highestSegmentLoaded, startingSegment);
+        }
+
         // Scan the log in reverse, this will ease stream trim mark resolution (as we require the
         // END records of a checkpoint which are always the last entry in this stream)
         // Note: if a checkpoint END record is not found (i.e., incomplete) this data is not considered
         // for stream trim mark computation.
+        log.info("Scanning segment {} to {} to build the remaining address space.", startingSegment, tailSegment);
         for (long currentSegment = tailSegment; currentSegment >= startingSegment; currentSegment--) {
-            try (Segment segment = getSegmentHandleForAddress(currentSegment * RECORDS_PER_LOG_FILE + 1)) {
+            try (Segment segment = getSegmentHandleForSegment(currentSegment)) {
                 for (Long address : segment.getAddresses()) {
-                    // skip trimmed entries
-                    if (address < dataStore.getStartingAddress()) {
+                    // skip trimmed entries and loaded addresses
+                    if (address < dataStore.getStartingAddress() || address <= highestTailLoaded) {
                         continue;
                     }
                     LogData logEntry = read(address);
@@ -186,6 +220,81 @@ public class StreamLogFiles implements StreamLog {
         log.info("initializeStreamTails: took {} ms to load {}, log start {}", end - start, logMetadata, getTrimMark());
     }
 
+    /**
+     * Load log metadata (stream address space map and stream tail map) from
+     * persisted log metadata file for fast startup. Only addresses in range
+     * [startingAddress, maxAddress] are considered valid and are loaded.
+     * @param maxAddress load addresses up to this address (inclusive)
+     * @return the highest stream tail loaded
+     */
+    private Long loadPersistedLogMetadata(long maxAddress) {
+        long start = System.currentTimeMillis();
+        Map<UUID, String> streamAddressSpaceMap = sc.getLogUnitMetadata();
+        if (streamAddressSpaceMap == null) {
+            log.info("Unable to load persisted log metadata due to missing file.");
+            return Address.NON_ADDRESS;
+        }
+
+        AtomicLong numOfAddrLoaded = new AtomicLong(0L);
+        streamAddressSpaceMap.forEach((uuid, serializedAddressSpace) -> {
+            StreamAddressSpace streamAddressSpace;
+            byte[] decodedBytes = Base64.getDecoder().decode(serializedAddressSpace);;
+            ByteArrayInputStream bis = new ByteArrayInputStream(decodedBytes);
+            try (DataInputStream data = new DataInputStream(bis)) {
+                streamAddressSpace = StreamAddressSpace.deserialize(data);
+            } catch (IOException ex) {
+                throw new SerializerException("Unexpected error while deserializing StreamAddressSpaceMsg", ex);
+            }
+
+            // maxAddress: for LU reset, logs greater than maxAddress are deleted.
+            // startingAddress: in case trim happened after the last log metadata dump,
+            // skip loading the trimmed addresses in the slightly old log metadata.
+            long endAddress = dataStore.getStartingAddress() - 1; // end is exclusive
+            StreamAddressRange validRange = new StreamAddressRange(uuid, maxAddress, endAddress);
+            StreamAddressSpace validAddressSpace = streamAddressSpace.getAddressesInRange(validRange);
+
+            logMetadata.getStreamsAddressSpaceMap().put(uuid, validAddressSpace);
+            logMetadata.getStreamTails().put(uuid, validAddressSpace.getTail());
+
+            numOfAddrLoaded.addAndGet(validAddressSpace.size());
+        });
+
+        long highestTail = Collections.max(logMetadata.getStreamTails().values());
+        long end = System.currentTimeMillis();
+        log.info("Loaded {} valid addresses from persisted log metadata in {} ms. Highest stream tail loaded is {}",
+                numOfAddrLoaded, end-start, highestTail);
+
+        return highestTail;
+    }
+
+    /**
+     * Persist the current stream address space map on disk.
+     */
+    @Override
+    public void persistLogMetadata() {
+        log.info("Start persisting log metadata.");
+        long start = System.currentTimeMillis();
+
+        Map<UUID, String> streamAddressSpaceMap = new HashMap<>();
+        logMetadata.getStreamsAddressSpaceMap().forEach((uuid, streamAddressSpace) -> {
+            if (streamAddressSpace.size() > 0) {
+                try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                    try (DataOutputStream dos = new DataOutputStream(bos)) {
+                        streamAddressSpace.serialize(dos);
+                        String base64Encoded = Base64.getEncoder().encodeToString(bos.toByteArray());
+                        streamAddressSpaceMap.put(uuid, base64Encoded);
+                    }
+                } catch (IOException ex) {
+                    throw new SerializerException("Unexpected error while serializing StreamAddressSpace", ex);
+                }
+            }
+        });
+        sc.setLogUnitMetadata(streamAddressSpaceMap);
+
+        long end = System.currentTimeMillis();
+        log.info("Persisted log metadata of {} streams in {} ms.}",
+                streamAddressSpaceMap.size(), end-start);
+    }
 
     @Override
     public boolean quotaExceeded() {
@@ -414,6 +523,14 @@ public class StreamLogFiles implements StreamLog {
         return address / RECORDS_PER_LOG_FILE;
     }
 
+    private long getFirstAddressInSegment(long segmentId) {
+        return segmentId * RECORDS_PER_LOG_FILE;
+    }
+
+    private long getLastAddressInSegment(long segmentId) {
+        return getFirstAddressInSegment(segmentId + 1) - 1;
+    }
+
     @Override
     public void append(List<LogData> range) {
 
@@ -618,27 +735,36 @@ public class StreamLogFiles implements StreamLog {
 
         try {
             long committedTail = getCommittedTail();
-            long latestSegment = getSegmentId(getLogTail());
-            long committedTailSegment = getSegmentId(committedTail);
-            for (long currSegmentId = committedTailSegment; currSegmentId <= latestSegment; currSegmentId++) {
-                // Close segments before deleting their corresponding log files
-                String segmentFilePath;
-                try (Segment sh = getSegmentHandleForSegment(currSegmentId)) {
-                    openSegments.remove(sh.id);
-                    segmentFilePath = sh.segmentFilePath;
+            long globalTail = getLogTail();
+            long newTailAddress = StreamLogDataStore.ZERO_ADDRESS;
+
+            if (committedTail < globalTail) {
+                // Delete all segments up to the committed tail's segment
+                long latestSegment = getSegmentId(globalTail);
+                long committedTailSegment = getSegmentId(committedTail);
+
+                for (long currSegmentId = committedTailSegment; currSegmentId <= latestSegment; currSegmentId++) {
+                    // Close segments before deleting their corresponding log files
+                    String segmentFilePath;
+                    try (Segment sh = getSegmentHandleForSegment(currSegmentId)) {
+                        openSegments.remove(sh.id);
+                        segmentFilePath = sh.segmentFilePath;
+                    }
+                    deleteFilesMatchingFilter(file -> file.getAbsolutePath().equals(segmentFilePath));
+                }
+                if (committedTailSegment > 0) {
+                    newTailAddress = getLastAddressInSegment(committedTailSegment - 1);
                 }
 
-                deleteFilesMatchingFilter(file -> file.getAbsolutePath().equals(segmentFilePath));
-            }
-
-            long newTailAddress = StreamLogDataStore.ZERO_ADDRESS;
-            if (committedTailSegment > 0) {
-                newTailAddress = committedTailSegment * RECORDS_PER_LOG_FILE + 1;
+            } else {
+                // Do not need to delete any segment
+                newTailAddress = globalTail;
             }
 
             logMetadata = new LogMetadata(dataStore);
-            logMetadata.syncTailSegment(newTailAddress);
-            initializeLogMetadata();
+            // Set force to true to regress the tail segment if needed
+            logMetadata.syncTailSegment(newTailAddress, true);
+            initializeLogMetadata(true);
             // would this lose the gauges pre-reset?
             removeLocalGauges();
         } finally {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -238,7 +238,7 @@ public class StreamLogFiles implements StreamLog {
         AtomicLong numOfAddrLoaded = new AtomicLong(0L);
         streamAddressSpaceMap.forEach((uuid, serializedAddressSpace) -> {
             StreamAddressSpace streamAddressSpace;
-            byte[] decodedBytes = Base64.getDecoder().decode(serializedAddressSpace);;
+            byte[] decodedBytes = Base64.getDecoder().decode(serializedAddressSpace);
             ByteArrayInputStream bis = new ByteArrayInputStream(decodedBytes);
             try (DataInputStream data = new DataInputStream(bis)) {
                 streamAddressSpace = StreamAddressSpace.deserialize(data);
@@ -259,11 +259,14 @@ public class StreamLogFiles implements StreamLog {
             numOfAddrLoaded.addAndGet(validAddressSpace.size());
         });
 
-        long highestTail = Collections.max(logMetadata.getStreamTails().values());
         long end = System.currentTimeMillis();
+
+        long highestTail = Address.NON_ADDRESS;
+        if (!logMetadata.getStreamTails().isEmpty()) {
+            highestTail = Collections.max(logMetadata.getStreamTails().values());
+        }
         log.info("Loaded {} valid addresses from persisted log metadata in {} ms. Highest stream tail loaded is {}",
                 numOfAddrLoaded, end-start, highestTail);
-
         return highestTail;
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.reflect.TypeToken;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.datastore.DataStore;
 import org.corfudb.infrastructure.datastore.KvDataStore.KvRecord;
@@ -10,6 +11,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -23,6 +26,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class DataStoreTest extends AbstractCorfuTest {
 
     private static final KvRecord<String> TEST_RECORD = KvRecord.of("test", "key", String.class);
+
+    private static final KvRecord<Map> TEST_MAP_RECORD = KvRecord.of("test_map", "key",
+            new TypeToken<HashMap<UUID, String>>(){}.getType());
 
     private DataStore createPersistDataStore(String serviceDir, String numRetention,
                                              Consumer<String> cleanupTask) {
@@ -52,6 +58,25 @@ public class DataStoreTest extends AbstractCorfuTest {
 
         dataStore.put(TEST_RECORD, "NEW_VALUE");
         assertThat(dataStore.get(TEST_RECORD)).isEqualTo("NEW_VALUE");
+    }
+
+    @Test
+    public void testPutGetNestedValue() {
+        final String numRetention = "10";
+        final String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        DataStore dataStore = createPersistDataStore(serviceDir, numRetention, fn -> {});
+        Map<UUID, String> value = new HashMap<>();
+        UUID uuidKey = UUID.randomUUID();
+        value.put(uuidKey, "value1");
+        dataStore.put(TEST_MAP_RECORD, value);
+        assertThat(dataStore.get(TEST_MAP_RECORD)).isEqualTo(value);
+
+        dataStore.delete(TEST_MAP_RECORD);
+        assertThat(dataStore.get(TEST_MAP_RECORD)).isEqualTo(value);
+
+        value.put(uuidKey, "value2");
+        dataStore.put(TEST_MAP_RECORD, value);
+        assertThat(dataStore.get(TEST_MAP_RECORD)).isEqualTo(value);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -767,7 +767,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.updateCommittedTail(RECORDS_PER_LOG_FILE * 2 - 1);
 
         // Perform prefixTrim at 15K and delete the first log segment
-        long trimAddress = (long) (1.5 * RECORDS_PER_LOG_FILE  - 1); // inclusive
+        long trimAddress = (long) (1.5 * RECORDS_PER_LOG_FILE - 1); // inclusive
         log.prefixTrim(trimAddress);
         log.compact();
 

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -30,9 +30,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -399,11 +403,20 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         assertThat(log.getDirtySegments().size()).isEqualTo(0);
     }
 
-    private void writeToLog(StreamLog log, long address) {
+    private void writeToLog(StreamLog log, long address, UUID streamId) {
         ByteBuf b = Unpooled.buffer();
         byte[] streamEntry = "Payload".getBytes();
         Serializers.CORFU.serialize(streamEntry, b);
-        log.append(address, new LogData(DataType.DATA, b));
+        LogData logData = new LogData(DataType.DATA, b);
+        Map<UUID, Long> map = new HashMap<>();
+        map.put(streamId, 0L);
+        logData.setBackpointerMap(map);
+        logData.setGlobalAddress(address);
+        log.append(address, logData);
+    }
+
+    private void writeToLog(StreamLog log, long address) {
+        writeToLog(log, address, UUID.randomUUID());
     }
 
     @Test
@@ -565,14 +578,14 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
             writeToLog(log, x);
         }
         final long filesToBeTrimmed = 1;
-        log.prefixTrim(RECORDS_PER_LOG_FILE * filesToBeTrimmed);
+        log.prefixTrim(RECORDS_PER_LOG_FILE * filesToBeTrimmed - 1);
         log.compact();
 
         File logsDir = new File(logDir);
 
         final int expectedFilesBeforeReset = (int) (numSegments - filesToBeTrimmed);
         final long globalTailBeforeReset = (RECORDS_PER_LOG_FILE * numSegments) - 1;
-        final long trimMarkBeforeReset = RECORDS_PER_LOG_FILE * filesToBeTrimmed + 1;
+        final long trimMarkBeforeReset = RECORDS_PER_LOG_FILE * filesToBeTrimmed;
         assertThat(logsDir.list()).hasSize(expectedFilesBeforeReset);
         assertThat(log.getLogTail()).isEqualTo(globalTailBeforeReset);
         assertThat(log.getTrimMark()).isEqualTo(trimMarkBeforeReset);
@@ -582,14 +595,208 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.reset();
         assertThat(log.getOpenSegments()).hasSize(0);
 
-        final int expectedFilesAfterReset = 2;
+        final int expectedFilesAfterReset = 1;
         assertThat(logsDir.list()).hasSize(expectedFilesAfterReset);
 
-        final long globalTailAfterReset = 20000 + 1;
+        final long globalTailAfterReset = 20000 - 1;
         assertThat(log.getLogTail()).isEqualTo(globalTailAfterReset);
 
         final long trimMarkAfterReset = trimMarkBeforeReset;
         assertThat(log.getTrimMark()).isEqualTo(trimMarkAfterReset);
+    }
+
+    /**
+     * 1. Generate 3 log segment data.
+     * 2. Trim the 1st segment.
+     * 3. Persist log metadata.
+     * 4. Generate 4th log segment.
+     * 5. Reconstruct StreamLogFiles from persisted log metadata.
+     */
+    @Test
+    public void testLogMetadataReconstructionBasic() {
+        ServerContext sc = getContext();
+        StreamLogFiles log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        List<UUID> streamIds = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            streamIds.add(UUID.randomUUID());
+        }
+
+        // Write 30K entries
+        final long numSegments = 3;
+        Map<UUID, List<Long>> addressMap = new HashMap<>();
+        for (int address = 0; address < RECORDS_PER_LOG_FILE * numSegments; address++) {
+            UUID streamId = streamIds.get(address%1000);
+            writeToLog(log, address, streamId);
+            addressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add((long) address);
+        }
+
+        // Perform prefixTrim and delete the first log segment
+        final long filesToBeTrimmed = 1;
+        long trimAddress = RECORDS_PER_LOG_FILE * filesToBeTrimmed - 1; // inclusive
+        log.prefixTrim(trimAddress);
+        log.compact();
+
+        final Map<UUID, List<Long>> trimmedAddressMap = addressMap.entrySet()
+            .stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().stream()
+                    .filter(val -> val > trimAddress)
+                    .collect(Collectors.toList())
+            ));
+
+        log.persistLogMetadata();
+
+        // Write 10K more addresses after the log metadata has been persisted
+        for (int address = (int) (RECORDS_PER_LOG_FILE * numSegments);
+             address < RECORDS_PER_LOG_FILE * (numSegments+1); address++) {
+            UUID streamId = streamIds.get(address%1000);
+            writeToLog(log, address, streamId);
+            trimmedAddressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add((long) address);
+        }
+        log.updateCommittedTail(RECORDS_PER_LOG_FILE * (numSegments+1) - 1);
+        log.close();
+
+        // Reconstruct log
+        log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Check the reconstructed log metadata
+        assertThat(log.getLogTail()).isEqualTo(RECORDS_PER_LOG_FILE * (numSegments+1) - 1);
+        assertThat(log.getCommittedTail()).isEqualTo(RECORDS_PER_LOG_FILE * (numSegments+1) - 1);
+        assertThat(log.getTrimMark()).isEqualTo(trimAddress + 1);
+
+        assertThat(log.getStreamsAddressSpace().getAddressMap()).hasSize(1000);
+        log.getStreamsAddressSpace().getAddressMap().forEach((uuid, streamAddressSpace) -> {
+            assertThat(streamAddressSpace.size()).isEqualTo(30);
+            assertThat(streamAddressSpace.toArray()).containsExactly(trimmedAddressMap.get(uuid).toArray(new Long[0]));
+        });
+    }
+
+    /**
+     * 1. Generate 0.5 segment of data to stream A.
+     * 2. Generate 1.5 segment of data to stream B.
+     * 3. Trim and delete the 1st segment. Now stream A is trimmed.
+     * 4. Reconstruct StreamLogFiles => prePersisting.
+     * 4. Persist log metadata.
+     * 5. Reconstruct StreamLogFiles => postPersisting.
+     * 6. Verify prePersisting and postPersisting.
+     */
+    @Test
+    public void testLogMetadataReconstructionWithEmptyStream() {
+        ServerContext sc = getContext();
+        StreamLogFiles log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        UUID streamA = UUID.randomUUID();
+        UUID streamB = UUID.randomUUID();
+
+        // Write 5K entries to stream id in [0..499]
+        Map<UUID, List<Long>> addressMap = new HashMap<>();
+        for (int address = 0; address < 0.5 * RECORDS_PER_LOG_FILE; address++) {
+            writeToLog(log, address, streamA);
+            addressMap.computeIfAbsent(streamA, k -> new ArrayList<>()).add((long) address);
+        }
+
+        // Write 15K entries to stream id in [500..999]
+        for (int address = (int) (0.5 * RECORDS_PER_LOG_FILE); address < 2 * RECORDS_PER_LOG_FILE; address++) {
+            writeToLog(log, address, streamB);
+            addressMap.computeIfAbsent(streamB, k -> new ArrayList<>()).add((long) address);
+        }
+        log.updateCommittedTail(RECORDS_PER_LOG_FILE * 2 - 1);
+
+        // Trim and delete the first log segment
+        final long filesToBeTrimmed = 1;
+        long trimAddress = RECORDS_PER_LOG_FILE * filesToBeTrimmed - 1; // inclusive
+        log.prefixTrim(trimAddress);
+        log.compact();
+
+        StreamLogFiles prePersisting = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Persist log metadata
+        log.persistLogMetadata();
+
+        // Reconstruct log from the persisted log metadata
+        StreamLogFiles postPersisting = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Check the reconstructed log metadata and verify the stream [0..499] doesn't exist
+        for (StreamLogFiles reconstructed : new StreamLogFiles[]{prePersisting, postPersisting}) {
+            assertThat(reconstructed.getLogTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+            assertThat(reconstructed.getCommittedTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+            assertThat(reconstructed.getTrimMark()).isEqualTo(RECORDS_PER_LOG_FILE * filesToBeTrimmed);
+            assertThat(reconstructed.getStreamsAddressSpace().getAddressMap()).doesNotContainKey(streamA);
+        }
+    }
+
+    /**
+     * 1. Generate 1 segment of data (10K entries).
+     * 2. Persist log metadata.
+     * 3. Generate additional 1 segment of data.
+     * 4. Trim at (15K-1) and delete the first segment.
+     * 5. Reconstruct StreamLogFiles from persisted log metadata.
+     */
+    @Test
+    public void testLogMetadataReconstructionWithHigherTrimMark() {
+        ServerContext sc = getContext();
+        StreamLogFiles log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        List<UUID> streamIds = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            streamIds.add(UUID.randomUUID());
+        }
+
+        // Write 10K entries
+        final long numSegments = 1;
+        Map<UUID, List<Long>> addressMap = new HashMap<>();
+        for (int address = 0; address < RECORDS_PER_LOG_FILE * numSegments; address++) {
+            UUID streamId = streamIds.get(address%1000);
+            writeToLog(log, address, streamId);
+            addressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add((long) address);
+        }
+
+        // Persist log metadata
+        log.persistLogMetadata();
+
+        // Write additional 10K entries
+        long start = RECORDS_PER_LOG_FILE * numSegments;
+        long end = RECORDS_PER_LOG_FILE * numSegments * 2;
+        for (long address = start; address < end; address++) {
+            UUID streamId = streamIds.get((int) (address%1000));
+            writeToLog(log, address, streamId);
+            addressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add(address);
+        }
+        log.updateCommittedTail(RECORDS_PER_LOG_FILE * 2 - 1);
+
+        // Perform prefixTrim at 15K and delete the first log segment
+        long trimAddress = (long) (1.5 * RECORDS_PER_LOG_FILE  - 1); // inclusive
+        log.prefixTrim(trimAddress);
+        log.compact();
+
+        final Map<UUID, List<Long>> trimmedAddressMap = addressMap.entrySet()
+            .stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().stream()
+                    .filter(val -> val > trimAddress)
+                    .collect(Collectors.toList())
+            ));
+
+        // Reconstruct log
+        log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Check the reconstructed log metadata
+        String logDir = sc.getServerConfig().get("--log-path") + File.separator + "log";
+        File logsDir = new File(logDir);
+        assertThat(logsDir.list()).hasSize(1);
+
+        assertThat(log.getLogTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+        assertThat(log.getCommittedTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+        assertThat(log.getTrimMark()).isEqualTo(trimAddress + 1);
+
+        assertThat(log.getStreamsAddressSpace().getAddressMap()).hasSize(1000);
+        log.getStreamsAddressSpace().getAddressMap().forEach((uuid, streamAddressSpace) -> {
+            assertThat(streamAddressSpace.size()).isEqualTo(5);
+            assertThat(streamAddressSpace.toArray()).containsExactly(trimmedAddressMap.get(uuid).toArray(new Long[0]));
+        });
     }
 
     @Test


### PR DESCRIPTION
## Overview
Log Unit Server bootstrap and reset workflows requires log metadata initialization which is based on scanning all log files. This can be a problem as the size of data grows. This PR addresses the slow LU initialization issue by periodically persisting log metadata, and speed up the initialization by reconstructing log metadata from it. Experiments on 16GB Corfu deployment on AWS shows that LU initialization time reduced from ~4 min to 5 seconds.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
