### PR TITLE
Add maxUncompressedCpEntrySize check while writing a cpEntry

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.NonNull;
+import lombok.Setter;
 import org.corfudb.infrastructure.health.Component;
 import org.corfudb.infrastructure.health.HealthMonitor;
 import org.corfudb.infrastructure.health.Issue;
@@ -49,7 +50,9 @@ public class CompactorService implements ManagementService {
     private volatile Optional<CorfuRuntime> corfuRuntimeOptional = Optional.empty();
     private volatile ScheduledFuture<?> scheduledFuture;
     private final Logger log;
-    private static final Duration LIVENESS_TIMEOUT = Duration.ofMinutes(1);
+
+    @Setter
+    private Duration LivenessTimeout = Duration.ofMinutes(5);
     private static final int SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT = 60;
 
     public CompactorService(@NonNull ServerContext serverContext,
@@ -149,7 +152,7 @@ public class CompactorService implements ManagementService {
             try {
                 optionalCompactorLeaderServices = Optional.of(new CompactorLeaderServices(getCorfuRuntime(),
                         serverContext.getLocalEndpoint(), getCorfuStore(),
-                        new LivenessValidator(getCorfuRuntime(), getCorfuStore(), LIVENESS_TIMEOUT)));
+                        new LivenessValidator(getCorfuRuntime(), getCorfuStore(), LivenessTimeout)));
             } catch (Exception ex) {
                 log.error("Unable to create CompactorLeaderServices object. Will retry on next attempt. Exception: ", ex);
                 throw ex;

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -301,6 +301,11 @@ public class CorfuRuntime {
         int checkpointBatchSize = 50;
 
         /*
+         * The maximum size of an uncompressed CheckpointEntry.CONTINUATION that can be written
+         */
+        long maxUncompressedCpEntrySize = 100_000_000;
+
+        /*
          * The maximum number of SMR entries that will be grouped in a MultiSMREntry during Restore
          */
         int restoreBatchSize = 50;
@@ -438,6 +443,7 @@ public class CorfuRuntime {
             private int trimRetry = 2;
             private int checkpointRetries = 5;
             private int checkpointBatchSize = 50;
+            private long maxUncompressedCpEntrySize = 100_000_000;
             private int restoreBatchSize = 50;
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 1;
@@ -688,6 +694,11 @@ public class CorfuRuntime {
                 return this;
             }
 
+            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder maxUncompressedCpEntrySize(long maxUncompressedCpEntrySize) {
+                this.maxUncompressedCpEntrySize = maxUncompressedCpEntrySize;
+                return this;
+            }
+
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder restoreBatchSize(int restoreBatchSize) {
                 this.restoreBatchSize = restoreBatchSize;
                 return this;
@@ -803,6 +814,7 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setTrimRetry(trimRetry);
                 corfuRuntimeParameters.setCheckpointRetries(checkpointRetries);
                 corfuRuntimeParameters.setCheckpointBatchSize(checkpointBatchSize);
+                corfuRuntimeParameters.setMaxUncompressedCpEntrySize(maxUncompressedCpEntrySize);
                 corfuRuntimeParameters.setRestoreBatchSize(restoreBatchSize);
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -511,6 +511,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        compactorService0.setLivenessTimeout(Duration.ofMinutes(1));
         doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));


### PR DESCRIPTION
When the checkpointer writes cp continuation entries by batching multiple SMREntries
together, it's not sufficient to just have a check for the compressed size and batch size.
The maxUncompressedCpEntrySize will prevent the compactor jvm to go OOM while batching the entries.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
