### PR TITLE
LR: improve logging for lastSnapshotStart by reading from DB

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -367,6 +367,11 @@ public class LogReplicationMetadataManager {
 
             txn.commit();
 
+            metadataMap = queryMetadata(txn, LogReplicationMetadataType.TOPOLOGY_CONFIG_ID,
+                    LogReplicationMetadataType.LAST_SNAPSHOT_STARTED);
+            persistedTopologyConfigID = metadataMap.get(LogReplicationMetadataType.TOPOLOGY_CONFIG_ID);
+            persistedSnapshotStart = metadataMap.get(LogReplicationMetadataType.LAST_SNAPSHOT_STARTED);
+
             log.debug("Commit. Set snapshotStart topologyConfigId={}, ts={}, persistedTopologyConfigID={}, " +
                             "persistedSnapshotStart={}",
                     topologyConfigId, ts, persistedTopologyConfigID, persistedSnapshotStart);


### PR DESCRIPTION
## Overview

Description:
This change is improving an existing log. Instead of printing a stale value of a field, retrieve the value from the DB and print it.

Why should this be merged: 
The log will make debugging issues comfortable

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
