### PR TITLE
RoutingQ: Stamp all full sync messages with requesting timestamp

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -56,8 +56,9 @@ public final class LogReplicationEventListener implements StreamListener {
         // Generate a discovery event and put it into the discovery service event queue.
         for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {
             for (CorfuStreamEntry entry : entryList) {
-                if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
-                    log.warn("LREventListener ignoring a CLEAR operation");
+                if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR ||
+                entry.getOperation() == CorfuStreamEntry.OperationType.DELETE) {
+                    log.warn("LREventListener ignoring a {} operation", entry.getOperation());
                     continue;
                 }
                 LogReplication.ReplicationEventInfoKey key = (LogReplication.ReplicationEventInfoKey) entry.getKey();

--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -60,15 +60,21 @@ message RoutingTableEntryMsg {
 
     // Operation type that marks the table content is being created or removed.
     OperationType operation_type = 7;
+
 }
 
-message RoutingQSnapStartEndKeyMsg {
-    string snapshot_sync_id = 1;
+// One entry is placed in this stream once per full sync transaction batch from client.
+// This helps identify which full sync request the client is responding to and helps ignore
+// older full sync messages.
+message RoutingQSnapSyncHeaderKeyMsg {
+    // Stamp every full sync request with a unique request id from lr server.
+    int64 full_sync_request_id = 1;
+    // Destination corresponding to this snapshot sync.
+    string destination = 2;
 }
 
-// Marker message denoting the end of a snapshot sync
-message RoutingQSnapStartEndMarkerMsg {
-    // Destination corresponding to this snapshot sync
-    string destination = 1;
-    int64 snapshot_start_timestamp = 2;
+message RoutingQSnapSyncHeaderMsg {
+    // This is the response that the Client started its full sync read snapshot on.
+    int64 snapshot_start_timestamp = 3;
+    // Marker message denoting the end of a snapshot sync is the same value in negative
 }

--- a/runtime/src/main/java/org/corfudb/runtime/LRFullStateReplicationContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LRFullStateReplicationContext.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime;
 import org.corfudb.runtime.LogReplication.ReplicationEvent.ReplicationEventType;
 import org.corfudb.runtime.collections.ScopedTransaction;
 import org.corfudb.runtime.collections.TxnContext;
+import static org.corfudb.runtime.Queue.RoutingTableEntryMsg;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
@@ -50,7 +51,7 @@ public interface LRFullStateReplicationContext {
      * Transmits one message for full sync.
      *
      */
-    void transmit(Queue.RoutingTableEntryMsg message) throws CancellationException;
+    void transmit(RoutingTableEntryMsg message) throws CancellationException;
 
     /**
      * Transmits one message for full sync.
@@ -58,7 +59,7 @@ public interface LRFullStateReplicationContext {
      * @param message message to transmit.
      * @param progress indicates progress of transmission, value between 0 and 100.
      */
-    void transmit(Queue.RoutingTableEntryMsg message, int progress) throws CancellationException;
+    void transmit(RoutingTableEntryMsg message, int progress) throws CancellationException;
 
     /**
      * Indicates that all data was transmitted from application to client.

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.corfudb.runtime.LogReplication.*;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
@@ -65,7 +66,7 @@ public final class LogReplicationUtils {
     // Stream tag applied to the replicated queue on the receiver
     public static final String REPLICATED_QUEUE_TAG = "lrq_recv";
 
-    public static final String SNAP_SYNC_START_END_Q_NAME = "LRQ_SNAPSHOT_START_END_MARKER";
+    public static final String SNAP_SYNC_TXN_ENVELOPE_TABLE = "LRQ_SnapSyncHeader";
 
     // ---- End RoutingQueue Model constants -------/
 
@@ -74,12 +75,12 @@ public final class LogReplicationUtils {
     public static final UUID lrFullSyncSendQId = CorfuRuntime.getStreamID(TableRegistry
             .getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, SNAPSHOT_SYNC_QUEUE_NAME_SENDER));
 
-    public static final UUID lrSnapStartEndQId = CorfuRuntime.getStreamID(TableRegistry
-            .getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, SNAP_SYNC_START_END_Q_NAME));
+    public static final UUID lrSnapSyncTxnEnvelopeStreamId = CorfuRuntime.getStreamID(TableRegistry
+            .getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, SNAP_SYNC_TXN_ENVELOPE_TABLE));
 
     public static boolean skipCheckpointFor(UUID streamId) {
         return streamId.equals(lrLogEntrySendQId) || streamId.equals(lrFullSyncSendQId)
-                || streamId.equals(lrSnapStartEndQId);
+                || streamId.equals(lrSnapSyncTxnEnvelopeStreamId);
     }
 
     private LogReplicationUtils() { }
@@ -160,7 +161,7 @@ public final class LogReplicationUtils {
                     List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
                         txnContext.executeQuery(replicationStatusTable,
                                 entry -> entry.getKey().getSubscriber().getModel()
-                                    .equals(LogReplication.ReplicationModel.LOGICAL_GROUPS) &&
+                                    .equals(ReplicationModel.LOGICAL_GROUPS) &&
                                     Objects.equals(entry.getKey().getSubscriber().getClientName(),
                                         clientListener.getClientName()));
 
@@ -262,7 +263,7 @@ public final class LogReplicationUtils {
                     List<CorfuStoreEntry<LogReplicationSession, ReplicationStatus, Message>> entries =
                             txnContext.executeQuery(replicationStatusTable,
                                     entry -> entry.getKey().getSubscriber().getModel()
-                                            .equals(LogReplication.ReplicationModel.ROUTING_QUEUES) &&
+                                            .equals(ReplicationModel.ROUTING_QUEUES) &&
                                             Objects.equals(entry.getKey().getSubscriber().getClientName(),
                                                     clientListener.getClientName()));
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ScopedTransaction.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ScopedTransaction.java
@@ -35,7 +35,7 @@ public class ScopedTransaction implements StoreTransaction<TxnContext>,
             Table<? extends Message, ? extends Message, ? extends Message>,
             Table> mapping;
 
-    ScopedTransaction(
+    public ScopedTransaction(
             @Nonnull final CorfuRuntime runtime,
             @Nonnull final String namespace,
             @Nonnull final IsolationLevel isolationLevel,


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
If LR server for any reason requested multiple full syncs from client then it is possible that
the client is providing multiple full syncs in the same stream at the same time.
To disambiguate one full sync response from another, stamp each full sync message 
with the LR Server's request (Destination+logTail at time of request)

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
