### PR TITLE
@rocksdb: Export write buffer size parameter

### DIFF
--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -37,6 +37,7 @@ message PersistenceOptions {
     optional string dataPath = 1;
     optional ConsistencyModel consistencyModel = 2;
     optional SizeComputationModel sizeComputationModel = 3;
+    optional int64 writeBufferSize = 4; // In bytes.
 }
 
 message ReplicationLogicalGroup {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/DiskBackedCorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/DiskBackedCorfuTable.java
@@ -147,6 +147,7 @@ public class DiskBackedCorfuTable<K, V> implements
             this.statistics = new Statistics();
             this.statistics.setStatsLevel(StatsLevel.ALL);
             rocksDbOptions.setStatistics(statistics);
+            persistenceOptions.getWriteBufferSize().map(rocksDbOptions::setWriteBufferSize);
 
             final RocksDbStore<DiskBackedCorfuTable<K, V>> rocksDbStore = new RocksDbStore<>(
                     persistenceOptions.getDataPath(), rocksDbOptions, writeOptions);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -237,6 +237,9 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
             if (tableParameters.getPersistenceOptions().hasSizeComputationModel()) {
                 persistenceOptions.sizeComputationModel(tableParameters.getPersistenceOptions().getSizeComputationModel());
             }
+            if (tableParameters.getPersistenceOptions().hasWriteBufferSize()) {
+                persistenceOptions.writeBufferSize(Optional.of(tableParameters.getPersistenceOptions().getWriteBufferSize()));
+            }
 
             ISerializer safeSerializer = new SafeProtobufSerializer(serializer);
             builder = runtime.getObjectsView().<PersistedCorfuTable<K, CorfuRecord<V, M>>>build()

--- a/runtime/src/main/java/org/corfudb/runtime/object/PersistenceOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/PersistenceOptions.java
@@ -6,22 +6,25 @@ import org.corfudb.runtime.CorfuOptions.ConsistencyModel;
 import org.corfudb.runtime.CorfuOptions.SizeComputationModel;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Reflects {@link org.corfudb.runtime.CorfuOptions.PersistenceOptions}
  * since Protobuf does not allow for explicit default options
  */
+@Getter
 @Builder
 public class PersistenceOptions {
 
-    @Getter
     Path dataPath;
 
-    @Getter
     @Builder.Default
     ConsistencyModel consistencyModel = ConsistencyModel.READ_YOUR_WRITES;
 
-    @Getter
     @Builder.Default
     SizeComputationModel sizeComputationModel = SizeComputationModel.EXACT_SIZE;
+
+    @Builder.Default
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    Optional<Long> writeBufferSize = Optional.empty();
 }


### PR DESCRIPTION
Allow clients to set the write buffer/memtable size via PersistenceOptions.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
