### PR TITLE
(WIP) Sink side session initialization workflow

### DIFF
--- a/infrastructure/proto/log_replication_transport.proto
+++ b/infrastructure/proto/log_replication_transport.proto
@@ -23,4 +23,6 @@ service LogReplication {
     // Used only by Sink when connection starter. This RPC creates a long living stream, on which the source and
     // sink exchange negotiation-msg/replication-msg/ACKs
     rpc reverseReplicate(stream org.corfudb.runtime.ResponseMsg) returns (stream org.corfudb.runtime.RequestMsg) {}
+
+    rpc test(stream org.corfudb.runtime.RequestMsg) returns (org.corfudb.runtime.ResponseMsg) {}
 }

--- a/infrastructure/proto/log_replication_transport.proto
+++ b/infrastructure/proto/log_replication_transport.proto
@@ -24,5 +24,5 @@ service LogReplication {
     // sink exchange negotiation-msg/replication-msg/ACKs
     rpc reverseReplicate(stream org.corfudb.runtime.ResponseMsg) returns (stream org.corfudb.runtime.RequestMsg) {}
 
-    rpc test(stream org.corfudb.runtime.RequestMsg) returns (org.corfudb.runtime.ResponseMsg) {}
+    rpc sinkSideSessionInitialize(stream org.corfudb.runtime.RequestMsg) returns (org.corfudb.runtime.ResponseMsg) {}
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -289,7 +289,7 @@ public class SessionManager {
         logNewlyAddedSessionInfo();
     }
 
-    private void createOutgoingSessionsBySubscriber(ReplicationSubscriber subscriber) {
+    public void createOutgoingSessionsBySubscriber(ReplicationSubscriber subscriber) {
         Set<LogReplicationSession> sessionsToAdd = new HashSet<>();
         try {
             String localClusterId = topology.getLocalClusterDescriptor().getClusterId();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -14,6 +14,7 @@ import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientSer
 import org.corfudb.infrastructure.logreplication.runtime.fsm.sink.RemoteSourceLeadershipManager;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
 import org.corfudb.runtime.LogReplication.ReplicationModel;
 import org.corfudb.runtime.LogReplication.ReplicationStatus;
@@ -22,6 +23,7 @@ import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
@@ -114,7 +116,7 @@ public class SessionManager {
 
         this.incomingMsgHandler = new LogReplicationServer(serverContext, sessions, metadataManager,
                 topology.getLocalNodeDescriptor().getNodeId(), topology.getLocalNodeDescriptor().getClusterId(),
-                replicationContext);
+                replicationContext, this);
 
         this.router = new LogReplicationClientServerRouter(replicationManager,
                 topology.getLocalNodeDescriptor().getClusterId(), topology.getLocalNodeDescriptor().getNodeId(),
@@ -240,6 +242,48 @@ public class SessionManager {
         }
     }
 
+    public synchronized void refreshForSinkSideInitialization(LogReplicationSession sessionFromSource) {
+        sessions.add(sessionFromSource);
+
+        Set<String> currentRemoteSources = topology.getRemoteSourceClusters().keySet();
+        Set<String> remoteSourceClustersUnchanged = currentRemoteSources;
+
+        Set<String> currentRemoteSinks = topology.getRemoteSinkClusters().keySet();
+
+        Set<LogReplicationSession> sessionsToRemove = new HashSet<>();
+        Set<LogReplicationSession> sessionsUnchanged = new HashSet<>();
+
+        try {
+            IRetry.build(IntervalRetry.class, () -> {
+                try (TxnContext txn = corfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
+                    sessions.forEach(session -> {
+                            sessionsUnchanged.add(session);
+                            //update topologyId for sink sessions
+                            if (remoteSourceClustersUnchanged.contains(session.getSourceClusterId())) {
+                                log.info("contains topo");
+                                metadataManager.updateReplicationMetadataField(txn, session,
+                                        ReplicationMetadata.TOPOLOGYCONFIGID_FIELD_NUMBER, topology.getTopologyConfigId());
+                            }
+
+                    });
+                    txn.commit();
+                } catch (TransactionAbortedException e) {
+                    throw new RetryNeededException();
+                }
+                stopReplication(sessionsToRemove);
+                updateTopology(topology);
+                updateReplicationParameters(Sets.intersection(sessionsUnchanged, outgoingSessions));
+                createSessions();
+                return null;
+            }).run();
+        } catch (InterruptedException e) {
+            log.error("Unrecoverable exception while refreshing sessions", e);
+            throw new UnrecoverableCorfuInterruptedError(e);
+        }
+
+    }
+
+
     /**
      * Update in-memory topology and topologyId
      * @param newTopology new topology
@@ -289,7 +333,7 @@ public class SessionManager {
         logNewlyAddedSessionInfo();
     }
 
-    public void createOutgoingSessionsBySubscriber(ReplicationSubscriber subscriber) {
+    public Set<LogReplicationSession> createOutgoingSessionsBySubscriber(ReplicationSubscriber subscriber) {
         Set<LogReplicationSession> sessionsToAdd = new HashSet<>();
         try {
             String localClusterId = topology.getLocalClusterDescriptor().getClusterId();
@@ -330,6 +374,7 @@ public class SessionManager {
                 subscriber, sessionsToAdd);
 
         configManager.generateConfig(sessionsToAdd);
+        return sessionsToAdd;
     }
 
     private void createIncomingSessionsBySubscriber(ReplicationSubscriber subscriber) {
@@ -581,5 +626,23 @@ public class SessionManager {
     public void notifyLeadershipChange() {
         incomingMsgHandler.leadershipChanged();
     }
+
+
+    public void sendOutSessionToSinkSide(LogReplication.ReplicationSubscriber subscriber) {
+        Set<LogReplicationSession> sessionForSinkSide = this.createOutgoingSessionsBySubscriber(subscriber);
+        for (LogReplicationSession session : sessionForSinkSide) {
+            LogReplication.LogReplicationSinkSessionInitializationMsg msg =
+                    LogReplication.LogReplicationSinkSessionInitializationMsg.newBuilder().setSession(session).build();
+            CorfuMessage.RequestPayloadMsg payload =
+                    CorfuMessage.RequestPayloadMsg.newBuilder().setLrSinkSessionInitialization(msg).build();
+
+            updateRouterWithNewSessions();
+            createSourceFSMs();
+            logNewlyAddedSessionInfo();
+            topology.getRemoteClusterEndpoints().put(session.getSourceClusterId(), topology.getRemoteSourceClusters().get(session.getSourceClusterId()));
+            router.connect(router.getSessionToRemoteClusterDescriptor().get(session), session);
+            CompletableFuture<LogReplication.LogReplicationMetadataResponseMsg> cf = router.sendRequestAndGetCompletable(session, payload, router.getSessionToRemoteClusterDescriptor().get(session).getClusterId());
+        }
+        }
 }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.SessionManager;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.transport.IClientServerRouter;
@@ -33,10 +34,15 @@ import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLeade
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getHeaderMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getResponseMsg;
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
-import static org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg.PayloadCase.*;
+import static org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg.PayloadCase.LR_ENTRY;
+import static org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY;
+import static org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST;
+import static org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg.PayloadCase.LR_SINK_SESSION_INITIALIZATION;
 import static org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK;
 import static org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_LEADERSHIP_RESPONSE;
 import static org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_METADATA_RESPONSE;
+import static org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_SINK_SESSION_INITIALIZATION_ACK;
+
 
 /**
  * This class represents the Log Replication Server, which is responsible of providing Log Replication across sites.
@@ -71,6 +77,8 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
 
     private final ServerContext serverContext;
 
+    private final SessionManager sessionManager;
+
     private final Set<LogReplicationSession> allSessions;
 
     private final LogReplicationMetadataManager metadataManager;
@@ -86,13 +94,14 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
 
     public LogReplicationServer(@Nonnull ServerContext context, Set<LogReplicationSession> sessions,
                                 LogReplicationMetadataManager metadataManager, String localNodeId, String localClusterId,
-                                LogReplicationContext replicationContext) {
+                                LogReplicationContext replicationContext, SessionManager sessionManager) {
         this.serverContext = context;
         this.allSessions = sessions;
         this.metadataManager = metadataManager;
         this.localNodeId = localNodeId;
         this.localClusterId = localClusterId;
         this.replicationContext = replicationContext;
+        this.sessionManager = sessionManager;
         // TODO V2: the number of threads will change in the follow up PR.
         this.executor = context.getExecutorService(1, EXECUTOR_NAME_PREFIX);
     }
@@ -195,18 +204,11 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
             // Since the two events are async, we wait to receive a new session in the incoming request.
             // If the incoming session is not known to sessionManager drop the message (until session is discovered by
             // local cluster), otherwise create a corresponding sinkManager.
-            // TODO[V2] : We still have a case where the cluster does not ever discover a session on its own, like in
-            //  the logical_group use case where only the source knows about the session even when sink starts the
-            //  connection.
-            //  To resolve this, we need to have a long living RPC from the connectionInitiator cluster which will query
-            //  for sessions from the other cluster
             if (sinkManager == null || sinkManager.isSinkManagerShutdown()) {
                 if(!allSessions.contains(session)) {
                     log.error("SessionManager does not know about incoming session {}, total={}, current sessions={}",
                             session, sessionToSinkManagerMap.size(), sessionToSinkManagerMap.keySet());
                     return;
-                } else {
-                    sinkManager = createSinkManager(session);
                 }
             }
 
@@ -315,8 +317,12 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
     private void handleSinkSideInitialization(RequestMsg request, ResponseMsg res,
                                               @Nonnull IClientServerRouter router) {
         log.debug("Log Replication Sink Side Session Initialization Request received by Server.");
-        ResponsePayloadMsg payload = ResponsePayloadMsg.newBuilder().
-                setLrSinkSessionInitialization(request.getPayload().getLrSinkSessionInitialization()).build();
+        LogReplicationSession session = request.getPayload().getLrSinkSessionInitialization().getSession();
+        createSinkManager(session);
+        this.sessionManager.refreshForSinkSideInitialization(session);
+        LogReplication.LogReplicationSinkSessionInitializationAck ack =
+                LogReplication.LogReplicationSinkSessionInitializationAck.newBuilder().build();
+        ResponsePayloadMsg payload = ResponsePayloadMsg.newBuilder().setLrSinkSessionInitializationAck(ack).build();
         HeaderMsg responseHeader = getHeaderMsg(request.getHeader());
         ResponseMsg response = getResponseMsg(responseHeader, payload);
         router.sendResponse(response);
@@ -352,6 +358,13 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
                 response.getPayload().getLrLeadershipResponse());
     }
 
+    @LogReplicationResponseHandler(responseType = LR_SINK_SESSION_INITIALIZATION_ACK)
+    private void handleSinkSessionInitialization(RequestMsg req, ResponseMsg response,
+                                          @Nonnull IClientServerRouter router) {
+        log.debug("Handle log replication sink side session initialization response msg {}", TextFormat.shortDebugString(response));
+        router.completeRequest(response.getHeader().getSession(), response.getHeader().getRequestId(),
+                response.getPayload().getLrSinkSessionInitializationAck());
+    }
 
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
@@ -119,7 +119,6 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
     @Override
     protected void processRequest(RequestMsg req, ResponseMsg res, IClientServerRouter r) {
         // TODO V2: add metrics around the queue size
-        log.info("zzzzzz");
         executor.submit(() -> getHandlerMethods().handle(req, res, r));
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -87,7 +87,7 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
     @Getter
     private String corfuEndpoint = "localhost:9000";
 
-    private DefaultClusterConfig topology;
+    public DefaultClusterConfig topology;
 
     @Getter
     public CorfuReplicationDiscoveryServiceAdapter corfuReplicationDiscoveryServiceAdapter;
@@ -98,7 +98,7 @@ public class DefaultClusterManager implements CorfuReplicationClusterManagerAdap
     public String localEndpoint;
 
     @Setter
-    private String localNodeId;
+    public String localNodeId;
 
     // since creating the topology and LR bootstrap is async to each other, wait until clusterManger is ready with the
     // desired topology

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -321,17 +321,13 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
         try {
             // Get the next request ID.
             requestId = sessionToRequestIdCounter.getOrDefault(session, new AtomicLong(0)).getAndIncrement();
-
             sessionToOutstandingRequests.putIfAbsent(session, new HashMap<>());
             sessionToOutstandingRequests.get(session).put(requestId, cf);
-
             header.setRequestId(requestId);
             header.setClusterId(getUuidMsg(UUID.fromString(this.localClusterId)));
-
             // If no endpoint is specified, the message is to be sent to the remote leader node.
             // We should block until a connection to the leader is established.
             if (nodeId.equals(REMOTE_LEADER)) {
-
                 if (isConnectionStarterForSession(session)) {
                     // Check the connection future. If connected, continue with sending the message.
                     // If timed out, return a exceptionally completed with the timeout.
@@ -346,7 +342,6 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
                         return cf;
                     }
                 }
-
                 if(outgoingSession.contains(session)) {
                     CorfuLogReplicationRuntime runtimeFSM = sessionToRuntimeFSM.get(session);
                     // Get Remote Leader
@@ -365,7 +360,6 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
                     nodeId = sessionToRemoteSourceLeaderManager.get(session).getRemoteLeaderNodeId().get();
                 }
             }
-
             // In the case the message is intended for a specific endpoint, we do not
             // block on connection future, this is the case of leader verification.
             if(isConnectionStarterForSession(session)) {
@@ -380,7 +374,6 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
                         payload.getPayloadCase(), session);
                 serverChannelAdapter.send(getRequestMsg(header.build(), payload));
             }
-
             // Generate a timeout future, which will complete exceptionally
             // if the main future is not completed.
             final CompletableFuture<T> cfTimeout =
@@ -394,7 +387,6 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
                 }
                 return null;
             });
-
             return cfTimeout;
 
         } catch (NetworkException ne) {
@@ -535,7 +527,13 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
                 completeRequest(msg.getHeader().getSession(), msg.getHeader().getRequestId(), null);
                 return;
 
-            } else {
+            } else if (msg.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_SINK_SESSION_INITIALIZATION_ACK)){
+                log.debug("Received an ACK for sink side session initialization {}/{}", msg.getHeader().getRequestId(),
+                        msg.getPayload().getPayloadCase());
+                completeRequest(msg.getHeader().getSession(), msg.getHeader().getRequestId(), null);
+                return;
+            }
+            else {
                 // Route the message to the handler.
                 if (log.isTraceEnabled()) {
                     log.trace("Message routed to {}}: {}", msgHandler.getClass().getSimpleName(), msg);
@@ -665,7 +663,8 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
         return message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_ENTRY) ||
                 message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST) ||
                 message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY) ||
-                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_LOSS);
+                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_LOSS) ||
+                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_SINK_SESSION_INITIALIZATION);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientServerRouter;
 import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationSession;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
@@ -30,6 +31,9 @@ public abstract class IClientChannelAdapter {
 
     @Getter
     private IChannelContext channelContext;
+
+    @Getter
+    public LogReplicationSession session;
 
     /**
      * Default Constructor

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -195,7 +195,6 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
     public void send(@Nonnull String nodeId, @Nonnull RequestMsg request) {
         // Check the connection future. If connected, continue with sending the message.
         // If timed out, return an exceptionally completed with the timeout.
-        test(nodeId, request);
         switch (request.getPayload().getPayloadCase()) {
             case LR_ENTRY:
                 replicate(nodeId, request);
@@ -205,6 +204,9 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                 break;
             case LR_METADATA_REQUEST:
                 requestMetadata(nodeId, request);
+                break;
+            case LR_SINK_SESSION_INITIALIZATION:
+                sinkSideSessionInitialize(nodeId, request);
                 break;
             default:
                 break;
@@ -381,7 +383,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         replicationReqObserverMap.get(Pair.of(sessionMsg, requestId)).onNext(request);
     }
 
-    private void test(String nodeId, RequestMsg request) {
+    private void sinkSideSessionInitialize(String nodeId, RequestMsg request) {
         LogReplicationSession sessionMsg = request.getHeader().getSession();
         long requestId = request.getHeader().getRequestId();
 
@@ -415,7 +417,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
             };
 
             if(sessionToAsyncStubMap.containsKey(sessionMsg)) {
-                StreamObserver<RequestMsg> requestObserver = sessionToAsyncStubMap.get(sessionMsg).test(responseObserver);
+                StreamObserver<RequestMsg> requestObserver = sessionToAsyncStubMap.get(sessionMsg).sinkSideSessionInitialize(responseObserver);
                 replicationReqObserverMap.put(Pair.of(sessionMsg, requestId), new CorfuStreamObserver<>(requestObserver));
             } else {
                 log.error("No stub found for remote node {}. Message dropped type={}",

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -194,7 +194,8 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
     @Override
     public void send(@Nonnull String nodeId, @Nonnull RequestMsg request) {
         // Check the connection future. If connected, continue with sending the message.
-        // If timed out, return a exceptionally completed with the timeout.
+        // If timed out, return an exceptionally completed with the timeout.
+        test(nodeId, request);
         switch (request.getPayload().getPayloadCase()) {
             case LR_ENTRY:
                 replicate(nodeId, request);
@@ -379,6 +380,56 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         // Send log replication entries across channel
         replicationReqObserverMap.get(Pair.of(sessionMsg, requestId)).onNext(request);
     }
+
+    private void test(String nodeId, RequestMsg request) {
+        LogReplicationSession sessionMsg = request.getHeader().getSession();
+        long requestId = request.getHeader().getRequestId();
+
+        if (!replicationReqObserverMap.containsKey(Pair.of(sessionMsg, requestId))) {
+            StreamObserver<ResponseMsg> responseObserver = new StreamObserver<ResponseMsg>() {
+                @Override
+                public void onNext(ResponseMsg response) {
+                    try {
+                        log.info("Received ACK for {}", response.getHeader().getRequestId());
+                        receive(response);
+                    } catch (Exception e) {
+                        log.error("Caught exception while receiving ACK", e);
+                        getRouter().completeExceptionally(sessionMsg, response.getHeader().getRequestId(), e);
+                        replicationReqObserverMap.remove(Pair.of(sessionMsg, requestId));
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    log.error("Error from response observer", t);
+                    long requestId = request.getHeader().getRequestId();
+                    onServiceUnavailable(t, nodeId, sessionMsg);
+                    getRouter().completeExceptionally(sessionMsg, requestId, t);
+                    replicationReqObserverMap.remove(Pair.of(sessionMsg, requestId));
+                }
+
+                @Override
+                public void onCompleted() {
+                    replicationReqObserverMap.remove(Pair.of(sessionMsg, requestId));
+                }
+            };
+
+            if(sessionToAsyncStubMap.containsKey(sessionMsg)) {
+                StreamObserver<RequestMsg> requestObserver = sessionToAsyncStubMap.get(sessionMsg).test(responseObserver);
+                replicationReqObserverMap.put(Pair.of(sessionMsg, requestId), new CorfuStreamObserver<>(requestObserver));
+            } else {
+                log.error("No stub found for remote node {}. Message dropped type={}",
+                        nodeId, request.getPayload().getPayloadCase());
+            }
+        }
+
+        log.info("Send replication entry: {} to node {}", request.getHeader().getRequestId(), nodeId);
+
+        // Send log replication entries across channel
+        replicationReqObserverMap.get(Pair.of(sessionMsg, requestId)).onNext(request);
+        this.session = sessionMsg;
+    }
+
 
     @Override
     public void stop() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -53,7 +53,6 @@ import java.util.stream.Stream;
 
 import static org.corfudb.infrastructure.logreplication.config.LogReplicationConfig.MERGE_ONLY_STREAMS;
 import static org.corfudb.infrastructure.logreplication.config.LogReplicationConfig.REGISTRY_TABLE_ID;
-import static org.corfudb.runtime.LogReplicationLogicalGroupClient.DEFAULT_LOGICAL_GROUP_CLIENT;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_MODEL_METADATA_TABLE_NAME;
 import static org.corfudb.runtime.LogReplicationLogicalGroupClient.LR_REGISTRATION_TABLE_NAME;
 import static org.corfudb.runtime.view.ObjectsView.LOG_REPLICATOR_STREAM_INFO;
@@ -94,6 +93,8 @@ public class LogReplicationConfigManager {
     @Getter
     private final Set<ReplicationSubscriber> registeredSubscribers = ConcurrentHashMap.newKeySet();
 
+    public ReplicationSubscriber clientReplicationSubscriber;
+
     // Map from a logical group to all the Sinks it is targeting.
     private final Map<String, Set<String>> groupSinksMap = new ConcurrentHashMap<>();
 
@@ -123,6 +124,7 @@ public class LogReplicationConfigManager {
         init();
     }
 
+    /**
     // TODO (V2): This builder should be removed after the rpc stream is added for Sink side session creation.
     public static ReplicationSubscriber getDefaultLogicalGroupSubscriber() {
         return ReplicationSubscriber.newBuilder()
@@ -131,12 +133,14 @@ public class LogReplicationConfigManager {
                 .build();
     }
 
+     */
     public static ReplicationSubscriber getDefaultSubscriber() {
         return ReplicationSubscriber.newBuilder()
                 .setClientName(DEFAULT_CLIENT)
                 .setModel(ReplicationModel.FULL_TABLE)
                 .build();
     }
+
 
     /**
      * Init config manager:
@@ -148,7 +152,7 @@ public class LogReplicationConfigManager {
         registeredSubscribers.add(getDefaultSubscriber());
         // TODO (V2): This builder should be removed after the rpc stream is added for Sink side session creation.
         //  and logical group subscribers should come from client registration.
-        registeredSubscribers.add(getDefaultLogicalGroupSubscriber());
+        //registeredSubscribers.add(getDefaultLogicalGroupSubscriber());
         openClientConfigTables();
         syncWithRegistryTable();
     }
@@ -236,19 +240,20 @@ public class LogReplicationConfigManager {
                 String logicalGroup = entry.getValue().getMetadata().getTableOptions()
                         .getReplicationGroup().getLogicalGroup();
                 // TODO (V2): Client name should be checked after the rpc stream is added for Sink side session creation.
-                // if (session.getSubscriber().getClientName().equals(clientName) && groups.contains(logicalGroup)) {
-                if (isSink || logicalGroupToStreams.containsKey(logicalGroup)) {
-                    streamsToReplicate.add(tableName);
-                    Set<String> relatedStreams = logicalGroupToStreams.getOrDefault(logicalGroup, new HashSet<>());
-                    relatedStreams.add(tableName);
-                    logicalGroupToStreams.put(logicalGroup, relatedStreams);
-                    // Collect tags for this stream
-                    List<UUID> tags = streamToTagsMap.getOrDefault(streamId, new ArrayList<>());
-                    tags.addAll(entry.getValue().getMetadata().getTableOptions().getStreamTagList().stream()
-                            .map(streamTag -> TableRegistry.getStreamIdForStreamTag(entry.getKey().getNamespace(), streamTag))
-                            .collect(Collectors.toList()));
-                    streamToTagsMap.put(streamId, tags);
-                }
+                //if (session.getSubscriber().getClientName().equals(clientName) && groups.contains(logicalGroup)) {
+                    if (isSink || logicalGroupToStreams.containsKey(logicalGroup)) {
+                        streamsToReplicate.add(tableName);
+                        Set<String> relatedStreams = logicalGroupToStreams.getOrDefault(logicalGroup, new HashSet<>());
+                        relatedStreams.add(tableName);
+                        logicalGroupToStreams.put(logicalGroup, relatedStreams);
+                        // Collect tags for this stream
+                        List<UUID> tags = streamToTagsMap.getOrDefault(streamId, new ArrayList<>());
+                        tags.addAll(entry.getValue().getMetadata().getTableOptions().getStreamTagList().stream()
+                                .map(streamTag -> TableRegistry.getStreamIdForStreamTag(entry.getKey().getNamespace(), streamTag))
+                                .collect(Collectors.toList()));
+                        streamToTagsMap.put(streamId, tags);
+                    }
+                //}
             }
         });
 
@@ -349,13 +354,10 @@ public class LogReplicationConfigManager {
                         ReplicationModel model = entry.getPayload().getModel();
                         ReplicationSubscriber subscriber = ReplicationSubscriber.newBuilder()
                                 .setClientName(clientName).setModel(model).build();
-                        // TODO (V2): currently we don't support ccustomized client name, default logical group subscriber
-                        //  should be removed after the grpc stream for Sink session creation is created.
-                        if (model.equals(ReplicationModel.LOGICAL_GROUPS)) {
-                            subscriber = getDefaultLogicalGroupSubscriber();
-                        }
+                        log.info("registering subscriber {}", subscriber);
                         registeredSubscribers.add(subscriber);
                     });
+
 
                     List<CorfuStoreEntry<ClientDestinationInfoKey, DestinationInfoVal, Message>> groupConfigResults =
                             txn.executeQuery(clientConfigTable, p -> true);
@@ -365,11 +367,7 @@ public class LogReplicationConfigManager {
                         ReplicationSubscriber subscriber = ReplicationSubscriber.newBuilder()
                                 .setClientName(clientName).setModel(model).build();
                         String groupName = entry.getKey().getGroupName();
-                        // TODO (V2): currently we don't support ccustomized client name, default logical group subscriber
-                        //  should be removed after the grpc stream for Sink session creation is created.
-                        if (model.equals(ReplicationModel.LOGICAL_GROUPS)) {
-                            subscriber = getDefaultLogicalGroupSubscriber();
-                        }
+
                         if (registeredSubscribers.contains(subscriber)) {
                             groupSinksMap.put(groupName, new HashSet<>(entry.getPayload().getDestinationIdsList()));
                         } else {
@@ -401,6 +399,7 @@ public class LogReplicationConfigManager {
         // TODO (V2): Currently we add a default subscriber for logical group use case instead of listening on client
         //  registration. Subscriber should be added upon registration after grpc stream for session creation is added.
         registeredSubscribers.add(subscriber);
+        clientReplicationSubscriber = subscriber;
     }
 
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -83,7 +83,7 @@ public class LogReplicationServerTest {
         LogReplicationContext replicationContext = new LogReplicationContext(mock(LogReplicationConfigManager.class),
                 0L, SAMPLE_HOSTNAME, true, mock(LogReplicationPluginConfig.class));
         lrServer = spy(new LogReplicationServer(context, sessionSet, metadataManager, SINK_NODE_ID, SINK_CLUSTER_ID,
-                replicationContext));
+                replicationContext, sessionManager));
         lrServer.getSessionToSinkManagerMap().put(session, sinkManager);
         mockHandlerContext = mock(ChannelHandlerContext.class);
         mockServerRouter = mock(IClientServerRouter.class);

--- a/runtime/proto/service/corfu_message.proto
+++ b/runtime/proto/service/corfu_message.proto
@@ -153,7 +153,7 @@ message ResponsePayloadMsg {
     LogReplicationLeadershipLossMsg lr_leadership_loss = 73;
     ReverseReplicateMsg lr_reverse_replicate_msg = 74;
 
-    LogReplicationSinkSessionInitializationMsg lr_sink_session_initialization = 75;
+    LogReplicationSinkSessionInitializationAck lr_sink_session_initialization_ack = 75;
 
 
     // Server Error

--- a/runtime/proto/service/corfu_message.proto
+++ b/runtime/proto/service/corfu_message.proto
@@ -94,6 +94,7 @@ message RequestPayloadMsg {
     LogReplicationMetadataRequestMsg lr_metadata_request = 71;
     LogReplicationLeadershipRequestMsg lr_leadership_query = 72;
     LogReplicationLeadershipLossMsg lr_leadership_loss = 73;
+    LogReplicationSinkSessionInitializationMsg lr_sink_session_initialization = 74;
   }
 }
 
@@ -151,6 +152,9 @@ message ResponsePayloadMsg {
 
     LogReplicationLeadershipLossMsg lr_leadership_loss = 73;
     ReverseReplicateMsg lr_reverse_replicate_msg = 74;
+
+    LogReplicationSinkSessionInitializationMsg lr_sink_session_initialization = 75;
+
 
     // Server Error
     ServerErrorMsg server_error = 200;

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -46,6 +46,10 @@ message LogReplicationLeadershipResponseMsg {
   string nodeId = 3;
 }
 
+message LogReplicationSinkSessionInitializationMsg {
+  LogReplicationSession session = 1;
+}
+
 enum LogReplicationEntryType {
   LOG_ENTRY_MESSAGE = 0;
   SNAPSHOT_MESSAGE = 1;

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -50,6 +50,10 @@ message LogReplicationSinkSessionInitializationMsg {
   LogReplicationSession session = 1;
 }
 
+message LogReplicationSinkSessionInitializationAck {
+
+}
+
 enum LogReplicationEntryType {
   LOG_ENTRY_MESSAGE = 0;
   SNAPSHOT_MESSAGE = 1;

--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
@@ -40,8 +40,6 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
  */
 @Slf4j
 public class LogReplicationLogicalGroupClient {
-    // TODO (V2): This field should be removed after the rpc stream is added for Sink side session creation.
-    public static final String DEFAULT_LOGICAL_GROUP_CLIENT = "00000000-0000-0000-0000-0000000000001";
 
     /**
      * Key: ClientRegistrationId
@@ -78,10 +76,8 @@ public class LogReplicationLogicalGroupClient {
     public LogReplicationLogicalGroupClient(CorfuRuntime runtime, String clientName)
             throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         Preconditions.checkArgument(isValid(clientName), "clientName is null or empty.");
-
         this.corfuStore = new CorfuStore(runtime);
-        // TODO (V2): client name cannot be customized as Sink side does not have a way to create sessions for now
-        this.clientName = DEFAULT_LOGICAL_GROUP_CLIENT;
+        this.clientName = clientName;
         this.clientKey = ClientRegistrationId.newBuilder()
                 .setClientName(clientName)
                 .build();
@@ -115,7 +111,6 @@ public class LogReplicationLogicalGroupClient {
                     null,
                     TableOptions.fromProtoSchema(DestinationInfoVal.class));
         }
-
         register();
     }
 
@@ -130,21 +125,21 @@ public class LogReplicationLogicalGroupClient {
                     ClientRegistrationInfo clientRegistrationInfo = txn.getRecord(replicationRegistrationTable, clientKey).getPayload();
 
                     if (clientRegistrationInfo != null) {
-                        log.warn(String.format("Client already registered.\n--- ClientRegistrationId ---\n%s" +
+                        log.info(String.format("Client already registered.\n--- ClientRegistrationId ---\n%s" +
                                 "--- ClientRegistrationInfo ---\n%s", clientKey, clientRegistrationInfo));
                     } else {
+                        log.info("going to put");
                         txn.putRecord(replicationRegistrationTable, clientKey, clientInfo, null);
                     }
 
-                    txn.commit();
                 } catch (TransactionAbortedException tae) {
-                    log.error(String.format("[%s] Unable to register client.", clientName), tae);
+                    log.info(String.format("[%s] Unable to register client.", clientName), tae);
                     throw new RetryNeededException();
                 }
                 return null;
             }).run();
         } catch (InterruptedException e) {
-            log.error(String.format("[%s] Client registration failed.", clientName), e);
+            log.info(String.format("[%s] Client registration failed.", clientName), e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.corfudb.runtime.LogReplicationLogicalGroupClient.DEFAULT_LOGICAL_GROUP_CLIENT;
 
 /**
  * A view of the objects inside a Corfu instance.
@@ -52,8 +51,8 @@ public class ObjectsView extends AbstractView {
 
     public static StreamTagInfo getLogicalGroupStreamTagInfo(String replicationClientName) {
         // TODO (V2): uncomment next line after customized client name is supported
-        // String streamName = LOGICAL_GROUP_REPLICATION_STREAM_NAME_PREFIX + replicationClientName;
-        String streamName = LOGICAL_GROUP_REPLICATION_STREAM_NAME_PREFIX + DEFAULT_LOGICAL_GROUP_CLIENT;
+        String streamName = LOGICAL_GROUP_REPLICATION_STREAM_NAME_PREFIX + replicationClientName;
+        //String streamName = LOGICAL_GROUP_REPLICATION_STREAM_NAME_PREFIX + DEFAULT_LOGICAL_GROUP_CLIENT;
         return new StreamTagInfo(streamName, CorfuRuntime.getStreamID(streamName));
     }
 


### PR DESCRIPTION
## Overview

Description: In IDFW use case, we hardcoded subscriber and client on both sides since sink did not know who was connecting to it. This PR introduces a sink side initialization workflow so sink side knows who is registering the client. (Please noted that this PR is still a work in progress as testing has not been completed yet.)

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
