### PR TITLE
@rocksdb: Compile against an older glibc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 
         <repository>
             <id>ossrh-staging</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/orgcorfudb-1009</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/orgcorfudb-1010</url>
         </repository>
     </repositories>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
 
-        <rocksdb.version>8.6.7.2</rocksdb.version>
+        <rocksdb.version>8.6.7.3</rocksdb.version>
         <kryo.version>5.5.0</kryo.version>
         <kryo.serializers.version>0.45</kryo.serializers.version>
         <plexus.version>3.0.24</plexus.version>


### PR DESCRIPTION
Ubuntu 20.04.6 LTS (Focal Fossa) uses an older version of glibc, therefore, when compiling RocksDB JNI, use version 2.31 insated.

GNU C Library (Ubuntu GLIBC 2.31-0ubuntu9.12) stable release version 2.31.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
