### PR TITLE
Do not ping unresponsive nodes when invalidating layout

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -192,6 +192,9 @@ public class ManagementAgent {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException(ie);
             }
+            catch (RuntimeException re) {
+                log.error("Hit exception when trying immediate recovery", re);
+            }
 
         }
         log.warn("Failed to recover immediately after the restart. The recovery will be completed " +

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -1132,8 +1132,14 @@ public class CorfuRuntime {
             List<String> servers = Optional.ofNullable(latestLayout)
                     .map(Layout::getLayoutServers)
                     .orElse(bootstrapLayoutServers);
-
-            layout = fetchLayout(servers);
+            final List<String> responsiveServer =
+                    servers.stream().filter(server -> !latestLayout.getUnresponsiveServers()
+                            .contains(server))
+                            .collect(Collectors.toList());
+            if (responsiveServer.isEmpty()) {
+                throw new IllegalStateException("All servers are unresponsive");
+            }
+            layout = fetchLayout(responsiveServer);
         }
 
         return layout;


### PR DESCRIPTION
## Overview

Description:

When invalidating the layout, if the shuffle selects an unresponsive server, the client will stall. This could affect the failure detection of sequencer failovers as the FailureDetectorAgents use their runtime to run FD workflows. 

This patch removes the unresponsive node from the fetchLayout. 
