### PR TITLE
Minor fix to CorfuQueueGuidGenerator for existing tests

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
@@ -79,6 +79,7 @@ public class CorfuGuidGenerator implements OrderedGuidGenerator {
                     continue;
                 }
             }
+            distributedCounter = distributedCounterTable;
 
             try (TxnContext txn = corfuStore.txn(TableRegistry.CORFU_SYSTEM_NAMESPACE)) {
                 final int GUID_INSTANCE_ID_KEY = 0xdeadbeef;


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Missed instantiating the table for the old guid generator causing IT failures
Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
