### PR TITLE
Upgrade Kryo to 5.5.0 and Guava to 32.1.2-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <protobuf.version>3.21.7</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>
-        <guava.version>28.0-jre</guava.version>
+        <guava.version>32.1.2-jre</guava.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <mockito.version>4.11.0</mockito.version>
         <bytebuddy.version>1.14.4</bytebuddy.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -15,8 +15,8 @@
         <maven.deploy.skip>false</maven.deploy.skip>
 
         <rocksdb.version>7.9.2</rocksdb.version>
-        <kryo.version>4.0.0</kryo.version>
-        <kryo.serializers.version>0.41</kryo.serializers.version>
+        <kryo.version>5.5.0</kryo.version>
+        <kryo.serializers.version>0.45</kryo.serializers.version>
         <plexus.version>3.0.24</plexus.version>
         <javassist.version>3.21.0-GA</javassist.version>
         <commons.lang3.version>3.11</commons.lang3.version>

--- a/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
@@ -1,6 +1,7 @@
 package org.corfudb.util.serializer;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.util.DefaultInstantiatorStrategy;
 import com.google.common.collect.ImmutableMap;
 import de.javakaffee.kryoserializers.guava.ImmutableListSerializer;
 import de.javakaffee.kryoserializers.guava.ImmutableMapSerializer;
@@ -30,7 +31,7 @@ public interface ISerializer {
         protected Kryo initialValue() {
             Kryo kryo = new Kryo();
             // Use an instantiator that does not require no-args
-            kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(
+            kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy(
                     new StdInstantiatorStrategy()));
             ImmutableListSerializer.registerSerializers(kryo);
             ImmutableSetSerializer.registerSerializers(kryo);


### PR DESCRIPTION
- Upgrade versions to mitigate security vulnerabilities.
- Guava - https://nvd.nist.gov/vuln/detail/CVE-2023-2976
- Kryo - https://osskb.eng.vmware.com/api/v1/vulnerabilities/html?uid=BDSA-2016-1151

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
