### PR TITLE
Avoid recreating an Opaque Stream every time when polling for data.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -75,6 +75,8 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
     // Boolean indicating if the Snapshot reader is waiting for a start marker from this snapshot sync
     private boolean waitingForStartMarker = true;
 
+    private OpaqueStream opaqueStream = null;
+
     public RoutingQueuesSnapshotReader(LogReplicationSession session,
                                        LogReplicationContext replicationContext) {
         super(session, replicationContext);
@@ -123,7 +125,9 @@ public class RoutingQueuesSnapshotReader extends BaseSnapshotReader {
         String streamOfStreamTag = TableRegistry.getStreamTagFullStreamName(CORFU_SYSTEM_NAMESPACE, streamTagFollowed);
         UUID uuidOfStreamTagFollowed = CorfuRuntime.getStreamID(streamOfStreamTag);
 
-        OpaqueStream opaqueStream = new OpaqueStream(rt.getStreamsView().get(uuidOfStreamTagFollowed));
+        if (opaqueStream == null) {
+            opaqueStream = new OpaqueStream(rt.getStreamsView().get(uuidOfStreamTagFollowed));
+        }
 
         // On first snapshot sync, lastReadTs will be 0. Change it to the latest trim mark
         long trimMark = rt.getAddressSpaceView().getTrimMark().getSequence();


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
