### PR TITLE
[TEST] Running test suites for routing-q-bidirectional after rebase

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
@@ -61,7 +61,7 @@ public class RoutingQueuesSnapshotReaderTest extends AbstractViewTest {
         configManager = new LogReplicationConfigManager(lrRuntime, session.getSourceClusterId());
         replicationContext = new LogReplicationContext(configManager, 5, session.getSourceClusterId(),
                 true, new LogReplicationPluginConfig(""), lrRuntime);
-        configManager.generateConfig(Collections.singleton(session));
+        configManager.generateConfig(Collections.singleton(session), false);
         snapshotReader = new RoutingQueuesSnapshotReader(session, replicationContext);
         snapshotReader.reset(lrRuntime.getAddressSpaceView().getLogTail());
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1287,7 +1287,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                 function, sinkContext, dstTestRuntime);
 
         LogReplicationConfigManager srcConfigManager = new LogReplicationConfigManager(srcTestRuntime, LOCAL_SOURCE_CLUSTER_ID);
-        srcConfigManager.generateConfig(Collections.singleton(session));
+        srcConfigManager.generateConfig(Collections.singleton(session), false);
         LogReplicationContext srcContext = new LogReplicationContext(srcConfigManager, 0, DEFAULT_ENDPOINT, pluginConfig, srcTestRuntime);
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
