### PR TITLE
@rocksdb: Consume internal fork of RocksDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             <name>libs-snapshot</name>
             <url>https://oss.jfrog.org/artifactory/libs-snapshot</url>
         </repository>
+
+        <repository>
+            <id>ossrh-staging</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/orgcorfudb-1009</url>
+        </repository>
     </repositories>
 
     <reporting>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
 
-        <rocksdb.version>7.9.2</rocksdb.version>
+        <rocksdb.version>8.6.7.2</rocksdb.version>
         <kryo.version>5.5.0</kryo.version>
         <kryo.serializers.version>0.45</kryo.serializers.version>
         <plexus.version>3.0.24</plexus.version>
@@ -137,7 +137,7 @@
             <version>${commons.compress.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.rocksdb</groupId>
+            <groupId>org.corfudb</groupId>
             <artifactId>rocksdbjni</artifactId>
             <version>${rocksdb.version}</version>
         </dependency>


### PR DESCRIPTION
Changes on the RocksDB side:
* Change the default Optimisitc Concurrency Control Validation Policy to kValidateSerial. This significantly reduces the amount of memory used by OptimisticTransactionDB.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
