### PR TITLE
Add LogMetadataRecorder (#3757)

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.TextFormat;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.infrastructure.BatchWriterOperation.Type;
@@ -57,6 +58,7 @@ public class BatchProcessor implements AutoCloseable {
      * is completed exceptionally with a WrongEpochException.
      * This is persisted in the ServerContext by the LogUnitServer to withstand restarts.
      */
+    @Getter
     private long sealEpoch;
 
     private final BatchProcessorContext context;
@@ -196,6 +198,9 @@ public class BatchProcessor implements AutoCloseable {
                                 break;
                             case RESET:
                                 streamLog.reset();
+                                break;
+                            case DUMP_LOG_METADATA:
+                                streamLog.persistLogMetadata();
                                 break;
                             case TAILS_QUERY:
                                 final TailsResponse tails;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -19,6 +19,7 @@ public class BatchWriterOperation<T> {
         PREFIX_TRIM,
         SEAL,
         RESET,
+        DUMP_LOG_METADATA,
         TAILS_QUERY,
         LOG_ADDRESS_SPACE_QUERY
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -11,6 +11,7 @@ import org.corfudb.infrastructure.health.Component;
 import org.corfudb.infrastructure.health.HealthMonitor;
 import org.corfudb.infrastructure.health.Issue;
 import org.corfudb.infrastructure.log.InMemoryStreamLog;
+import org.corfudb.infrastructure.log.LogMetadataRecorder;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.infrastructure.log.StreamLogCompaction;
 import org.corfudb.infrastructure.log.StreamLogFiles;
@@ -121,6 +122,7 @@ public class LogUnitServer extends AbstractServer {
     private final StreamLogCompaction logCleaner;
     private final BatchProcessor batchProcessor;
     private final ExecutorService executor;
+    private final LogMetadataRecorder metadataRecorder;
 
     /**
      * Returns a new LogUnitServer.
@@ -161,6 +163,7 @@ public class LogUnitServer extends AbstractServer {
         dataCache = serverInitializer.buildLogUnitServerCache(config, streamLog);
         batchProcessor = serverInitializer.buildBatchProcessor(config, streamLog, serverContext, batchProcessorContext);
         logCleaner = serverInitializer.buildStreamLogCompaction(streamLog);
+        metadataRecorder = serverInitializer.buildLogMetadataRecorder(batchProcessor);
     }
 
     @Override
@@ -549,6 +552,7 @@ public class LogUnitServer extends AbstractServer {
         log.info("Shutdown LogUnit server. Current epoch: {}, ", serverContext.getServerEpoch());
         super.shutdown();
         executor.shutdown();
+        metadataRecorder.shutdown();
         logCleaner.shutdown();
         batchProcessor.close();
         streamLog.close();
@@ -636,6 +640,10 @@ public class LogUnitServer extends AbstractServer {
 
         StreamLogCompaction buildStreamLogCompaction(@Nonnull StreamLog streamLog) {
             return new StreamLogCompaction(streamLog, 10, 45, TimeUnit.MINUTES, ServerContext.SHUTDOWN_TIMER);
+        }
+
+        LogMetadataRecorder buildLogMetadataRecorder(@Nonnull BatchProcessor batchProcessor) {
+            return new LogMetadataRecorder(batchProcessor);
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -8,6 +8,7 @@ import static org.corfudb.common.util.URLUtils.getVersionFormattedHostAddress;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.reflect.TypeToken;
 import io.netty.channel.EventLoopGroup;
 import java.io.File;
 import java.nio.file.Files;
@@ -85,6 +86,8 @@ public class ServerContext implements AutoCloseable {
     // LogUnit Server
     private static final String PREFIX_LOGUNIT = "LOGUNIT";
     private static final String EPOCH_WATER_MARK = "EPOCH_WATER_MARK";
+    private static final String PREFIX_LOG_METADATA = "LOGUNIT_METADATA";
+    private static final String KEY_LOG_METADATA = "CURRENT";
 
     // Corfu Replication Server
     public static final String PLUGIN_CONFIG_FILE_PATH = "../resources/corfu_plugin_config.properties";
@@ -113,6 +116,10 @@ public class ServerContext implements AutoCloseable {
 
     private static final KvRecord<Long> LOG_UNIT_WATERMARK_RECORD = KvRecord.of(
             PREFIX_LOGUNIT, EPOCH_WATER_MARK, Long.class
+    );
+
+    private static final KvRecord<Map> LOG_UNIT_METADATA_RECORD = KvRecord.of(
+            PREFIX_LOG_METADATA, KEY_LOG_METADATA, new TypeToken<Map<UUID, String>>(){}.getType()
     );
 
 
@@ -650,6 +657,14 @@ public class ServerContext implements AutoCloseable {
     public synchronized long getLogUnitEpochWaterMark() {
         Long resetEpoch = dataStore.get(LOG_UNIT_WATERMARK_RECORD);
         return resetEpoch == null ? Layout.INVALID_EPOCH : resetEpoch;
+    }
+
+    public synchronized void setLogUnitMetadata(Map<UUID, String> streamAddressSpace) {
+        dataStore.put(LOG_UNIT_METADATA_RECORD, streamAddressSpace);
+    }
+
+    public synchronized Map<UUID, String> getLogUnitMetadata() {
+        return (Map<UUID, String>)dataStore.get(LOG_UNIT_METADATA_RECORD);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
@@ -18,6 +18,7 @@ import org.corfudb.util.JsonUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.CopyOption;
@@ -124,7 +125,7 @@ public class DataStore implements KvDataStore {
                 .build();
     }
 
-    private <T> T load(Class<T> tClass, String key) {
+    private <T> T load(Type type, String key) {
         try {
             Path path = Paths.get(logDirPath, key + EXTENSION);
             if (!Files.isReadable(path)) {
@@ -138,7 +139,7 @@ public class DataStore implements KvDataStore {
             }
 
             String json = new String(bytes, 4, bytes.length - 4);
-            return JsonUtils.parser.fromJson(json, tClass);
+            return JsonUtils.parser.fromJson(json, type);
         } catch (IOException e) {
             throw new DataCorruptionException(e);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/KvDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/KvDataStore.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import org.corfudb.common.result.Result;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 
+import java.lang.reflect.Type;
 import java.util.Optional;
 
 /**
@@ -81,7 +82,7 @@ public interface KvDataStore {
         /**
          * The class of the value in a data store
          */
-        private final Class<T> dataType;
+        private final Type dataType;
 
         /**
          * Build kv record
@@ -91,7 +92,7 @@ public interface KvDataStore {
          * @param <R> class type
          * @return kv record
          */
-        public static <R> KvRecord<R> of(String prefix, String key, Class<R> dataType) {
+        public static <R> KvRecord<R> of(String prefix, String key, Type dataType) {
             return new KvRecord<>(prefix, key, dataType);
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -235,4 +235,9 @@ public class InMemoryStreamLog implements StreamLog {
         // Clearing all data from the cache.
         logCache.clear();
     }
+
+    @Override
+    public void persistLogMetadata() {
+        // no-op
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -165,12 +165,16 @@ public class LogMetadata {
     }
 
     public void syncTailSegment(long address) {
+        syncTailSegment(address, false);
+    }
+
+    public void syncTailSegment(long address, boolean force) {
         // TODO(Maithem) since writing a record and setting the tail segment is not
         // an atomic operation, it is possible to set an incorrect tail segment. In
         // that case we will need to scan more than one segment
         updateGlobalTail(address);
         long segment = address / RECORDS_PER_LOG_FILE;
 
-        dataStore.updateTailSegment(segment);
+        dataStore.updateTailSegment(segment, force);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadataRecorder.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadataRecorder.java
@@ -1,0 +1,56 @@
+package org.corfudb.infrastructure.log;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.BatchProcessor;
+import org.corfudb.infrastructure.BatchWriterOperation;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+import org.corfudb.util.LambdaUtils;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class LogMetadataRecorder {
+
+    private final BatchProcessor batchProcessor;
+
+    private final ScheduledExecutorService recorder;
+
+    private static final Duration LOG_METADATA_RECORDER_INTERVAL = Duration.ofSeconds(30);
+
+    public LogMetadataRecorder(BatchProcessor batchProcessor) {
+        this.batchProcessor = batchProcessor;
+        this.recorder = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("LogMetadataRecorder")
+                .build());
+        start();
+    }
+
+    private void start() {
+        recorder.scheduleAtFixedRate(
+            () -> LambdaUtils.runSansThrow(this::triggerDump),
+            LogMetadataRecorder.LOG_METADATA_RECORDER_INTERVAL.toMillis() / 2,
+            LogMetadataRecorder.LOG_METADATA_RECORDER_INTERVAL.toMillis(),
+            TimeUnit.MILLISECONDS
+        );
+    }
+
+    public void shutdown() {
+        recorder.shutdownNow();
+        log.info("LogMetadataRecorder shutting down.");
+    }
+
+    private void triggerDump() {
+        batchProcessor.addTask(BatchWriterOperation.Type.DUMP_LOG_METADATA,
+            CorfuMessage.RequestMsg.newBuilder()
+                .setHeader(CorfuMessage.HeaderMsg.newBuilder()
+                        .setEpoch(batchProcessor.getSealEpoch())
+                        .build()).build());
+    }
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -124,6 +124,8 @@ public interface StreamLog {
      */
     void reset();
 
+    void persistLogMetadata();
+
     /**
      * Get overwrite cause for a given address.
      *

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
@@ -82,7 +82,11 @@ public class StreamLogDataStore {
      * @param newTailSegment updated tail segment
      */
     public void updateTailSegment(long newTailSegment) {
-        if (tailSegment.get() >= newTailSegment) {
+        updateTailSegment(newTailSegment, false);
+    }
+
+    public void updateTailSegment(long newTailSegment, boolean force) {
+        if (!force && tailSegment.get() >= newTailSegment) {
             log.trace("New tail segment {} less than or equals to the old one. Ignore", newTailSegment);
             return;
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -10,15 +10,22 @@ import org.corfudb.infrastructure.ResourceQuota;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.LogUnitException;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.SerializerException;
 import org.corfudb.runtime.exceptions.TrimmedException;
-import org.corfudb.runtime.view.Layout;
-import org.corfudb.util.JsonUtils;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+>>>>>>> 0c73abc53dc (Add LogMetadataRecorder (#3757))
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -27,7 +34,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -153,27 +162,50 @@ public class StreamLogFiles implements StreamLog {
         log.info("initStreamLogDirectory: initialized {}", logDir);
     }
 
+    private void initializeLogMetadata() {
+        initializeLogMetadata(false);
+    }
+
     /**
-     * This method will scan the log (i.e. read all log segment files)
-     * on this LU and create a map of stream offsets and the global
-     * addresses seen.
+     * This method will scan the log (i.e. persisted log metadata and
+     * read all log segment files) on this LU and create a map of stream
+     * offsets and the global addresses seen.
      * <p>
      * consecutive segments from [startSegment, endSegment]
+     *
+     * @param reset if this part of a LU reset
      */
-    private void initializeLogMetadata() {
+
+    private void initializeLogMetadata(boolean reset) {
+        long start = System.currentTimeMillis();
+
         long startingSegment = getStartingSegment();
         long tailSegment = dataStore.getTailSegment();
 
-        long start = System.currentTimeMillis();
+        long highestTailLoaded = Address.NON_ADDRESS;
+        try {
+            // 1. For reset, load up to the rewound global tail.
+            // 2. For fresh startup, load all metadata.
+            highestTailLoaded = loadPersistedLogMetadata(reset ? getCommittedTail() : Address.MAX);
+        } catch (Exception e) {
+            log.warn("Failed to load persisted log metadata.");
+        }
+
+        if (highestTailLoaded != Address.NON_ADDRESS) {
+            long highestSegmentLoaded = getSegmentId(highestTailLoaded);
+            startingSegment = Math.max(highestSegmentLoaded, startingSegment);
+        }
+
         // Scan the log in reverse, this will ease stream trim mark resolution (as we require the
         // END records of a checkpoint which are always the last entry in this stream)
         // Note: if a checkpoint END record is not found (i.e., incomplete) this data is not considered
         // for stream trim mark computation.
+        log.info("Scanning segment {} to {} to build the remaining address space.", startingSegment, tailSegment);
         for (long currentSegment = tailSegment; currentSegment >= startingSegment; currentSegment--) {
-            try (Segment segment = getSegmentHandleForAddress(currentSegment * RECORDS_PER_LOG_FILE + 1)) {
+            try (Segment segment = getSegmentHandleForSegment(currentSegment)) {
                 for (Long address : segment.getAddresses()) {
-                    // skip trimmed entries
-                    if (address < dataStore.getStartingAddress()) {
+                    // skip trimmed entries and loaded addresses
+                    if (address < dataStore.getStartingAddress() || address <= highestTailLoaded) {
                         continue;
                     }
                     LogData logEntry = read(address);
@@ -188,6 +220,82 @@ public class StreamLogFiles implements StreamLog {
         log.info("initializeStreamTails: took {} ms to load {}, log start {}", end - start, logMetadata, getTrimMark());
     }
 
+    /**
+     * Load log metadata (stream address space map and stream tail map) from
+     * persisted log metadata file for fast startup. Only addresses in range
+     * [startingAddress, maxAddress] are considered valid and are loaded.
+     * @param maxAddress load addresses up to this address (inclusive)
+     * @return the highest stream tail loaded
+     */
+    private Long loadPersistedLogMetadata(long maxAddress) {
+        long start = System.currentTimeMillis();
+        Map<UUID, String> streamAddressSpaceMap = sc.getLogUnitMetadata();
+        if (streamAddressSpaceMap == null) {
+            log.info("Unable to load persisted log metadata due to missing file.");
+            return Address.NON_ADDRESS;
+        }
+
+        streamAddressSpaceMap.forEach((uuid, serializedAddressSpace) -> {
+            StreamAddressSpace streamAddressSpace;
+            byte[] decodedBytes = Base64.getDecoder().decode(serializedAddressSpace);
+            ByteArrayInputStream bis = new ByteArrayInputStream(decodedBytes);
+            try (DataInputStream data = new DataInputStream(bis)) {
+                streamAddressSpace = StreamAddressSpace.deserialize(data);
+            } catch (IOException ex) {
+                throw new SerializerException("Unexpected error while deserializing StreamAddressSpaceMsg", ex);
+            }
+
+            // maxAddress: for LU reset, logs greater than maxAddress are deleted.
+            // startingAddress: in case trim happened after the last log metadata dump,
+            // skip loading the trimmed addresses in the slightly old log metadata.
+            long endAddress = dataStore.getStartingAddress() - 1; // end is exclusive
+            StreamAddressRange validRange = new StreamAddressRange(uuid, maxAddress, endAddress);
+            StreamAddressSpace validAddressSpace = streamAddressSpace.getAddressesInRange(validRange);
+
+            logMetadata.getStreamsAddressSpaceMap().put(uuid, validAddressSpace);
+            logMetadata.getStreamTails().put(uuid, validAddressSpace.getTail());
+        });
+
+        long end = System.currentTimeMillis();
+
+        long highestTail = Address.NON_ADDRESS;
+        if (!logMetadata.getStreamTails().isEmpty()) {
+            highestTail = Collections.max(logMetadata.getStreamTails().values());
+        }
+        logMetadata.updateGlobalTail(highestTail);
+        log.info("Loaded persisted log metadata in {} ms. Valid address is {} - {}. Highest stream tail loaded is {}.",
+                end-start, dataStore.getStartingAddress(), maxAddress, highestTail);
+        return highestTail;
+    }
+
+    /**
+     * Persist the current stream address space map on disk.
+     */
+    @Override
+    public void persistLogMetadata() {
+        log.info("Start persisting log metadata.");
+        long start = System.currentTimeMillis();
+
+        Map<UUID, String> streamAddressSpaceMap = new HashMap<>();
+        logMetadata.getStreamsAddressSpaceMap().forEach((uuid, streamAddressSpace) -> {
+            if (streamAddressSpace.size() > 0) {
+                try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                    try (DataOutputStream dos = new DataOutputStream(bos)) {
+                        streamAddressSpace.serialize(dos);
+                        String base64Encoded = Base64.getEncoder().encodeToString(bos.toByteArray());
+                        streamAddressSpaceMap.put(uuid, base64Encoded);
+                    }
+                } catch (IOException ex) {
+                    throw new SerializerException("Unexpected error while serializing StreamAddressSpace", ex);
+                }
+            }
+        });
+        sc.setLogUnitMetadata(streamAddressSpaceMap);
+
+        long end = System.currentTimeMillis();
+        log.info("Persisted log metadata of {} streams in {} ms.}",
+                streamAddressSpaceMap.size(), end-start);
+    }
 
     @Override
     public boolean quotaExceeded() {
@@ -416,6 +524,14 @@ public class StreamLogFiles implements StreamLog {
         return address / RECORDS_PER_LOG_FILE;
     }
 
+    private long getFirstAddressInSegment(long segmentId) {
+        return segmentId * RECORDS_PER_LOG_FILE;
+    }
+
+    private long getLastAddressInSegment(long segmentId) {
+        return getFirstAddressInSegment(segmentId + 1) - 1;
+    }
+
     @Override
     public void append(List<LogData> range) {
 
@@ -607,8 +723,8 @@ public class StreamLogFiles implements StreamLog {
      * through instantiation not by clearing this class' state
      * <p>
      * Resets the Stream log.
-     * Clears all data and resets the handlers.
-     * Usage: To heal a recovering node, we require to wipe off existing data.
+     * Clears all data after the committed tail segment (inclusive) and resets the handlers.
+     * Usage: To heal a recovering node, we require to wipe off existing uncommitted data.
      */
     @Override
     public void reset() {
@@ -620,27 +736,36 @@ public class StreamLogFiles implements StreamLog {
 
         try {
             long committedTail = getCommittedTail();
-            long latestSegment = getSegmentId(getLogTail());
-            long committedTailSegment = getSegmentId(committedTail);
-            for (long currSegmentId = committedTailSegment; currSegmentId <= latestSegment; currSegmentId++) {
-                // Close segments before deleting their corresponding log files
-                String segmentFilePath;
-                try (Segment sh = getSegmentHandleForSegment(currSegmentId)) {
-                    openSegments.remove(sh.id);
-                    segmentFilePath = sh.segmentFilePath;
+            long globalTail = getLogTail();
+            long newTailAddress = StreamLogDataStore.ZERO_ADDRESS;
+
+            if (committedTail < globalTail) {
+                // Delete all segments from the committed tail (including the committed tail segment)
+                long latestSegment = getSegmentId(globalTail);
+                long committedTailSegment = getSegmentId(committedTail);
+
+                for (long currSegmentId = committedTailSegment; currSegmentId <= latestSegment; currSegmentId++) {
+                    // Close segments before deleting their corresponding log files
+                    String segmentFilePath;
+                    try (Segment sh = getSegmentHandleForSegment(currSegmentId)) {
+                        openSegments.remove(sh.id);
+                        segmentFilePath = sh.segmentFilePath;
+                    }
+                    deleteFilesMatchingFilter(file -> file.getAbsolutePath().equals(segmentFilePath));
+                }
+                if (committedTailSegment > 0) {
+                    newTailAddress = getLastAddressInSegment(committedTailSegment - 1);
                 }
 
-                deleteFilesMatchingFilter(file -> file.getAbsolutePath().equals(segmentFilePath));
-            }
-
-            long newTailAddress = StreamLogDataStore.ZERO_ADDRESS;
-            if (committedTailSegment > 0) {
-                newTailAddress = committedTailSegment * RECORDS_PER_LOG_FILE + 1;
+            } else {
+                // Do not need to delete any segment
+                newTailAddress = globalTail;
             }
 
             logMetadata = new LogMetadata(dataStore);
-            logMetadata.syncTailSegment(newTailAddress);
-            initializeLogMetadata();
+            // Set force to true to regress the tail segment if needed
+            logMetadata.syncTailSegment(newTailAddress, true);
+            initializeLogMetadata(true);
             // would this lose the gauges pre-reset?
             removeLocalGauges();
         } finally {

--- a/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -1,10 +1,14 @@
 package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.reflect.TypeToken;
+
 
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -24,6 +28,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class DataStoreTest extends AbstractCorfuTest {
 
     private static final KvRecord<String> TEST_RECORD = KvRecord.of("test", "key", String.class);
+
+    private static final KvRecord<Map> TEST_MAP_RECORD = KvRecord.of("test_map", "key",
+            new TypeToken<HashMap<UUID, String>>(){}.getType());
 
     private DataStore createPersistDataStore(String serviceDir, String numRetention,
                                              Consumer<String> cleanupTask) {
@@ -53,6 +60,25 @@ public class DataStoreTest extends AbstractCorfuTest {
 
         dataStore.put(TEST_RECORD, "NEW_VALUE");
         assertThat(dataStore.get(TEST_RECORD)).isEqualTo("NEW_VALUE");
+    }
+
+    @Test
+    public void testPutGetNestedValue() {
+        final String numRetention = "10";
+        final String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        DataStore dataStore = createPersistDataStore(serviceDir, numRetention, fn -> {});
+        Map<UUID, String> value = new HashMap<>();
+        UUID uuidKey = UUID.randomUUID();
+        value.put(uuidKey, "value1");
+        dataStore.put(TEST_MAP_RECORD, value);
+        assertThat(dataStore.get(TEST_MAP_RECORD)).isEqualTo(value);
+
+        dataStore.delete(TEST_MAP_RECORD);
+        assertThat(dataStore.get(TEST_MAP_RECORD)).isEqualTo(value);
+
+        value.put(uuidKey, "value2");
+        dataStore.put(TEST_MAP_RECORD, value);
+        assertThat(dataStore.get(TEST_MAP_RECORD)).isEqualTo(value);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -17,9 +17,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
@@ -401,11 +405,20 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         assertThat(log.getDirtySegments().size()).isEqualTo(0);
     }
 
-    private void writeToLog(StreamLog log, long address) {
+    private void writeToLog(StreamLog log, long address, UUID streamId) {
         ByteBuf b = Unpooled.buffer();
         byte[] streamEntry = "Payload".getBytes();
         Serializers.CORFU.serialize(streamEntry, b);
-        log.append(address, new LogData(DataType.DATA, b));
+        LogData logData = new LogData(DataType.DATA, b);
+        Map<UUID, Long> map = new HashMap<>();
+        map.put(streamId, 0L);
+        logData.setBackpointerMap(map);
+        logData.setGlobalAddress(address);
+        log.append(address, logData);
+    }
+
+    private void writeToLog(StreamLog log, long address) {
+        writeToLog(log, address, UUID.randomUUID());
     }
 
     @Test
@@ -567,14 +580,14 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
             writeToLog(log, x);
         }
         final long filesToBeTrimmed = 1;
-        log.prefixTrim(RECORDS_PER_LOG_FILE * filesToBeTrimmed);
+        log.prefixTrim(RECORDS_PER_LOG_FILE * filesToBeTrimmed - 1);
         log.compact();
 
         File logsDir = new File(logDir);
 
         final int expectedFilesBeforeReset = (int) (numSegments - filesToBeTrimmed);
         final long globalTailBeforeReset = (RECORDS_PER_LOG_FILE * numSegments) - 1;
-        final long trimMarkBeforeReset = RECORDS_PER_LOG_FILE * filesToBeTrimmed + 1;
+        final long trimMarkBeforeReset = RECORDS_PER_LOG_FILE * filesToBeTrimmed;
         assertThat(logsDir.list()).hasSize(expectedFilesBeforeReset);
         assertThat(log.getLogTail()).isEqualTo(globalTailBeforeReset);
         assertThat(log.getTrimMark()).isEqualTo(trimMarkBeforeReset);
@@ -584,14 +597,208 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.reset();
         assertThat(log.getOpenSegments()).hasSize(0);
 
-        final int expectedFilesAfterReset = 2;
+        final int expectedFilesAfterReset = 1;
         assertThat(logsDir.list()).hasSize(expectedFilesAfterReset);
 
-        final long globalTailAfterReset = 20000 + 1;
+        final long globalTailAfterReset = 20000 - 1;
         assertThat(log.getLogTail()).isEqualTo(globalTailAfterReset);
 
         final long trimMarkAfterReset = trimMarkBeforeReset;
         assertThat(log.getTrimMark()).isEqualTo(trimMarkAfterReset);
+    }
+
+    /**
+     * 1. Generate 3 log segment data.
+     * 2. Trim the 1st segment.
+     * 3. Persist log metadata.
+     * 4. Generate 4th log segment.
+     * 5. Reconstruct StreamLogFiles from persisted log metadata.
+     */
+    @Test
+    public void testLogMetadataReconstructionBasic() {
+        ServerContext sc = getContext();
+        StreamLogFiles log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        List<UUID> streamIds = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            streamIds.add(UUID.randomUUID());
+        }
+
+        // Write 30K entries
+        final long numSegments = 3;
+        Map<UUID, List<Long>> addressMap = new HashMap<>();
+        for (int address = 0; address < RECORDS_PER_LOG_FILE * numSegments; address++) {
+            UUID streamId = streamIds.get(address%1000);
+            writeToLog(log, address, streamId);
+            addressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add((long) address);
+        }
+
+        // Perform prefixTrim and delete the first log segment
+        final long filesToBeTrimmed = 1;
+        long trimAddress = RECORDS_PER_LOG_FILE * filesToBeTrimmed - 1; // inclusive
+        log.prefixTrim(trimAddress);
+        log.compact();
+
+        final Map<UUID, List<Long>> trimmedAddressMap = addressMap.entrySet()
+            .stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().stream()
+                    .filter(val -> val > trimAddress)
+                    .collect(Collectors.toList())
+            ));
+
+        log.persistLogMetadata();
+
+        // Write 10K more addresses after the log metadata has been persisted
+        for (int address = (int) (RECORDS_PER_LOG_FILE * numSegments);
+             address < RECORDS_PER_LOG_FILE * (numSegments+1); address++) {
+            UUID streamId = streamIds.get(address%1000);
+            writeToLog(log, address, streamId);
+            trimmedAddressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add((long) address);
+        }
+        log.updateCommittedTail(RECORDS_PER_LOG_FILE * (numSegments+1) - 1);
+        log.close();
+
+        // Reconstruct log
+        log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Check the reconstructed log metadata
+        assertThat(log.getLogTail()).isEqualTo(RECORDS_PER_LOG_FILE * (numSegments+1) - 1);
+        assertThat(log.getCommittedTail()).isEqualTo(RECORDS_PER_LOG_FILE * (numSegments+1) - 1);
+        assertThat(log.getTrimMark()).isEqualTo(trimAddress + 1);
+
+        assertThat(log.getStreamsAddressSpace().getAddressMap()).hasSize(1000);
+        log.getStreamsAddressSpace().getAddressMap().forEach((uuid, streamAddressSpace) -> {
+            assertThat(streamAddressSpace.size()).isEqualTo(30);
+            assertThat(streamAddressSpace.toArray()).containsExactly(trimmedAddressMap.get(uuid).toArray(new Long[0]));
+        });
+    }
+
+    /**
+     * 1. Generate 0.5 segment of data to stream A.
+     * 2. Generate 1.5 segment of data to stream B.
+     * 3. Trim and delete the 1st segment. Now stream A is trimmed.
+     * 4. Reconstruct StreamLogFiles => prePersisting.
+     * 4. Persist log metadata.
+     * 5. Reconstruct StreamLogFiles => postPersisting.
+     * 6. Verify prePersisting and postPersisting.
+     */
+    @Test
+    public void testLogMetadataReconstructionWithEmptyStream() {
+        ServerContext sc = getContext();
+        StreamLogFiles log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        UUID streamA = UUID.randomUUID();
+        UUID streamB = UUID.randomUUID();
+
+        // Write 5K entries to stream id in [0..499]
+        Map<UUID, List<Long>> addressMap = new HashMap<>();
+        for (int address = 0; address < 0.5 * RECORDS_PER_LOG_FILE; address++) {
+            writeToLog(log, address, streamA);
+            addressMap.computeIfAbsent(streamA, k -> new ArrayList<>()).add((long) address);
+        }
+
+        // Write 15K entries to stream id in [500..999]
+        for (int address = (int) (0.5 * RECORDS_PER_LOG_FILE); address < 2 * RECORDS_PER_LOG_FILE; address++) {
+            writeToLog(log, address, streamB);
+            addressMap.computeIfAbsent(streamB, k -> new ArrayList<>()).add((long) address);
+        }
+        log.updateCommittedTail(RECORDS_PER_LOG_FILE * 2 - 1);
+
+        // Trim and delete the first log segment
+        final long filesToBeTrimmed = 1;
+        long trimAddress = RECORDS_PER_LOG_FILE * filesToBeTrimmed - 1; // inclusive
+        log.prefixTrim(trimAddress);
+        log.compact();
+
+        StreamLogFiles prePersisting = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Persist log metadata
+        log.persistLogMetadata();
+
+        // Reconstruct log from the persisted log metadata
+        StreamLogFiles postPersisting = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Check the reconstructed log metadata and verify the stream [0..499] doesn't exist
+        for (StreamLogFiles reconstructed : new StreamLogFiles[]{prePersisting, postPersisting}) {
+            assertThat(reconstructed.getLogTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+            assertThat(reconstructed.getCommittedTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+            assertThat(reconstructed.getTrimMark()).isEqualTo(RECORDS_PER_LOG_FILE * filesToBeTrimmed);
+            assertThat(reconstructed.getStreamsAddressSpace().getAddressMap()).doesNotContainKey(streamA);
+        }
+    }
+
+    /**
+     * 1. Generate 1 segment of data (10K entries).
+     * 2. Persist log metadata.
+     * 3. Generate additional 1 segment of data.
+     * 4. Trim at (15K-1) and delete the first segment.
+     * 5. Reconstruct StreamLogFiles from persisted log metadata.
+     */
+    @Test
+    public void testLogMetadataReconstructionWithHigherTrimMark() {
+        ServerContext sc = getContext();
+        StreamLogFiles log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        List<UUID> streamIds = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            streamIds.add(UUID.randomUUID());
+        }
+
+        // Write 10K entries
+        final long numSegments = 1;
+        Map<UUID, List<Long>> addressMap = new HashMap<>();
+        for (int address = 0; address < RECORDS_PER_LOG_FILE * numSegments; address++) {
+            UUID streamId = streamIds.get(address%1000);
+            writeToLog(log, address, streamId);
+            addressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add((long) address);
+        }
+
+        // Persist log metadata
+        log.persistLogMetadata();
+
+        // Write additional 10K entries
+        long start = RECORDS_PER_LOG_FILE * numSegments;
+        long end = RECORDS_PER_LOG_FILE * numSegments * 2;
+        for (long address = start; address < end; address++) {
+            UUID streamId = streamIds.get((int) (address%1000));
+            writeToLog(log, address, streamId);
+            addressMap.computeIfAbsent(streamId, k -> new ArrayList<>()).add(address);
+        }
+        log.updateCommittedTail(RECORDS_PER_LOG_FILE * 2 - 1);
+
+        // Perform prefixTrim at 15K and delete the first log segment
+        long trimAddress = (long) (1.5 * RECORDS_PER_LOG_FILE - 1); // inclusive
+        log.prefixTrim(trimAddress);
+        log.compact();
+
+        final Map<UUID, List<Long>> trimmedAddressMap = addressMap.entrySet()
+            .stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().stream()
+                    .filter(val -> val > trimAddress)
+                    .collect(Collectors.toList())
+            ));
+
+        // Reconstruct log
+        log = new StreamLogFiles(sc, new BatchProcessorContext());
+
+        // Check the reconstructed log metadata
+        String logDir = sc.getServerConfig().get("--log-path") + File.separator + "log";
+        File logsDir = new File(logDir);
+        assertThat(logsDir.list()).hasSize(1);
+
+        assertThat(log.getLogTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+        assertThat(log.getCommittedTail()).isEqualTo(RECORDS_PER_LOG_FILE * 2 - 1);
+        assertThat(log.getTrimMark()).isEqualTo(trimAddress + 1);
+
+        assertThat(log.getStreamsAddressSpace().getAddressMap()).hasSize(1000);
+        log.getStreamsAddressSpace().getAddressMap().forEach((uuid, streamAddressSpace) -> {
+            assertThat(streamAddressSpace.size()).isEqualTo(5);
+            assertThat(streamAddressSpace.toArray()).containsExactly(trimmedAddressMap.get(uuid).toArray(new Long[0]));
+        });
     }
 
     @Test


### PR DESCRIPTION
Log Unit Server bootstrap and reset workflows requires log metadata initialization which is based on scanning all log files. This can be a problem as the size of data grows. This PR addresses the slow LU initialization issue by periodically persisting log metadata, and speed up the initialization by reconstructing log metadata from it. Experiments on 16GB Corfu deployment on AWS shows that the LU initialization time reduced from ~4 min to 5 seconds.


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
