### PR TITLE
RQ: allow requestSnapshotSync in parent txn

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -868,7 +868,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
         CorfuStore corfuStore = new CorfuStore(runtime);
         try {
             RoutingQueueSenderClient routingQueueSenderClient = new RoutingQueueSenderClient(corfuStore, RoutingQueueSenderClient.DEFAULT_ROUTING_QUEUE_CLIENT);
-            routingQueueSenderClient.requestGlobalSnapshotSync(UUID.randomUUID(), UUID.randomUUID());
+            routingQueueSenderClient.requestGlobalSnapshotSync("any", "any");
             System.out.println("Full Sync requested for ALL remote sites");
         } catch (NoSuchMethodException | IllegalAccessException e) {
             System.out.println("Hit exception on requestGlobalFullSync"+e);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -57,7 +57,7 @@ public final class LogReplicationEventListener implements StreamListener {
         for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {
             for (CorfuStreamEntry entry : entryList) {
                 if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR ||
-                entry.getOperation() == CorfuStreamEntry.OperationType.DELETE) {
+                        entry.getOperation() == CorfuStreamEntry.OperationType.DELETE) {
                     log.warn("LREventListener ignoring a {} operation", entry.getOperation());
                     continue;
                 }

--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -60,15 +60,14 @@ message RoutingTableEntryMsg {
 
     // Operation type that marks the table content is being created or removed.
     OperationType operation_type = 7;
-
 }
 
 // One entry is placed in this stream once per full sync transaction batch from client.
 // This helps identify which full sync request the client is responding to and helps ignore
 // older full sync messages.
 message RoutingQSnapSyncHeaderKeyMsg {
-    // Stamp every full sync request with a unique request id from lr server.
-    int64 full_sync_request_id = 1;
+    // Stamp every full snapshot sync request with a unique request id from lr server.
+    int64 snap_sync_request_id = 1;
     // Destination corresponding to this snapshot sync.
     string destination = 2;
 }

--- a/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
@@ -160,8 +160,8 @@ public class LogReplicationRoutingQueueIT extends CorfuReplicationMultiSourceSin
 
             // Now request a full sync this time for just one site!
             snapshotProvider.isSnapshotSent = false;
-            queueSenderClient.requestSnapshotSync(UUID.fromString(DefaultClusterConfig.getSourceClusterIds().get(0)),
-                    UUID.fromString(DefaultClusterConfig.getSinkClusterIds().get(0)));
+            queueSenderClient.requestSnapshotSync(DefaultClusterConfig.getSourceClusterIds().get(0),
+                    DefaultClusterConfig.getSinkClusterIds().get(0));
 
             while (numFullSyncMsgsGot < 15) {
                 Thread.sleep(5000);


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Prevents spawning another thread just to request a full sync

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
