### PR TITLE
Add maxUncompressedCpEntrySize check while writing a cpEntry

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.NonNull;
+import lombok.Setter;
 import org.corfudb.infrastructure.health.Component;
 import org.corfudb.infrastructure.health.HealthMonitor;
 import org.corfudb.infrastructure.health.Issue;
@@ -49,7 +50,9 @@ public class CompactorService implements ManagementService {
     private volatile Optional<CorfuRuntime> corfuRuntimeOptional = Optional.empty();
     private volatile ScheduledFuture<?> scheduledFuture;
     private final Logger log;
-    private static final Duration LIVENESS_TIMEOUT = Duration.ofMinutes(1);
+
+    @Setter
+    private Duration LivenessTimeout = Duration.ofMinutes(5);
     private static final int SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT = 60;
 
     public CompactorService(@NonNull ServerContext serverContext,
@@ -149,7 +152,7 @@ public class CompactorService implements ManagementService {
             try {
                 optionalCompactorLeaderServices = Optional.of(new CompactorLeaderServices(getCorfuRuntime(),
                         serverContext.getLocalEndpoint(), getCorfuStore(),
-                        new LivenessValidator(getCorfuRuntime(), getCorfuStore(), LIVENESS_TIMEOUT)));
+                        new LivenessValidator(getCorfuRuntime(), getCorfuStore(), LivenessTimeout)));
             } catch (Exception ex) {
                 log.error("Unable to create CompactorLeaderServices object. Will retry on next attempt. Exception: ", ex);
                 throw ex;

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -303,6 +303,11 @@ public class CorfuRuntime {
         int checkpointBatchSize = 50;
 
         /*
+         * The maximum size of an uncompressed CheckpointEntry.CONTINUATION that can be written
+         */
+        long maxUncompressedCpEntrySize = 100_000_000;
+
+        /*
          * The maximum number of SMR entries that will be grouped in a MultiSMREntry during Restore
          */
         int restoreBatchSize = 50;
@@ -441,6 +446,7 @@ public class CorfuRuntime {
             private int trimRetry = 2;
             private int checkpointRetries = 5;
             private int checkpointBatchSize = 50;
+            private long maxUncompressedCpEntrySize = 100_000_000;
             private int restoreBatchSize = 50;
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 1;
@@ -696,6 +702,11 @@ public class CorfuRuntime {
                 return this;
             }
 
+            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder maxUncompressedCpEntrySize(long maxUncompressedCpEntrySize) {
+                this.maxUncompressedCpEntrySize = maxUncompressedCpEntrySize;
+                return this;
+            }
+
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder restoreBatchSize(int restoreBatchSize) {
                 this.restoreBatchSize = restoreBatchSize;
                 return this;
@@ -812,6 +823,7 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setTrimRetry(trimRetry);
                 corfuRuntimeParameters.setCheckpointRetries(checkpointRetries);
                 corfuRuntimeParameters.setCheckpointBatchSize(checkpointBatchSize);
+                corfuRuntimeParameters.setMaxUncompressedCpEntrySize(maxUncompressedCpEntrySize);
                 corfuRuntimeParameters.setRestoreBatchSize(restoreBatchSize);
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -512,6 +512,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         testSetup(logSizeLimitPercentageFull);
 
         CompactorService compactorService0 = spy(new CompactorService(sc0, Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL), mockInvokeJvm0, dynamicTriggerPolicy0));
+        compactorService0.setLivenessTimeout(Duration.ofMinutes(1));
         doReturn(runtime0).when(compactorService0).getNewCorfuRuntime();
         when(dynamicTriggerPolicy0.shouldTrigger(anyLong(), any(), any())).thenReturn(true).thenReturn(false);
         compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.corfudb.CorfuTestParameters;
+import org.apache.commons.lang.StringUtils;
 import org.corfudb.common.compression.Codec;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
@@ -815,6 +816,161 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         final long cont3Recordffset = startAddress + 3;
         cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(cont3Recordffset).getPayload(r);
         assertThat(((CheckpointEntry) cpEntry).getSmrEntries().getUpdates().size()).isEqualTo(23);
+    }
+
+    /**
+     * Test checkpoint of a large transaction
+     * <p>
+     * CheckpointWriter should be able to write CheckpointEntries even if the size
+     * of a single transaction is larger than the compressed and uncompressed size limits.
+     */
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void checkpointLargeTransactionTest() {
+        final String streamName = "mystream8";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final int numKeys = 2;
+
+        PersistentCorfuTable<String, String> m = instantiateStringTable(streamName);
+
+        //8 MB of data
+        String repeatedCharString = StringUtils.repeat("a", (1 << 23));
+
+        for (int i = 0; i < numKeys; i++) {
+            String key = String.valueOf(i);
+            String payload = repeatedCharString;
+            m.insert(key, payload);
+        }
+
+        getRuntime().getParameters().setCodecType(Codec.Type.ZSTD);
+        getRuntime().getParameters().setMaxUncompressedCpEntrySize(2_000_000);
+        CheckpointWriter<PersistentCorfuTable<String, String>> cpw = new CheckpointWriter<>(getRuntime(), streamId, "author", m);
+        cpw.setSerializer(serializer);
+
+        // Write all CP data.
+        r.getObjectsView().TXBuild()
+                .type(TransactionType.SNAPSHOT)
+                .build()
+                .begin();
+        Token snapshot = TransactionalContext
+                .getCurrentContext()
+                .getSnapshotTimestamp();
+        try {
+            cpw.startCheckpoint(snapshot);
+            cpw.appendObjectState(m.entryStream());
+            cpw.finishCheckpoint();
+        } finally {
+            r.getObjectsView().TXEnd();
+        }
+
+        setRuntime();
+        r.getSerializers().registerSerializer(serializer);
+        long startAddress = snapshot.getSequence() + 1;
+        assertThat(r.getAddressSpaceView().read(startAddress).getCheckpointType())
+                .isEqualTo(CheckpointEntry.CheckpointEntryType.START);
+
+        final long contRecordffset = startAddress + 1;
+        ILogData logData = r.getAddressSpaceView().read(contRecordffset);
+        CheckpointEntry cpEntry = (CheckpointEntry) logData.getPayload(r);
+        long logDataSize = logData.getSizeEstimate();
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(0);
+
+        final long cont2Recordffset = startAddress + 2;
+        logData = r.getAddressSpaceView().read(cont2Recordffset);
+        cpEntry = (CheckpointEntry) logData.getPayload(r);
+        logDataSize = logData.getSizeEstimate();
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
+
+        final long cont3Recordffset = startAddress + 3;
+        logData = r.getAddressSpaceView().read(cont3Recordffset);
+        cpEntry = (CheckpointEntry) logData.getPayload(r);
+        logDataSize = logData.getSizeEstimate();
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
+    }
+
+    /**
+     * Test the CheckpointWriter's uncompressed size check
+     * <p>
+     * CheckpointWriter aggregates a batch of SMREntries into one CheckpointEntry.
+     * This test verifies that it batches only SMR entries that are lesser
+     * in size when aggregated than the maxUncompressedSize limit, even if the
+     * compressedSize limit is not reached
+     *
+     */
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void checkpointUnompressedSizeTest() {
+        final String streamName = "mystream8";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final int numKeys = 5;
+
+        PersistentCorfuTable<String, String> m = instantiateStringTable(streamName);
+
+        //8 MB of data
+        String repeatedCharString = StringUtils.repeat("a", (1 << 23));
+
+        for (int i = 0; i < numKeys; i++) {
+            String key = String.valueOf(i);
+            String payload = repeatedCharString;
+            m.insert(key, payload);
+        }
+
+        getRuntime().getParameters().setCodecType(Codec.Type.ZSTD);
+        getRuntime().getParameters().setMaxUncompressedCpEntrySize(25_000_000);
+        CheckpointWriter<PersistentCorfuTable<String, String>> cpw = new CheckpointWriter<>(getRuntime(), streamId, "author", m);
+        cpw.setSerializer(serializer);
+
+        // Write all CP data.
+        r.getObjectsView().TXBuild()
+                .type(TransactionType.SNAPSHOT)
+                .build()
+                .begin();
+        Token snapshot = TransactionalContext
+                .getCurrentContext()
+                .getSnapshotTimestamp();
+        try {
+            cpw.startCheckpoint(snapshot);
+            cpw.appendObjectState(m.entryStream());
+            cpw.finishCheckpoint();
+        } finally {
+            r.getObjectsView().TXEnd();
+        }
+
+        setRuntime();
+        r.getSerializers().registerSerializer(serializer);
+        long startAddress = snapshot.getSequence() + 1;
+        assertThat(r.getAddressSpaceView().read(startAddress).getCheckpointType())
+                .isEqualTo(CheckpointEntry.CheckpointEntryType.START);
+
+        final long contRecordffset = startAddress + 1;
+        ILogData logData = r.getAddressSpaceView().read(contRecordffset);
+        CheckpointEntry cpEntry = (CheckpointEntry) logData.getPayload(r);
+        long logDataSize = logData.getSizeEstimate();
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(2);
+
+        final long cont2Recordffset = startAddress + 2;
+        logData = r.getAddressSpaceView().read(cont2Recordffset);
+        cpEntry = (CheckpointEntry) logData.getPayload(r);
+        logDataSize = logData.getSizeEstimate();
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(2);
+
+        final long cont3Recordffset = startAddress + 3;
+        logData = r.getAddressSpaceView().read(cont3Recordffset);
+        cpEntry = (CheckpointEntry) logData.getPayload(r);
+        logDataSize = logData.getSizeEstimate();
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
+        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
     }
 
     private Token checkpointUfoSystemTables(CorfuRuntime runtime, ISerializer serializer) {


### PR DESCRIPTION
When the checkpointer writes cp continuation entries by batching multiple SMREntries together, it's not sufficient to just have a check for the compressed size and batch size. The maxUncompressedCpEntrySize will prevent the compactor jvm to go OOM while batching the entries.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
