### PR TITLE
LR listener task synchronization fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationUtils.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -57,6 +58,9 @@ public final class LogReplicationUtils {
                                  @Nonnull String streamTag, @Nonnull List<String> tablesOfInterest,
                                  int bufferSize, CorfuStore corfuStore) {
         log.info("Client subscription process has started.");
+
+        // Ensure status table is opened here in case FullSyncExecutor is late to do so.
+        openReplicationStatusTable(corfuStore);
 
         Map<String, List<String>> nsToTableName = new HashMap<>();
         nsToTableName.put(namespace, tablesOfInterest);
@@ -114,6 +118,17 @@ public final class LogReplicationUtils {
         }
     }
 
+    private static Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(CorfuStore corfuStore) {
+        try {
+            return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE_NAME,
+                    LogReplicationSession.class, ReplicationStatus.class, null,
+                    TableOptions.fromProtoSchema(ReplicationStatus.class));
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            log.error("Failed to open the Replication Status table", e);
+            throw new StreamingException(e, StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
+        }
+    }
+
     private static class ClientFullSyncAndSubscriptionTask implements Callable<Void> {
 
         private LogReplicationListener listener;
@@ -121,6 +136,7 @@ public final class LogReplicationUtils {
         private String namespace;
         private Map<String, String> nsToStreamTags;
         private Map<String, List<String>> nsToTableName;
+        private Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable;
         private int bufferSize;
         private static final Duration retryThreshold = Duration.ofMinutes(2);
 
@@ -146,8 +162,26 @@ public final class LogReplicationUtils {
             Optional<Counter> conflictCounter = MicroMeterUtils.counter("logreplication.subscribe.conflict.count");
             Optional<Timer.Sample> subscribeTimer = MicroMeterUtils.startTimer();
 
-            Table<LogReplicationSession, ReplicationStatus, Message> replicationStatusTable =
-                    openReplicationStatusTable(corfuStore);
+            try {
+                replicationStatusTable = corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE_NAME);
+            } catch (NoSuchElementException | IllegalArgumentException e) {
+                log.warn("Failed getTable operation for LR status table, opening table.", e);
+                try {
+                    IRetry.build(ExponentialBackoffRetry.class, () -> {
+                        try {
+                            replicationStatusTable = openReplicationStatusTable(corfuStore);
+                        } catch (StreamingException se) {
+                            log.warn("Failed to open LR status table, retrying.");
+                            throw new RetryNeededException();
+                        }
+                        return null;
+                    }).setOptions(retrySettings).run();
+                } catch (InterruptedException ie) {
+                    log.warn("Subscription has failed due to inability to open LR status table.");
+                    listener.onError(new StreamingException(ie, StreamingException.ExceptionCause.SUBSCRIBE_ERROR));
+                }
+            }
+
            Long fullSyncTimestamp = null;
             try {
                 fullSyncTimestamp = IRetry.build(ExponentialBackoffRetry.class, RetryExhaustedException.class, () -> {
@@ -179,7 +213,7 @@ public final class LogReplicationUtils {
                         // from LR and subscription will be a no-op.
                         if (entries.isEmpty()) {
                             log.warn("No record for client {} and Logical Group Model found in the Status Table.  " +
-                                    "Subscription could have been attempted before LR startup.  Subscribe the listener and" +
+                                    "Subscription could have been attempted before LR startup.  Subscribe the listener and " +
                                     "wait for initial Snapshot Sync", listener.getClientName());
                         } else {
                             // For a given replication model and client, any Sink node will have a single session.
@@ -244,17 +278,6 @@ public final class LogReplicationUtils {
                         listener, nsToTableName, nsToStreamTags, fullSyncTimestamp, bufferSize);
             }
             return null;
-        }
-
-        private Table<LogReplicationSession, ReplicationStatus, Message> openReplicationStatusTable(CorfuStore corfuStore) {
-            try {
-                return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, REPLICATION_STATUS_TABLE_NAME,
-                        LogReplicationSession.class, ReplicationStatus.class, null,
-                        TableOptions.fromProtoSchema(ReplicationStatus.class));
-            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                log.error("Failed to open the Replication Status table", e);
-                throw new StreamingException(e, StreamingException.ExceptionCause.SUBSCRIBE_ERROR);
-            }
         }
 
         private void incrementCount(Optional<Counter> counter) {


### PR DESCRIPTION
## Overview

- `openTable()` for LR Status Table occurs in a separate thread from subscribe, main thread may have progressed and the open may not have happened so adding supplemental open outside the thread.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
