### PR TITLE
make max-replication-data-message-size configurable.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
@@ -32,16 +32,13 @@ public abstract class LogReplicationConfig {
 
     // Max message size supported by protocol buffers is 64MB. Log Replication uses this limit as the default message
     // size to batch and send data across over to the other side.
-    public static final long DEFAULT_MAX_DATA_MSG_SIZE = 64 << 20;
+    public static final long DEFAULT_MAX_DATA_MSG_SIZE = 31457280;
 
     // Log Replication default max cache number of entries
     // Note: if we want to improve performance for large scale this value should be tuned as it
     // used in snapshot sync to quickly access shadow stream entries, written locally.
     // This value is exposed as a configuration parameter for LR.
     public static final int DEFAULT_MAX_CACHE_NUM_ENTRIES = 200;
-
-    // Percentage of log data per log replication message
-    public static final int DATA_FRACTION_PER_MSG = 90;
 
     public static final UUID REGISTRY_TABLE_ID = CorfuRuntime.getStreamID(
         TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, TableRegistry.REGISTRY_TABLE_NAME));
@@ -60,16 +57,13 @@ public abstract class LogReplicationConfig {
     // Snapshot Sync Batch Size(number of messages)
     private int maxNumMsgPerBatch;
 
-    // Max Size of Log Replication Data Message
-    private long maxMsgSize;
-
     // Max Cache number of entries
     private int maxCacheSize;
 
     /**
-     * The max size of data payload for the log replication message.
+     * Max Size of Log Replication Data Message
      */
-    private long maxDataSizePerMsg;
+    private long maxMsgSize;
 
     /**
      * Max number of entries to be applied during a snapshot sync.  For special tables only.
@@ -103,6 +97,5 @@ public abstract class LogReplicationConfig {
             this.maxCacheSize = serverContext.getLogReplicationCacheMaxSize();
             this.maxSnapshotEntriesApplied = serverContext.getMaxSnapshotEntriesApplied();
         }
-        this.maxDataSizePerMsg = maxMsgSize * DATA_FRACTION_PER_MSG / 100;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
@@ -75,7 +75,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
     public BaseLogEntryReader(LogReplication.LogReplicationSession replicationSession,
                               LogReplicationContext replicationContext) {
         CorfuRuntime runtime = replicationContext.getCorfuRuntime();
-        this.maxDataSizePerMsg = replicationContext.getConfig(replicationSession).getMaxDataSizePerMsg();
+        this.maxDataSizePerMsg = replicationContext.getConfig(replicationSession).getMaxMsgSize();
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         this.deltaCounter = configureDeltaCounter();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -69,7 +69,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
         this.rt = replicationContext.getCorfuRuntime();
         this.session = session;
         this.replicationContext = replicationContext;
-        this.maxDataSizePerMsg = replicationContext.getConfig(session).getMaxDataSizePerMsg();
+        this.maxDataSizePerMsg = replicationContext.getConfig(session).getMaxMsgSize();
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         refreshStreamsToReplicateSet();
         log.info("Total of {} streams to replicate at initialization. Streams to replicate={}, Session={}",

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -740,9 +740,7 @@ public class AbstractIT extends AbstractCorfuTest {
             StringBuilder command = new StringBuilder();
             command.append("-a ").append(host);
 
-            if (msg_size != 0) {
-                command.append(" --max-replication-data-message-size=").append(msg_size);
-            }
+            command.append(" --max-replication-data-message-size=").append("30000000");
 
             if (logPath != null) {
                 command.append(" -l ").append(logPath);

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1247,7 +1247,6 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // values are not used
         sinkContext.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);
         sinkContext.getConfig(session).setMaxMsgSize(SMALL_MSG_SIZE);
-        sinkContext.getConfig(session).setMaxDataSizePerMsg(SMALL_MSG_SIZE * LogReplicationConfig.DATA_FRACTION_PER_MSG / 100);
 
         // Data Sender
         sourceDataSender = new SourceForwardingDataSender(testConfig, destMetadataManager,
@@ -1260,7 +1259,6 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // values are not used
         srcContext.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);
         srcContext.getConfig(session).setMaxMsgSize(SMALL_MSG_SIZE);
-        srcContext.getConfig(session).setMaxDataSizePerMsg(SMALL_MSG_SIZE * LogReplicationConfig.DATA_FRACTION_PER_MSG / 100);
 
         // Source Manager
         LogReplicationSourceManager logReplicationSourceManager = new LogReplicationSourceManager(srcMetadataManager,


### PR DESCRIPTION
This is used to build LR msgs in snapshot and logEntry readers

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
