### PR TITLE
Connect to all sessions on leadership acquire

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -511,7 +511,9 @@ public class SessionManager {
             return;
         }
 
-        newSessionsDiscovered.stream()
+        // Connect to all the discovered sessions on becoming a leader. Connection for an already connected session is
+        // skipped in the router.
+        sessions.stream()
                 .filter(session -> topology.getRemoteClusterEndpoints().containsKey(session.getSourceClusterId()) ||
                         topology.getRemoteClusterEndpoints().containsKey(session.getSinkClusterId()))
                 .forEach(session -> {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -329,7 +329,7 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
                 topologyConfig.getAllClustersInTopology(), connectionEndPoints, localNodeId);
     }
 
-    private void createSingleSourceMultiSinkTopology() {
+    public void createSingleSourceMultiSinkTopology() {
         topologyConfig = initConfig();
 
         Map<ClusterDescriptor, Set<LogReplication.ReplicationModel>> remoteSourceToReplicationModels = new HashMap<>();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.runtime;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
@@ -170,6 +171,16 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
      */
     private Map<LogReplicationSession, CorfuMessage.ResponseMsg> reverseReplicateInitMsgBuffer;
 
+    /**
+     * Keeps track of sessions connection has been established once the local node became the leader. This is for the
+     * optimization that connection is not retriggered for sessions where there is a quick leadership loass and acquire.
+     *
+     * This data structure does not track any transient failure in connection. That is handled by the state machine's
+     * retry logic.
+     */
+    @Getter
+    private Set<LogReplicationSession> connectedSessions = ConcurrentHashMap.newKeySet();
+
 
 
     /**
@@ -205,6 +216,32 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
         this.reverseReplicateInitMsgBuffer = new ConcurrentHashMap<>();
         createTransportServerAdapter(serverContext, pluginConfig);
         createTransportClientAdapter(pluginConfig);
+    }
+
+    @VisibleForTesting
+    public LogReplicationClientServerRouter(long timeout,
+                                            String localClusterId, String localNodeId,
+                                            Set<LogReplicationSession> incomingSession,
+                                            Set<LogReplicationSession> outgoingSession,
+                                            LogReplicationServer msgHandler,
+                                            IClientChannelAdapter clientChannelAdapter,
+                                            IServerChannelAdapter serverChannelAdapter) {
+        this.timeoutResponse = timeout;
+        this.localClusterId = localClusterId;
+        this.localNodeId = localNodeId;
+        this.incomingSession = incomingSession;
+        this.outgoingSession = outgoingSession;
+        this.msgHandler = msgHandler;
+
+        this.sessionToRemoteClusterDescriptor = new ConcurrentHashMap<>();
+        this.sessionToRequestIdCounter = new ConcurrentHashMap<>();
+        this.sessionToOutstandingRequests = new ConcurrentHashMap<>();
+        this.sessionToLeaderConnectionFuture = new ConcurrentHashMap<>();
+        this.sessionToRemoteSourceLeaderManager = new ConcurrentHashMap<>();
+        this.reverseReplicateInitMsgBuffer = new ConcurrentHashMap<>();
+        this.sessionToRuntimeFSM = new ConcurrentHashMap<>();
+        this.clientChannelAdapter = clientChannelAdapter;
+        this.serverChannelAdapter = serverChannelAdapter;
     }
 
     /**
@@ -621,6 +658,7 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
         sessionToRemoteClusterDescriptor.remove(session);
         sessionToRequestIdCounter.remove(session);
         sessionToLeaderConnectionFuture.remove(session);
+        connectedSessions.remove(session);
     }
 
     public void shutDownMsgHandlerServer() {
@@ -705,6 +743,11 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
      * @param session session information
      */
     public void connect(ClusterDescriptor remoteClusterDescriptor, LogReplicationSession session) {
+        if (connectedSessions.contains(session)) {
+            log.trace("Skipping as connection is already established for session {}", session);
+            return;
+        }
+
         log.info("Connect asynchronously to remote cluster {} and session {} ", remoteClusterDescriptor.getClusterId(),
                 session);
 
@@ -712,6 +755,7 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     this.clientChannelAdapter.connectAsync(remoteClusterDescriptor, session);
+                    connectedSessions.add(session);
                 } catch (Exception e) {
                     log.error("Failed to connect to remote cluster for session {}. Retry after 1 second. Exception {}.",
                             session, e);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/SessionManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/SessionManagerTest.java
@@ -1,6 +1,8 @@
 package org.corfudb.infrastructure.logreplication;
 
 import com.google.common.collect.Sets;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
 import org.corfudb.infrastructure.logreplication.infrastructure.SessionManager;
 import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
@@ -10,6 +12,8 @@ import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultC
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationSinkManager;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientServerRouter;
+import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication;
@@ -18,9 +22,11 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -150,6 +156,54 @@ public class SessionManagerTest extends AbstractViewTest {
 
         //verify router.stop was called with old stale sessions
         Mockito.verify(router, Mockito.times(1)).stop(Sets.difference(sessionsFromTopology1, sessionFromTopology2));
+
+    }
+
+    /**
+     * Test to 'connect' invocation for sessions. A session which has a connection established, should be skipped.
+     * This is simulated by removing a cluster and then adding it back to topology.
+     * @throws Exception
+     */
+    @Test
+    public void testSessionConnection() throws Exception {
+        DefaultClusterManager clusterManager = new DefaultClusterManager();
+        DefaultClusterConfig topologyConfig = new DefaultClusterConfig();
+        clusterManager.setLocalNodeId(topologyConfig.getSourceNodeUuids().get(0));
+        clusterManager.createSingleSourceMultiSinkTopology();
+        topology = clusterManager.topologyConfig;
+
+        IClientChannelAdapter clientChannelAdapter = Mockito.mock(IClientChannelAdapter.class);
+        IServerChannelAdapter serverChannelAdapter = Mockito.mock(IServerChannelAdapter.class);
+        this.router = new LogReplicationClientServerRouter(0L,
+                topology.getLocalNodeDescriptor().getClusterId(), topology.getLocalNodeDescriptor().getNodeId(),
+                new HashSet<>(), new HashSet<>(), msgHandler, clientChannelAdapter, serverChannelAdapter);
+
+        SessionManager sessionManager = new SessionManager(topology, corfuRuntime, replicationManager, router,
+                msgHandler, pluginConfig);
+        sessionManager.refresh(topology);
+        sessionManager.connectToRemoteClusters();
+        Mockito.verify(clientChannelAdapter, Mockito.times(3)).connectAsync(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+        //create a new topology by removing a cluster
+        ClusterDescriptor clusterToRemove = topology.getAllClustersInTopology().get(DefaultClusterConfig.getSinkClusterIds().get(0));
+        Map<ClusterDescriptor, Set<LogReplication.ReplicationModel>> remoteSinkToModel = new HashMap<>(topology.getRemoteSinkClusterToReplicationModels());
+        remoteSinkToModel.remove(clusterToRemove);
+        Map<String, ClusterDescriptor> newAllClusters = new HashMap<>(topology.getAllClustersInTopology());
+        newAllClusters.remove(clusterToRemove.getClusterId());
+        Set<ClusterDescriptor> newRemoteClusterEndpoints = new HashSet<>(topology.getRemoteClusterEndpoints().values());
+        newRemoteClusterEndpoints.remove(clusterToRemove);
+
+        TopologyDescriptor newTopology = new TopologyDescriptor(topology.getTopologyConfigId() + 1, remoteSinkToModel,
+                topology.getRemoteSourceClusterToReplicationModels(), newAllClusters, newRemoteClusterEndpoints,
+                topology.getLocalNodeDescriptor().getNodeId());
+        sessionManager.refresh(newTopology);
+        Assert.assertTrue(router.getConnectedSessions().size() == 2);
+
+        Mockito.clearInvocations(clientChannelAdapter);
+        //simulate adding a cluster back to topology. ConnectAsync should be called for the newly added cluster only.
+        sessionManager.refresh(topology);
+        sessionManager.connectToRemoteClusters();
+        Mockito.verify(clientChannelAdapter, Mockito.times(1)).connectAsync(ArgumentMatchers.any(), ArgumentMatchers.any());
 
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -142,8 +142,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     @Parameterized.Parameters
     public static List<ClusterUuidMsg> input() {
         return Arrays.asList(
-                TP_SINGLE_SOURCE_SINK
-                //TP_SINGLE_SOURCE_SINK_REV_CONNECTION
+                TP_SINGLE_SOURCE_SINK,
+                TP_SINGLE_SOURCE_SINK_REV_CONNECTION
         );
 
     }


### PR DESCRIPTION
## Overview

Description:
Currently, the connection is established to newly discovered sessions only.
But incase of leadership bounce, where the sessions are in memory due to refresh(), connection will not be established to any of the sessions.

This change fixes this issue by trying to connect to all the sessions. the Router module skips the sessions which had been connected already. This is an optimization to avoid creating more channels and objects when not necessary.


Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
