### PR TITLE
Fix data overlow bug in maxMsgSize computation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -281,7 +281,7 @@ public class ServerContext implements AutoCloseable {
      *
      * @return max data message size
      */
-    public int getLogReplicationMaxDataMessageSize() {
+    public long getLogReplicationMaxDataMessageSize() {
         String val = getServerConfig(String.class, "--max-replication-data-message-size");
         return val == null ? DEFAULT_MAX_DATA_MSG_SIZE : Integer.parseInt(val);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
@@ -32,7 +32,7 @@ public abstract class LogReplicationConfig {
 
     // Max message size supported by protocol buffers is 64MB. Log Replication uses this limit as the default message
     // size to batch and send data across over to the other side.
-    public static final int DEFAULT_MAX_DATA_MSG_SIZE = 64 << 20;
+    public static final long DEFAULT_MAX_DATA_MSG_SIZE = 64 << 20;
 
     // Log Replication default max cache number of entries
     // Note: if we want to improve performance for large scale this value should be tuned as it
@@ -61,7 +61,7 @@ public abstract class LogReplicationConfig {
     private int maxNumMsgPerBatch;
 
     // Max Size of Log Replication Data Message
-    private int maxMsgSize;
+    private long maxMsgSize;
 
     // Max Cache number of entries
     private int maxCacheSize;
@@ -69,7 +69,7 @@ public abstract class LogReplicationConfig {
     /**
      * The max size of data payload for the log replication message.
      */
-    private int maxDataSizePerMsg;
+    private long maxDataSizePerMsg;
 
     /**
      * Max number of entries to be applied during a snapshot sync.  For special tables only.


### PR DESCRIPTION
When we compute the 90% of this we were doing
an integer value of 64 MB times 90 which overflows and results in a value of 17MB computed max size.
This limits the amount of data that is batched and has performance ramifications.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
