### PR TITLE
Amortize Q's precommit listener to avoid OOMs

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -8,7 +8,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.logprotocol.SMREntry;
-import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.Queue;
@@ -274,28 +273,6 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     }
 
     /**
-     * This is a callback that is placed into the root transaction's context on
-     * the thread local stack which will be invoked right after this transaction
-     * is deemed successful and has obtained a final sequence number to write.
-     */
-    @AllArgsConstructor
-    class QueueEntryAddressGetter implements TransactionalContext.PreCommitListener {
-        private CorfuRecord<V, M> record;
-
-        /**
-         * If we are in a transaction, determine the commit address and fix it up in
-         * the queue entry's metadata.
-         * @param tokenResponse - the sequencer's token response returned.
-         */
-        @Override
-        public void preCommitCallback(TokenResponse tokenResponse) {
-            record.setMetadata((M) Queue.CorfuQueueMetadataMsg.newBuilder()
-                    .setTxSequence(tokenResponse.getSequence()).build());
-            log.trace("preCommitCallback for Queue: " + tokenResponse);
-        }
-    }
-
-    /**
      * Appends the specified element at the end of this unbounded queue.
      * Capacity restrictions and backoffs must be implemented outside this
      * interface. Consider validating the size of the queue against a high
@@ -306,8 +283,6 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
      *                                  element prevents it from being added to this queue
      */
     public K enqueue(V e) {
-
-
         // Obtain a cluster-wide unique 64-bit id to identify this entry in the queue.
         // long entryId = guidGenerator.nextLong();
         long entryId = guidGenerator.nextLong(TransactionalContext.getRootContext().getTxnContext(), this);
@@ -316,13 +291,7 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
 
         // Prepare a partial record with the queue's payload and temporary metadata that will be overwritten
         // by the QueueEntryAddressGetter callback above when the transaction finally commits.
-        CorfuRecord<V, M> queueEntry = new CorfuRecord<>(e,
-                (M) Queue.CorfuQueueMetadataMsg.newBuilder().setTxSequence(0).build());
-
-        QueueEntryAddressGetter addressGetter = new QueueEntryAddressGetter(queueEntry);
-        log.trace("enqueue: Adding preCommitListener for Queue: " + e.toString());
-        TransactionalContext.getRootContext().addPreCommitListener(addressGetter);
-
+        CorfuRecord<V, M> queueEntry = new CorfuRecord<>(e, (M) null);
         corfuTable.insert(keyOfQueueEntry, queueEntry);
         return keyOfQueueEntry;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -105,6 +105,7 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     /**
      * In case this table is opened as a Queue, we need the Guid generator to support enqueue operations.
      */
+    @Getter
     private final CorfuGuidGenerator guidGenerator;
 
     @Getter
@@ -273,6 +274,28 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     }
 
     /**
+     * This is a callback that is placed into the root transaction's context on
+     * the thread local stack which will be invoked right after this transaction
+     * is deemed successful and has obtained a final sequence number to write.
+     */
+    @AllArgsConstructor
+    class QueueEntryAddressGetter implements TransactionalContext.PreCommitListener {
+        private CorfuRecord<V, M> record;
+
+        /**
+         * If we are in a transaction, determine the commit address and fix it up in
+         * the queue entry's metadata.
+         * @param tokenResponse - the sequencer's token response returned.
+         */
+        @Override
+        public void preCommitCallback(TokenResponse tokenResponse) {
+            record.setMetadata((M) Queue.CorfuQueueMetadataMsg.newBuilder()
+                    .setTxSequence(tokenResponse.getSequence()).build());
+            log.trace("preCommitCallback for Queue: " + tokenResponse);
+        }
+    }
+
+    /**
      * Appends the specified element at the end of this unbounded queue.
      * Capacity restrictions and backoffs must be implemented outside this
      * interface. Consider validating the size of the queue against a high
@@ -283,27 +306,7 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
      *                                  element prevents it from being added to this queue
      */
     public K enqueue(V e) {
-        /**
-         * This is a callback that is placed into the root transaction's context on
-         * the thread local stack which will be invoked right after this transaction
-         * is deemed successful and has obtained a final sequence number to write.
-         */
-        @AllArgsConstructor
-        class QueueEntryAddressGetter implements TransactionalContext.PreCommitListener {
-            private CorfuRecord<V, M> record;
 
-            /**
-             * If we are in a transaction, determine the commit address and fix it up in
-             * the queue entry's metadata.
-             * @param tokenResponse - the sequencer's token response returned.
-             */
-            @Override
-            public void preCommitCallback(TokenResponse tokenResponse) {
-                record.setMetadata((M) Queue.CorfuQueueMetadataMsg.newBuilder()
-                        .setTxSequence(tokenResponse.getSequence()).build());
-                log.trace("preCommitCallback for Queue: " + tokenResponse);
-            }
-        }
 
         // Obtain a cluster-wide unique 64-bit id to identify this entry in the queue.
         // long entryId = guidGenerator.nextLong();
@@ -339,23 +342,6 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
          * the thread local stack which will be invoked right after this transaction
          * is deemed successful and has obtained a final sequence number to write.
          */
-        @AllArgsConstructor
-        class QueueEntryAddressGetter implements TransactionalContext.PreCommitListener {
-            private CorfuRecord<V, M> record;
-
-            /**
-             * If we are in a transaction, determine the commit address and fix it up in
-             * the queue entry's metadata.
-             * @param tokenResponse - the sequencer's token response returned.
-             */
-            @Override
-            public void preCommitCallback(TokenResponse tokenResponse) {
-                record.setMetadata((M) Queue.CorfuQueueMetadataMsg.newBuilder()
-                        .setTxSequence(tokenResponse.getSequence()).build());
-                log.trace("preCommitCallback for Queue: " + tokenResponse);
-            }
-        }
-
         // Obtain a cluster-wide unique 64-bit id to identify this entry in the queue.
         long entryId = guidGenerator.nextLong(TransactionalContext.getRootContext().getTxnContext(), this);
         // Embed this key into a protobuf.
@@ -363,12 +349,7 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
 
         // Prepare a partial record with the queue's payload and temporary metadata that will be overwritten
         // by the QueueEntryAddressGetter callback above when the transaction finally commits.
-        CorfuRecord<V, M> queueEntry = new CorfuRecord<>(e,
-                (M) Queue.CorfuQueueMetadataMsg.newBuilder().setTxSequence(0).build());
-
-        QueueEntryAddressGetter addressGetter = new QueueEntryAddressGetter(queueEntry);
-        log.trace("enqueue: Adding preCommitListener for Queue: " + e.toString());
-        TransactionalContext.getRootContext().addPreCommitListener(addressGetter);
+        CorfuRecord<V, M> queueEntry = new CorfuRecord<>(e, (M) null);
 
         Object[] smrArgs = new Object[2];
         smrArgs[0] = keyOfQueueEntry;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.collections;
 import com.google.protobuf.Message;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 
 import javax.annotation.Nonnull;
@@ -12,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Callable;
+import org.corfudb.runtime.Queue;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
@@ -279,6 +280,37 @@ public class TransactionCrud<T extends StoreTransaction<T>>
     public <K extends Message, V extends Message, M extends Message>
     K logUpdateEnqueue(@Nonnull Table<K, V, M> table,
                        @Nonnull final V record, List<UUID> streamTags, CorfuStore corfuStore) {
+        class QueueEntryAddressGetter implements TransactionalContext.PreCommitListener {
+            final int smrIndexOfValue = 1;
+            public QueueEntryAddressGetter() {}
+            /**
+             * If we are in a transaction, determine the commit address and fix it up in
+             * the queue entry's metadata.
+             * @param tokenResponse - the sequencer's token response returned.
+             */
+            @Override
+            public void preCommitCallback(TokenResponse tokenResponse) {
+                tablesUpdated.entrySet().forEach(e -> {
+                    if (e.getValue().getGuidGenerator() == null) {
+                        return; // Transaction has an update to a table which is not a Queue, so ignore.
+                    }
+                    TransactionalContext.getRootContext().getWriteSetInfo().getWriteSet().getSMRUpdates(e.getKey())
+                            .forEach(smrEntry -> {
+                                if (smrEntry.getSMRArguments().length > smrIndexOfValue) {
+                                    CorfuRecord<V, M> queueRecord =
+                                            (CorfuRecord<V, M>) smrEntry.getSMRArguments()[smrIndexOfValue];
+                                    queueRecord.setMetadata((M)
+                                            Queue.CorfuQueueMetadataMsg
+                                                    .newBuilder().setTxSequence(tokenResponse.getSequence())
+                                                    .build());
+                                }
+                            });
+                });
+            }
+        }
+        if (TransactionalContext.getRootContext().getPreCommitListeners().isEmpty()) {
+            TransactionalContext.getCurrentContext().addPreCommitListener(new QueueEntryAddressGetter());
+        }
         K ret = table.logUpdateEnqueue(record, streamTags, corfuStore);
         tablesUpdated.putIfAbsent(table.getStreamUUID(), table);
         return ret;


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
An optimization that can avoid OOMs esp if very large number of entries are inserted into a Queue in a single transaction.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
