### PR TITLE
LR: add session "name" to log statements

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/FsmTaskManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/FsmTaskManager.java
@@ -138,14 +138,14 @@ public class FsmTaskManager {
         // for a given session, The fsm event should be processed in the order they are queued. This condition ensures
         // that in the event of 2 threads contending for the monitor, only the task submitted first would be processed.
         synchronized (sessionToRuntimeEventIdMap.get(sessionName)) {
-                while (!sessionToRuntimeEventIdMap.get(sessionName).get(0).equals(event.getEventId())) {
-                    try {
-                        sessionToRuntimeEventIdMap.get(sessionName).wait();
-                    } catch (InterruptedException e) {
-                        log.error("[{}]:: Wait was interrupted {}", sessionName, e.getMessage());
-                    }
+            while (!sessionToRuntimeEventIdMap.get(sessionName).get(0).equals(event.getEventId())) {
+                try {
+                    sessionToRuntimeEventIdMap.get(sessionName).wait();
+                } catch (InterruptedException e) {
+                    log.error("[{}]:: Wait was interrupted {}", sessionName, e.getMessage());
                 }
             }
+        }
 
 
             LogReplicationRuntimeState currState = fsm.getState();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/FsmTaskManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/FsmTaskManager.java
@@ -3,12 +3,13 @@ package org.corfudb.infrastructure.logreplication;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.replication.fsm.IllegalTransitionException;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationFSM;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationState;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationStateType;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
-import org.corfudb.infrastructure.logreplication.runtime.fsm.IllegalTransitionException;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.IllegalRuntimeTransitionException;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeState;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeStateType;
@@ -162,7 +163,7 @@ public class FsmTaskManager {
                     fsm.setState(newState);
 
                 }
-            } catch (IllegalTransitionException illegalState) {
+            } catch (IllegalRuntimeTransitionException illegalState) {
                 log.error("[{}]:: Illegal log replication event {} when in state {}", sessionName, event.getType(), currState.getType());
             }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/FsmTaskManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/FsmTaskManager.java
@@ -169,7 +169,7 @@ public class FsmTaskManager {
 
         synchronized(sessionToRuntimeEventIdMap.get(sessionName)) {
             sessionToRuntimeEventIdMap.get(sessionName).remove(0);
-            fsm.notifyAll();
+            sessionToRuntimeEventIdMap.get(sessionName).notifyAll();
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -420,7 +420,7 @@ public class SessionManager {
         int hash = 41;
         hash = (53 * hash) + session.getSourceClusterId().hashCode();
         hash = (53 * hash) + session.getSinkClusterId().hashCode();
-        hash = (53 * hash) + session.getSubscriber().getModel().hashCode();
+        hash = (53 * hash) + session.getSubscriber().getModel().toString().hashCode();
         hash = (53 * hash) + session.getSubscriber().getClientName().hashCode();
 
         return hash;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -85,7 +85,7 @@ public class SessionManager {
 
     private final LogReplicationServer incomingMsgHandler;
 
-    private String SESSION_NAME_PREFIX = "session_";
+    private final String SESSION_NAME_PREFIX = "session_";
 
     /**
      * Constructor

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -80,7 +80,7 @@ public class InLogEntrySyncState implements LogReplicationState {
                     log.debug("Log Entry Sync ACK, update last ack timestamp to {}", event.getMetadata().getLastLogEntrySyncedTimestamp());
                     fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 }
-                // Do not return a new state as there is no actual transition, the IllegalTransitionException
+                // Do not return a new state as there is no actual transition, the IllegalRuntimeTransitionException
                 // will allow us to avoid any transition from this state given the event.
                 break;
             case LOG_ENTRY_SYNC_CONTINUE:

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -31,7 +31,7 @@ public class InitializedState implements LogReplicationState {
     public LogReplicationState processEvent(LogReplicationEvent event) throws IllegalTransitionException {
         switch (event.getType()) {
             case SNAPSHOT_SYNC_REQUEST:
-                log.info("Start Snapshot Sync, requestId={}", event.getEventId());
+                log.info("[{}]:: Start Snapshot Sync, requestId={}", fsm.getSessionName(), event.getEventId());
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState snapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
@@ -39,7 +39,7 @@ public class InitializedState implements LogReplicationState {
                 ((InSnapshotSyncState)snapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                 return snapshotSyncState;
             case SNAPSHOT_TRANSFER_COMPLETE:
-                log.info("Snapshot Sync transfer completed. Wait for snapshot apply to complete.");
+                log.info("[{}]:: Snapshot Sync transfer completed. Wait for snapshot apply to complete.", fsm.getSessionName());
                 WaitSnapshotApplyState waitSnapshotApplyState = (WaitSnapshotApplyState)fsm.getStates().get(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
                 waitSnapshotApplyState.setTransitionEventId(event.getEventId());
                 waitSnapshotApplyState.setBaseSnapshotTimestamp(event.getMetadata().getLastTransferredBaseSnapshot());
@@ -47,7 +47,7 @@ public class InitializedState implements LogReplicationState {
                 fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 return waitSnapshotApplyState;
             case LOG_ENTRY_SYNC_REQUEST:
-                log.info("Start Log Entry Sync, requestId={}", event.getEventId());
+                log.info("[{}]:: Start Log Entry Sync, requestId={}", fsm.getSessionName(), event.getEventId());
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState logEntrySyncState = fsm.getStates().get(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
@@ -60,7 +60,7 @@ public class InitializedState implements LogReplicationState {
             case REPLICATION_SHUTDOWN:
                 return fsm.getStates().get(LogReplicationStateType.ERROR);
             default: {
-                log.warn("Unexpected log replication event {} when in initialized state.", event.getType());
+                log.warn("[{}]:: Unexpected log replication event {} when in initialized state.", fsm.getSessionName(), event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());
             }
         }
@@ -71,7 +71,7 @@ public class InitializedState implements LogReplicationState {
         if (from != this) {
             fsm.getAckReader().markSyncStatus(SyncStatus.STOPPED);
             fsm.getAckReader().cancelScheduledAckPollerTask();
-            log.debug("Replication status changed to STOPPED");
+            log.debug("[{}]:: Replication status changed to STOPPED", fsm.getSessionName());
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -195,6 +195,9 @@ public class LogReplicationFSM {
     private final FsmTaskManager fsmTaskManager;
 
 
+    @Getter
+    private final String sessionName;
+
     /**
      * Constructor for LogReplicationFSM, custom read processor for data transformation.
      *
@@ -209,6 +212,7 @@ public class LogReplicationFSM {
         this.snapshotReader = createSnapshotReader(session, replicationContext);
         this.logEntryReader = createLogEntryReader(session, replicationContext);
 
+        this.sessionName = replicationContext.getSessionName(session);
         this.ackReader = ackReader;
         this.session = session;
         this.snapshotSender = new SnapshotSender(replicationContext, snapshotReader, dataSender, this);
@@ -217,7 +221,7 @@ public class LogReplicationFSM {
         this.fsmTaskManager = replicationContext.getTaskManager();
         this.fsmTaskManager.createReplicationTaskManager("replicationFSM", MAX_REPLICATION_WORKER_THREAD_COUNT);
 
-        init(dataSender, session);
+        init(dataSender);
         setTopologyConfigId(replicationContext.getTopologyConfigId());
     }
 
@@ -236,6 +240,7 @@ public class LogReplicationFSM {
     public LogReplicationFSM(SnapshotReader snapshotReader, DataSender dataSender,
                              LogEntryReader logEntryReader, LogReplicationAckReader ackReader,
                              LogReplicationSession session, LogReplicationContext replicationContext) {
+        this.sessionName = replicationContext.getSessionName(session);
         this.snapshotReader = snapshotReader;
         this.logEntryReader = logEntryReader;
         this.ackReader = ackReader;
@@ -245,7 +250,7 @@ public class LogReplicationFSM {
         this.fsmTaskManager = replicationContext.getTaskManager();
         this.fsmTaskManager.createReplicationTaskManager("replicationFSM", MAX_REPLICATION_WORKER_THREAD_COUNT);
 
-        init(dataSender, session);
+        init(dataSender);
     }
 
     private SnapshotReader createSnapshotReader(LogReplicationSession session, LogReplicationContext replicationContext) {
@@ -265,7 +270,7 @@ public class LogReplicationFSM {
                 break;
 
             default:
-                log.error("Unsupported replication model found: {}", model);
+                log.error("[{}]:: Unsupported replication model found: {}",sessionName, model);
                 throw new IllegalArgumentException("Unsupported replication model found: " + model);
 
         }
@@ -289,18 +294,18 @@ public class LogReplicationFSM {
                 break;
 
             default:
-                log.error("Unsupported Replication Model Found: {}", model);
+                log.error("[{}]:: Unsupported Replication Model Found: {}", sessionName, model);
                 throw new IllegalArgumentException("Unsupported Replication Model Found: " +
                         session.getSubscriber().getModel());
         }
         return logEntryReader;
     }
 
-    private void init(DataSender dataSender, LogReplicationSession session) {
+    private void init(DataSender dataSender) {
         // Initialize Log Replication 5 FSM states - single instance per state
         initializeStates(snapshotSender, logEntrySender, dataSender);
         this.state = states.get(LogReplicationStateType.INITIALIZED);
-        log.info("Log Replication FSM initialized for session={}", session);
+        log.info("[{}]:: Log Replication FSM initialized", sessionName);
     }
 
     /**
@@ -330,11 +335,11 @@ public class LogReplicationFSM {
      */
     public void input(LogReplicationEvent event) {
         if (state.getType().equals(LogReplicationStateType.ERROR)) {
-            log.warn("Not accepting event {} as current state is {}", event.getType(), state.getType());
+            log.warn("[{}]:: Not accepting event {} as current state is {}", sessionName, event.getType(), state.getType());
             return;
         }
         if (event.getType() != LogReplicationEventType.LOG_ENTRY_SYNC_CONTINUE) {
-            log.trace("Enqueue event {} with ID {}", event.getType(), event.getEventId());
+            log.trace("[{}]:: Enqueue event {} with ID {}", sessionName, event.getType(), event.getEventId());
         }
         this.fsmTaskManager.addTask(event, FsmTaskManager.FsmEventType.LogReplicationEvent, 0, this);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
@@ -47,7 +47,7 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
                 .mergeFrom(entry.getMetadata())
                 .setEntryType(LogReplicationEntryType.LOG_ENTRY_REPLICATED)
                 .setTimestamp(lastProcessedSeq).build();
-        log.debug("Sink Buffer lastProcessedSeq {}", lastProcessedSeq);
+        log.debug("[{}]:: Sink Buffer lastProcessedSeq {}", sinkManager.getSessionName(), lastProcessedSeq);
         return metadata;
     }
 
@@ -59,7 +59,7 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
     @Override
     public boolean verifyMessageType(LogReplicationEntryMsg entry) {
         if (entry.getMetadata().getEntryType() != type) {
-            log.warn("Got msg type {} but expecting type {}",
+            log.warn("[{}]:: Got msg type {} but expecting type {}", sinkManager.getSessionName(),
                     entry.getMetadata().getEntryType(), type);
             return false;
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -207,10 +207,10 @@ public class LogEntryWriter extends SinkWriter {
                     return null;
                 }).run();
             } catch (IllegalArgumentException e) {
-                log.error("[{}]:: Metadata mismatch detected in entry with sequence {}" + getSessionName(), opaqueEntry.getVersion(), e);
+                log.error("[{}]:: Metadata mismatch detected in entry with sequence {}", getSessionName(), opaqueEntry.getVersion(), e);
                 return false;
             } catch (InterruptedException e) {
-                log.error("[{}]:: Could not apply entry with sequence {}" + getSessionName(), opaqueEntry.getVersion(), e);
+                log.error("[{}]:: Could not apply entry with sequence {}", getSessionName(), opaqueEntry.getVersion(), e);
                 return false;
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -207,10 +207,10 @@ public class LogEntryWriter extends SinkWriter {
                     return null;
                 }).run();
             } catch (IllegalArgumentException e) {
-                log.error("[{}]:: Metadata mismatch detected in entry with sequence " + getSessionName(), opaqueEntry.getVersion(), e);
+                log.error("[{}]:: Metadata mismatch detected in entry with sequence {}" + getSessionName(), opaqueEntry.getVersion(), e);
                 return false;
             } catch (InterruptedException e) {
-                log.error("[{}]:: Could not apply entry with sequence " + getSessionName(), opaqueEntry.getVersion());
+                log.error("[{}]:: Could not apply entry with sequence {}" + getSessionName(), opaqueEntry.getVersion(), e);
                 return false;
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -121,6 +121,8 @@ public class LogReplicationSinkManager implements DataReceiver {
     @Getter
     private final AtomicBoolean ongoingApply = new AtomicBoolean(false);
 
+    @Getter
+    private final String sessionName;
 
     /**
      * Constructor Sink Manager
@@ -137,6 +139,22 @@ public class LogReplicationSinkManager implements DataReceiver {
         this.topologyConfigId = replicationContext.getTopologyConfigId();
         this.session = session;
         this.metadataManager = metadataManager;
+        this.sessionName = replicationContext.getSessionName(session);
+
+        init();
+    }
+
+    @VisibleForTesting
+    public LogReplicationSinkManager(String localCorfuEndpoint, LogReplicationMetadataManager metadataManager,
+                                     LogReplicationSession session,
+                                     LogReplicationContext context) {
+        this.runtime =  CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder()
+                .maxCacheEntries(context.getConfig(session).getMaxCacheSize()).build())
+                .parseConfigurationString(localCorfuEndpoint).connect();
+        this.metadataManager = metadataManager;
+        this.session = session;
+        this.replicationContext = context;
+        this.sessionName = replicationContext.getSessionName(session);
 
         init();
     }
@@ -164,16 +182,16 @@ public class LogReplicationSinkManager implements DataReceiver {
                 try {
                      metadataManager.setDataConsistentOnSink(isDataConsistent, session);
                 } catch (TransactionAbortedException tae) {
-                    log.error("Error while attempting to setDataConsistent in SinkManager's init", tae);
+                    log.error("[{}]:: Error while attempting to setDataConsistent in SinkManager's init", sessionName, tae);
                     throw new RetryNeededException();
                 }
 
-                log.debug("setDataConsistentWithRetry succeeds, current value is {}", isDataConsistent);
+                log.debug("[{}]:: setDataConsistentWithRetry succeeds, current value is {}", sessionName, isDataConsistent);
 
                 return null;
             }).run();
         } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to setDataConsistent in SinkManager's init.", e);
+            log.error("[{}]:: Unrecoverable exception when attempting to setDataConsistent in SinkManager's init.", sessionName, e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
     }
@@ -229,7 +247,7 @@ public class LogReplicationSinkManager implements DataReceiver {
             return (ISnapshotSyncPlugin) plugin.getDeclaredConstructor(CorfuRuntime.class)
                     .newInstance(runtime);
         } catch (Throwable t) {
-            log.error("Fatal error: Failed to get snapshot sync plugin {}", config.getSnapshotSyncPluginCanonicalName(), t);
+            log.error("[{}]:: Fatal error: Failed to get snapshot sync plugin {}", sessionName, config.getSnapshotSyncPluginCanonicalName(), t);
             throw new UnrecoverableCorfuError(t);
         }
     }
@@ -251,11 +269,11 @@ public class LogReplicationSinkManager implements DataReceiver {
             ackCycleTime = Integer.parseInt(props.getProperty("log_writer_ack_cycle_time", Integer.toString(ackCycleTime)));
             reader.close();
         } catch (FileNotFoundException e) {
-            log.warn("Config file {} does not exist. Using default configs", CONFIG_FILE);
+            log.warn("[{}]:: Config file {} does not exist. Using default configs", sessionName, CONFIG_FILE);
         } catch (IOException e) {
-            log.error("IO Exception when reading config file", e);
+            log.error("[{}]:: IO Exception when reading config file", sessionName, e);
         }
-        log.info("Sink Manager Buffer config queue size {} ackCycleCnt {} ackCycleTime {}", bufferSize, ackCycleCnt,
+        log.info("[{}]:: Sink Manager Buffer config queue size {} ackCycleCnt {} ackCycleTime {}", sessionName, bufferSize, ackCycleCnt,
             ackCycleTime);
     }
 
@@ -270,13 +288,13 @@ public class LogReplicationSinkManager implements DataReceiver {
         rxMessageCounter++;
         rxMessageCount.setValue(rxMessageCounter);
 
-        log.debug("Sink manager received {} while in {}", message.getMetadata().getEntryType(), rxState);
+        log.debug("[{}]:: Sink manager received {} while in {}", sessionName, message.getMetadata().getEntryType(), rxState);
 
         // Ignore messages that have different topologyConfigId.
         // It could be caused by an out-of-date sender or the local node hasn't done the site discovery yet.
         // If there is a siteConfig change, the discovery service will detect it and reset the state.
         if (message.getMetadata().getTopologyConfigID() != topologyConfigId) {
-            log.warn("Drop message {}. Topology config id mismatch, local={}, msg={}", message.getMetadata().getEntryType(),
+            log.warn("[{}]:: Drop message {}. Topology config id mismatch, local={}, msg={}", sessionName, message.getMetadata().getEntryType(),
                     topologyConfigId, message.getMetadata().getTopologyConfigID());
             return null;
         }
@@ -289,9 +307,9 @@ public class LogReplicationSinkManager implements DataReceiver {
                 // so the system can prepare for the full sync. Typically, to stop checkpoint/trim
                 // during the period of the snapshot sync to prevent data loss from shadow tables
                 // (temporal non-checkpointed streams). This is a blocking call.
-                log.info("Enter onSnapshotSyncStart :: {}", snapshotSyncPlugin.getClass().getSimpleName());
+                log.info("[{}]:: Enter onSnapshotSyncStart :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());
                 snapshotSyncPlugin.onSnapshotSyncStart(runtime);
-                log.info("Exit onSnapshotSyncStart :: {}", snapshotSyncPlugin.getClass().getSimpleName());
+                log.info("[{}]:: Exit onSnapshotSyncStart :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());
             }
             return null;
         }
@@ -304,14 +322,14 @@ public class LogReplicationSinkManager implements DataReceiver {
             if (message.getMetadata().getEntryType() == LogReplicationEntryType.SNAPSHOT_END) {
                 LogReplicationEntryMetadataMsg ackMetadata = snapshotSinkBufferManager.generateAckMetadata(message);
                 if (ackMetadata.getEntryType() == LogReplicationEntryType.SNAPSHOT_TRANSFER_COMPLETE) {
-                    log.warn("Resend snapshot sync transfer complete ack. Sink state={}, received={}", rxState,
+                    log.warn("[{}]:: Resend snapshot sync transfer complete ack. Sink state={}, received={}", sessionName, rxState,
                             message.getMetadata().getEntryType());
                     return getLrEntryAckMsg(ackMetadata);
                 }
             }
 
             // Drop all other invalid messages
-            log.warn("Sink Manager in state {} and received message {}. Dropping Message.", rxState,
+            log.warn("[{}]:: Sink Manager in state {} and received message {}. Dropping Message.", sessionName, rxState,
                     message.getMetadata().getEntryType());
 
             return null;
@@ -345,14 +363,14 @@ public class LogReplicationSinkManager implements DataReceiver {
         if (Objects.equals(latestSnapshotSyncCycleId, ackSnapshotSyncCycleId) &&
             (entry.getMetadata().getSnapshotTimestamp() == lastAppliedBaseSnapshotTimestamp)) {
             // Notify end of snapshot sync. This is a blocking call.
-            log.info("Notify Snapshot Sync Plugin completion of snapshot sync id={}, baseSnapshot={}", ackSnapshotSyncCycleId,
+            log.info("[{}]:: Notify Snapshot Sync Plugin completion of snapshot sync id={}, baseSnapshot={}", sessionName, ackSnapshotSyncCycleId,
                 lastAppliedBaseSnapshotTimestamp);
-            log.info("Enter onSnapshotSyncEnd :: {}", snapshotSyncPlugin.getClass().getSimpleName());
+            log.info("[{}]:: Enter onSnapshotSyncEnd :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());
             snapshotSyncPlugin.onSnapshotSyncEnd(runtime);
-            log.info("Exit onSnapshotSyncEnd :: {}", snapshotSyncPlugin.getClass().getSimpleName());
+            log.info("[{}]:: Exit onSnapshotSyncEnd :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());
         } else {
-            log.warn("SNAPSHOT_SYNC has completed for {}, but new ongoing SNAPSHOT_SYNC is {}. Id mismatch :: " +
-                    "current_snapshot_cycle_id={}, ack_cycle_id={}", entry.getMetadata().getSnapshotTimestamp(),
+            log.warn("[{}]:: SNAPSHOT_SYNC has completed for {}, but new ongoing SNAPSHOT_SYNC is {}. Id mismatch :: " +
+                    "current_snapshot_cycle_id={}, ack_cycle_id={}", sessionName, entry.getMetadata().getSnapshotTimestamp(),
                     lastAppliedBaseSnapshotTimestamp, latestSnapshotSyncCycleId, ackSnapshotSyncCycleId);
         }
     }
@@ -369,15 +387,15 @@ public class LogReplicationSinkManager implements DataReceiver {
         long messageBaseSnapshot = entry.getMetadata().getSnapshotTimestamp();
         UUID messageSnapshotId = getUUID(entry.getMetadata().getSyncRequestId());
 
-        log.debug("Received snapshot sync start marker with request id {} on base snapshot timestamp {}",
+        log.debug("[{}]:: Received snapshot sync start marker with request id {} on base snapshot timestamp {}", sessionName,
                 entry.getMetadata().getSyncRequestId(), entry.getMetadata().getSnapshotTimestamp());
 
         // Drop out of date messages, that have been resent
         // If no further writes have come into the log, the baseSnapshotTimestamp could be the same,
         // for this reason we should also compare based on the snapshot sync identifier
         if (messageBaseSnapshot <= baseSnapshotTimestamp && messageSnapshotId != null && messageSnapshotId.equals(lastSnapshotSyncId)) {
-            log.warn("Sink Manager, state={} while received message={}. " +
-                            "Dropping message with smaller snapshot timestamp than current {}",
+            log.warn("[{}]:: Sink Manager, state={} while received message={}. " +
+                            "Dropping message with smaller snapshot timestamp than current {}", sessionName,
                     rxState, entry.getMetadata(), baseSnapshotTimestamp);
             return false;
         }
@@ -385,8 +403,8 @@ public class LogReplicationSinkManager implements DataReceiver {
         // Fails to set the baseSnapshot at the metadata store, it could be an out of date message,
         // or the current node is out of sync, ignore it.
        if (!metadataManager.setBaseSnapshotStart(session, topologyConfigId, messageBaseSnapshot)) {
-          log.warn("Sink Manager in state {} and received message {}. " +
-                           "Dropping message due to failure to update the metadata store.", rxState, entry.getMetadata());
+          log.warn("[{}]:: Sink Manager in state {} and received message {}. " +
+                           "Dropping message due to failure to update the metadata store.", sessionName, rxState, entry.getMetadata());
             return false;
        }
 
@@ -414,7 +432,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                 metadataManager.getReplicationMetadata(session).getLastSnapshotTransferredSeqNumber(), this);
         rxState = RxState.SNAPSHOT_SYNC;
 
-        log.info("Sink manager entry {} state, snapshot start with {}", rxState,
+        log.info("[{}]:: Sink manager entry {} state, snapshot start with {}", sessionName, rxState,
                 TextFormat.shortDebugString(entry.getMetadata()));
     }
 
@@ -429,13 +447,13 @@ public class LogReplicationSinkManager implements DataReceiver {
                 try {
                     metadataManager.setSnapshotAppliedComplete(entry, session);
                 } catch (TransactionAbortedException tae) {
-                    log.error("Error while attempting to set SNAPSHOT_SYNC as completed.", tae);
+                    log.error("[{}]:: Error while attempting to set SNAPSHOT_SYNC as completed.", sessionName, tae);
                     throw new RetryNeededException();
                 }
                 return null;
             }).run();
         } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to set SNAPSHOT_SYNC as completed.", e);
+            log.error("[{}]:: Unrecoverable exception when attempting to set SNAPSHOT_SYNC as completed.", sessionName, e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
 
@@ -450,7 +468,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                     .getLastLogEntryBatchProcessed(), this);
         logEntryWriter.reset(entry.getMetadata().getSnapshotTimestamp(), entry.getMetadata().getSnapshotTimestamp());
 
-        log.info("Snapshot apply complete, sync_id={}, snapshot={}, state={}", entry.getMetadata().getSyncRequestId(),
+        log.info("[{}]:: Snapshot apply complete, sync_id={}, snapshot={}, state={}", sessionName, entry.getMetadata().getSyncRequestId(),
                 entry.getMetadata().getSnapshotTimestamp(), rxState);
     }
 
@@ -471,7 +489,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                 }
                 break;
             default:
-                log.warn("Message type {} should not be applied during snapshot sync.", entry.getMetadata().getEntryType());
+                log.warn("[{}]:: Message type {} should not be applied during snapshot sync.", sessionName, entry.getMetadata().getEntryType());
                 break;
         }
     }
@@ -483,7 +501,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                 try {
                     startSnapshotApply(entry);
                 } catch (Exception e) {
-                    log.error("Error while attempting to start snapshot apply.", e);
+                    log.error("[{}]:: Error while attempting to start snapshot apply.", sessionName, e);
                     ongoingApply.set(false);
                 }
             });
@@ -491,7 +509,7 @@ public class LogReplicationSinkManager implements DataReceiver {
     }
 
     private synchronized void startSnapshotApply(LogReplicationEntryMsg entry) {
-        log.info("Start snapshot sync apply, id={}", entry.getMetadata().getSyncRequestId());
+        log.info("[{}]:: Start snapshot sync apply, id={}", sessionName, entry.getMetadata().getSyncRequestId());
         setDataConsistentWithRetry(false);
 
         // Sync with registry after transfer phase to capture local updates, as transfer phase could
@@ -501,7 +519,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         snapshotWriter.startSnapshotSyncApply();
         completeSnapshotApply(entry);
         ongoingApply.set(false);
-        log.debug("Exit start snapshot sync apply, id={}", entry.getMetadata().getSyncRequestId());
+        log.debug("[{}]:: Exit start snapshot sync apply, id={}", sessionName, entry.getMetadata().getSyncRequestId());
     }
 
     private void completeSnapshotTransfer(LogReplicationEntryMsg message) {
@@ -516,7 +534,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      * @return true if msg was processed else false.
      */
     public boolean processMessage(LogReplicationEntryMsg message) {
-        log.trace("Received dataMessage by Sink Manager. Total [{}]", rxMessageCounter);
+        log.trace("[{}]:: Received dataMessage by Sink Manager. Total [{}]", sessionName, rxMessageCounter);
 
         switch (rxState) {
             case LOG_ENTRY_SYNC:
@@ -527,7 +545,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                 return true;
 
             default:
-                log.error("Wrong state {}.", rxState);
+                log.error("[{}]:: Wrong state {}.", sessionName, rxState);
                 return false;
         }
     }
@@ -563,7 +581,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      * */
     public void reset() {
         ReplicationMetadata metadata = metadataManager.getReplicationMetadata(session);
-        log.debug("Reset sink manager, lastAppliedSnapshotTs={}, lastProcessedLogEntryTs={}", metadata.getLastSnapshotApplied(),
+        log.debug("[{}]:: Reset sink manager, lastAppliedSnapshotTs={}, lastProcessedLogEntryTs={}", sessionName, metadata.getLastSnapshotApplied(),
                 metadata.getLastLogEntryBatchProcessed());
         snapshotWriter.reset(topologyConfigId, metadata.getLastSnapshotApplied());
         logEntryWriter.reset(metadata.getLastSnapshotApplied(), metadata.getLastLogEntryBatchProcessed());
@@ -589,7 +607,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         snapshotWriter.reset(topologyConfigId, metadata.getLastSnapshotStarted());
         long snapshotTransferTs = metadata.getLastSnapshotTransferred();
         UUID snapshotSyncId = new UUID(metadata.getCurrentSnapshotCycleId().getMsb(), metadata.getCurrentSnapshotCycleId().getLsb());
-        log.info("Resume Snapshot Sync Apply, snapshot_transfer_ts={}, id={}", snapshotTransferTs, snapshotSyncId);
+        log.info("[{}]:: Resume Snapshot Sync Apply, snapshot_transfer_ts={}, id={}", sessionName, snapshotTransferTs, snapshotSyncId);
 
         // Construct message used to complete (ack) the snapshot sync transfer
         LogReplicationEntryMetadataMsg metadataMsg = LogReplicationEntryMetadataMsg.newBuilder()
@@ -613,20 +631,17 @@ public class LogReplicationSinkManager implements DataReceiver {
         // TODO: check if we'd recover from trim in shadow streams by the protocol itself
         if (rxState == RxState.SNAPSHOT_SYNC) {
             if (snapshotWriter.getPhase() == StreamsSnapshotWriter.Phase.TRANSFER_PHASE) {
-                log.warn("Leadership lost while in TRANSFER phase. Trigger " +
-                    "snapshot sync plugin end, to avoid effects of" +
-                    "delayed restarts of snapshot sync.");
-                log.info("Run onSnapshotSyncEnd :: {}",
-                    snapshotSyncPlugin.getClass().getSimpleName());
+                log.warn("[{}]:: Leadership lost while in TRANSFER phase. Trigger " +
+                    "snapshot sync plugin end, to avoid effects of" + "delayed restarts of snapshot sync.", sessionName);
+                log.info("[{}]:: Run onSnapshotSyncEnd :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());
                 snapshotSyncPlugin.onSnapshotSyncEnd(runtime);
-                log.info("Completed onSnapshotSyncEnd :: {}",
-                    snapshotSyncPlugin.getClass().getSimpleName());
+                log.info("[{}]:: Completed onSnapshotSyncEnd :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());
             } else {
-                log.warn("Leadership lost while in APPLY phase. Note that snapshot sync end plugin might not " +
-                    "have been ran.");
+                log.warn("[{}]:: Leadership lost while in APPLY phase. Note that snapshot sync end plugin might not " +
+                    "have been ran.", sessionName);
             }
         } else {
-            log.info("Leadership lost while in Log Entry Sync State");
+            log.info("[{}]:: Leadership lost while in Log Entry Sync State",sessionName);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -632,7 +632,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         if (rxState == RxState.SNAPSHOT_SYNC) {
             if (snapshotWriter.getPhase() == StreamsSnapshotWriter.Phase.TRANSFER_PHASE) {
                 log.warn("[{}]:: Leadership lost while in TRANSFER phase. Trigger " +
-                    "snapshot sync plugin end, to avoid effects of" + "delayed restarts of snapshot sync.", sessionName);
+                    "snapshot sync plugin end, to avoid effects of delayed restarts of snapshot sync.", sessionName);
                 log.info("[{}]:: Run onSnapshotSyncEnd :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());
                 snapshotSyncPlugin.onSnapshotSyncEnd(runtime);
                 log.info("[{}]:: Completed onSnapshotSyncEnd :: {}", sessionName, snapshotSyncPlugin.getClass().getSimpleName());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
@@ -124,7 +124,7 @@ public abstract class SinkBufferManager {
     public LogReplicationEntryMsg processMsgAndBuffer(LogReplicationEntryMsg dataMessage) {
 
         if (!verifyMessageType(dataMessage)) {
-            log.warn("Received invalid message type {}", dataMessage.getMetadata());
+            log.warn("[{}]:: Received invalid message type {}", sinkManager.getSessionName(), dataMessage.getMetadata());
             return null;
         }
 
@@ -133,14 +133,15 @@ public abstract class SinkBufferManager {
 
         // This message contains entries that haven't been applied yet
         if (preTs <= lastProcessedSeq && currentTs > lastProcessedSeq) {
-            log.debug("Received in order message={}, lastProcessed={}", currentTs, lastProcessedSeq);
+            log.debug("[{}]:: Received in order message={}, lastProcessed={}", sinkManager.getSessionName(), currentTs, lastProcessedSeq);
             if (sinkManager.processMessage(dataMessage)) {
                 ackCnt++;
                 lastProcessedSeq = getCurrentSeq(dataMessage);
             }
             processBuffer();
         } else if (currentTs > lastProcessedSeq && buffer.size() < maxSize) {
-            log.debug("Received unordered message, currentTs={}, lastProcessed={}", currentTs, lastProcessedSeq);
+            log.debug("[{}]:: Received unordered message, currentTs={}, lastProcessed={}", sinkManager.getSessionName(),
+                    currentTs, lastProcessedSeq);
             buffer.put(preTs, dataMessage);
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkWriter.java
@@ -2,6 +2,8 @@ package org.corfudb.infrastructure.logreplication.replication.receive;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import lombok.Generated;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.config.LogReplicationFullTableConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
@@ -34,10 +36,14 @@ public abstract class SinkWriter {
     // Replication context that provides configuration for LR in Source / Sink cluster.
     final LogReplicationContext replicationContext;
 
+    @Getter
+    private final String sessionName;
+
     // Limit the initialization of this class only to its children classes.
     SinkWriter(LogReplicationSession session, LogReplicationContext replicationContext) {
         this.session = session;
         this.replicationContext = replicationContext;
+        this.sessionName = replicationContext.getSessionName(session);
 
         // The CorfuRuntime in LogReplicationConfigManager used to get the config fields from registry
         // table, and the protobufSerializer is guaranteed to be registered before initializing SinkWriter.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
@@ -72,7 +72,7 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
         }
 
         metadata.setSnapshotSyncSeqNum(lastProcessedSeq);
-        log.debug("SnapshotSinkBufferManager send ACK {} for {}",
+        log.debug("[{}]:: SnapshotSinkBufferManager send ACK {} for {}", sinkManager.getSessionName(),
                 lastProcessedSeq, TextFormat.shortDebugString(metadata));
         return metadata.build();
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -139,7 +139,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         if (metadata.getEntryType() != LogReplicationEntryType.SNAPSHOT_MESSAGE ||
                 metadata.getSnapshotTimestamp() != srcGlobalSnapshot ||
                 metadata.getSnapshotSyncSeqNum() != recvSeq) {
-            log.error("Expected snapshot={}, received snapshot={}, expected seq={}, received seq={}",
+            log.error("[{}]:: Expected snapshot={}, received snapshot={}, expected seq={}, received seq={}", getSessionName(),
                     srcGlobalSnapshot, metadata.getSnapshotTimestamp(), metadata.getSnapshotSyncSeqNum(), recvSeq);
             throw new ReplicationWriterException("Snapshot message out of order");
         }
@@ -152,7 +152,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
      * @param snapshot base snapshot timestamp
      */
     public void reset(long topologyId, long snapshot) {
-        log.debug("Reset snapshot writer, snapshot={}, topologyConfigId={}", snapshot, topologyId);
+        log.debug("[{}]:: Reset snapshot writer, snapshot={}, topologyConfigId={}", getSessionName(), snapshot, topologyId);
         topologyConfigId = topologyId;
         srcGlobalSnapshot = snapshot;
         recvSeq = 0;
@@ -176,7 +176,8 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
         try (TxnContext txn = metadataManager.getTxnContext()) {
             updateLog(txn, smrEntries, shadowStreamUuid);
-            metadataManager.updateReplicationMetadataField(txn, session, ReplicationMetadata.LASTSNAPSHOTTRANSFERREDSEQNUMBER_FIELD_NUMBER, currentSeqNum);
+            metadataManager.updateReplicationMetadataField(txn, session,
+                    ReplicationMetadata.LASTSNAPSHOTTRANSFERREDSEQNUMBER_FIELD_NUMBER, currentSeqNum);
             timestamp = txn.commit();
         }
 
@@ -188,7 +189,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
             }
         }
 
-        log.debug("Process entries total={}, set sequence number {}", smrEntries.size(), currentSeqNum);
+        log.debug("[{}]:: Process entries total={}, set sequence number {}", getSessionName(), smrEntries.size(), currentSeqNum);
     }
 
     /**
@@ -204,9 +205,10 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         long persistedSequenceNum = metadata.getLastSnapshotTransferredSeqNumber();
 
         if (topologyConfigId != persistedTopologyConfigId || srcGlobalSnapshot != persistedSnapshotStart) {
-            log.warn("Skip processing opaque entry. Current topologyConfigId={}, srcGlobalSnapshot={}, currentSeqNum={}, " +
-                            "persistedTopologyConfigId={}, persistedSnapshotStart={}, persistedLastSequenceNum={}", topologyConfigId,
-                    srcGlobalSnapshot, recvSeq, persistedTopologyConfigId, persistedSnapshotStart, persistedSequenceNum);
+            log.warn("[{}]:: Skip processing opaque entry. Current topologyConfigId={}, srcGlobalSnapshot={}, currentSeqNum={}, " +
+                            "persistedTopologyConfigId={}, persistedSnapshotStart={}, persistedLastSequenceNum={}",
+                    getSessionName(), topologyConfigId, srcGlobalSnapshot, recvSeq, persistedTopologyConfigId,
+                    persistedSnapshotStart, persistedSequenceNum);
             return;
         }
 
@@ -239,9 +241,10 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
         if (message.getMetadata().getSnapshotSyncSeqNum() != recvSeq ||
                 message.getMetadata().getEntryType() != LogReplicationEntryType.SNAPSHOT_MESSAGE) {
-            log.error("Received {} Expecting snapshot message sequencer number {} != recvSeq {} or wrong message type {} expecting {}",
-                    message.getMetadata(), message.getMetadata().getSnapshotSyncSeqNum(), recvSeq,
-                    message.getMetadata().getEntryType(), LogReplicationEntryType.SNAPSHOT_MESSAGE);
+            log.error("[{}]:: Received {} Expecting snapshot message sequencer number {} != recvSeq {} or " +
+                            "wrong message type {} expecting {}", getSessionName(), message.getMetadata(),
+                    message.getMetadata().getSnapshotSyncSeqNum(), recvSeq, message.getMetadata().getEntryType(),
+                    LogReplicationEntryType.SNAPSHOT_MESSAGE);
             throw new ReplicationWriterException("Message is out of order or wrong type");
         }
 
@@ -249,20 +252,20 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
         // For snapshot message, it has only one opaque entry.
         if (opaqueEntryList.size() > 1) {
-            log.error(" Get {} instead of one opaque entry in Snapshot Message", opaqueEntryList.size());
+            log.error("[{}]::  Get {} instead of one opaque entry in Snapshot Message", getSessionName(), opaqueEntryList.size());
             return;
         }
 
         OpaqueEntry opaqueEntry = opaqueEntryList.get(0);
         if (opaqueEntry.getEntries().keySet().size() != 1) {
-            log.error("The opaqueEntry has more than one entry {}", opaqueEntry);
+            log.error("[{}]:: The opaqueEntry has more than one entry {}", getSessionName(), opaqueEntry);
             return;
         }
         UUID regularStreamId = opaqueEntry.getEntries().keySet().stream().findFirst().get();
 
         if (ignoreEntriesForStream(regularStreamId)) {
-            log.warn("Skip applying log entries for stream {} as it is noisy. Source and Sink are likely to be operating in" +
-                    " different versions", regularStreamId);
+            log.warn("[{}]:: Skip applying log entries for stream {} as it is noisy. Source and Sink are likely to be operating in" +
+                    " different versions", getSessionName(), regularStreamId);
             recvSeq++;
             return;
         }
@@ -296,10 +299,11 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
      * @param snapshot base snapshot timestamp
      */
     private void applyShadowStream(UUID streamId, long snapshot) {
-        log.debug("Apply shadow stream for stream {}, snapshot={}", streamId, snapshot);
+        log.debug("[{}]:: Apply shadow stream for stream {}, snapshot={}", getSessionName(), streamId, snapshot);
 
-        log.trace("Current addresses of stream {} :: {}", streamId, rt.getSequencerView().getStreamAddressSpace(
-            new StreamAddressRange(streamId, Long.MAX_VALUE, Address.NON_ADDRESS)));
+        log.trace("[{}]:: Current addresses of stream {} :: {}", getSessionName(), streamId,
+                rt.getSequencerView().getStreamAddressSpace(
+                        new StreamAddressRange(streamId, Long.MAX_VALUE, Address.NON_ADDRESS)));
 
         UUID shadowStreamId = getShadowStreamId(streamId);
 
@@ -332,7 +336,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         // 2. Streams which did not evidence data on either source or sink
         // as these streams will get trimmed and 'clear' will be a 'data loss'.
         if (MERGE_ONLY_STREAMS.contains(streamId)) {
-            log.debug("Do not clear stream={} (merge stream)", streamId);
+            log.debug("[{}]:: Do not clear stream={} (merge stream)", getSessionName(), streamId);
         }
 
         boolean shouldAddClearRecord = !MERGE_ONLY_STREAMS.contains(streamId);
@@ -350,7 +354,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
         // if clear record has not been added by now, indicates that shadow stream is empty.
         if (shouldAddClearRecord) {
-            log.trace("No data was written to stream {} on source or sink. Do not clear.", streamId);
+            log.trace("[{}]:: No data was written to stream {} on source or sink. Do not clear.", getSessionName(), streamId);
             return;
         }
 
@@ -376,8 +380,8 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
                 try (TxnContext txnContext = metadataManager.getTxnContext()) {
                     updateLog(txnContext, buffer, streamId);
                     CorfuStoreMetadata.Timestamp ts = txnContext.commit();
-                    log.debug("Applied shadow stream partially for stream {} on address :: {}.  {} SMR entries written",
-                        streamId, ts.getSequence(), buffer.size());
+                    log.debug("[{}]:: Applied shadow stream partially for stream {} on address :: {}.  {} SMR entries written",
+                            getSessionName(), streamId, ts.getSequence(), buffer.size());
                     buffer.clear();
                     buffer.add(smrEntry);
                     bufferSize = smrEntry.getSerializedSize();
@@ -394,8 +398,8 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
                 txnContext.commit();
             }
         }
-        log.debug("Completed applying updates to stream {}.  {} entries applied across {} transactions.  ", streamId,
-            smrEntries.size(), numBatches);
+        log.debug("[{}]:: Completed applying updates to stream {}.  {} entries applied across {} transactions.",
+                getSessionName(), streamId, smrEntries.size(), numBatches);
     }
 
     private boolean maxEntriesLimitReached(UUID streamId, List<SMREntry> buffer) {
@@ -407,7 +411,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
      * Read from shadowStream and append/apply to the actual stream
      */
     public void applyShadowStreams() {
-        log.debug("Apply Shadow Streams, total={}", replicatedStreamIds.size());
+        log.debug("[{}]:: Apply Shadow Streams, total={}", getSessionName(), replicatedStreamIds.size());
         long snapshot = rt.getAddressSpaceView().getLogTail();
 
         // Registry table needs to be applied first, as there could be tables that haven't been opened in Sink side,
@@ -453,7 +457,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         long sequenceNumber = metadataManager.getReplicationMetadata(session).getLastSnapshotTransferredSeqNumber();
 
         if (sequenceNumber != Address.NON_ADDRESS) {
-            log.debug("Start applying shadow streams, seqNum={}", sequenceNumber);
+            log.debug("[{}]:: Start applying shadow streams, seqNum={}", getSessionName(), sequenceNumber);
             applyShadowStreams();
 
             // For Routing Queue replication model, write a dummy entry indicating the end of Snapshot sync
@@ -537,8 +541,8 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
             streamsToQuery.add(id);
         }
 
-        log.debug("Total of {} streams were replicated from Source, sequencer query for {} streams, streamsToQuery={}",
-            replicatedStreamIds.size(), streamsToQuery.size(), streamsToQuery);
+        log.debug("[{}]:: Total of {} streams were replicated from Source, sequencer query for {} streams, streamsToQuery={}",
+                getSessionName(), replicatedStreamIds.size(), streamsToQuery.size(), streamsToQuery);
         TokenResponse tokenResponse = rt.getSequencerView().query(
             streamsToQuery.toArray(new UUID[0]));
         Set<UUID> streamsWithLocalWrites = new HashSet<>();
@@ -549,10 +553,10 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         });
 
         if (!streamsWithLocalWrites.isEmpty()) {
-            log.debug("Clear streams with local writes, total={}, streams={}",
-                streamsWithLocalWrites.size(), streamsWithLocalWrites);
+            log.debug("[{}]:: Clear streams with local writes, total={}, streams={}", getSessionName(),
+                    streamsWithLocalWrites.size(), streamsWithLocalWrites);
         } else {
-            log.debug("No local written streams were found, nothing to clear.");
+            log.debug("[{}]:: No local written streams were found, nothing to clear.", getSessionName());
         }
         clearStreams(streamsWithLocalWrites);
     }
@@ -567,15 +571,17 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
                         clearStream(streamId, txnContext);
                     });
                     CorfuStoreMetadata.Timestamp ts = txnContext.commit();
-                    log.trace("Clear {} streams committed at :: {}", streamsToClear.size(), ts.getSequence());
+                    log.trace("[{}]:: Clear {} streams committed at :: {}", getSessionName(), streamsToClear.size(),
+                            ts.getSequence());
                 } catch (TransactionAbortedException tae) {
-                    log.error("Error while attempting to clear locally written streams.", tae);
+                    log.error("[{}]:: Error while attempting to clear locally written streams.", getSessionName(), tae);
                     throw new RetryNeededException();
                 }
                 return null;
             }).run();
         } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to clear locally written streams.", e);
+            log.error("[{}]:: Unrecoverable exception when attempting to clear locally written streams.",
+                    getSessionName(), e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySenderBufferManager.java
@@ -25,8 +25,8 @@ public class LogEntrySenderBufferManager extends SenderBufferManager {
      * Constructor
      * @param dataSender
      */
-    public LogEntrySenderBufferManager(DataSender dataSender, LogReplicationAckReader ackReader) {
-        super(dataSender, configureAcksCounter());
+    public LogEntrySenderBufferManager(DataSender dataSender, LogReplicationAckReader ackReader, String sessionName) {
+        super(dataSender, configureAcksCounter(), sessionName);
         this.ackReader = ackReader;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
@@ -461,15 +461,9 @@ public class LogReplicationAckReader {
      * Start periodic replication status update task (completion percentage)
      */
     public void startSyncStatusUpdatePeriodicTask() {
-<<<<<<< HEAD
-        log.info("Start sync status update periodic task");
-        sessionToAckPollerFuture.put(session, lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0, ACKED_TS_READ_INTERVAL_SECONDS,
-                TimeUnit.SECONDS));
-=======
         log.info("[{}]:: Start sync status update periodic task", sessionName);
         lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0, ACKED_TS_READ_INTERVAL_SECONDS,
                 TimeUnit.SECONDS);
->>>>>>> b351fac91f6 (1. Generate unique name for session)
     }
 
     /**
@@ -490,7 +484,7 @@ public class LogReplicationAckReader {
                         metadataManager.updateRemainingEntriesToSend(session, entriesToSend, lastSyncType);
                     } catch (TransactionAbortedException tae) {
                         log.error("[{}]:: Error while attempting to set remaining entries for remote session {} with " +
-                                "lastSyncType {}.", session, lastSyncType, tae);
+                                "lastSyncType {}.", sessionName, lastSyncType, tae);
                         throw new RetryNeededException();
                     } finally {
                         lock.unlock();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
@@ -64,7 +64,7 @@ public class LogReplicationSourceManager {
         Set<String> streamsToReplicate = replicationContext.getConfig(session).getStreamsToReplicate();
         if (streamsToReplicate == null || streamsToReplicate.isEmpty()) {
             // Avoid FSM being initialized if there are no streams to replicate
-            throw new IllegalArgumentException(sessionName+" Invalid Log Replication: Streams to replicate is EMPTY");
+            throw new IllegalArgumentException(sessionName + " Invalid Log Replication: Streams to replicate is EMPTY");
         }
 
         this.metadataManager = metadataManager;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Executors;
 @Data
 @Slf4j
 public class LogReplicationSourceManager {
-    
+
     @VisibleForTesting
     private final LogReplicationFSM logReplicationFSM;
 
@@ -44,6 +44,8 @@ public class LogReplicationSourceManager {
     private int countACKs = 0;
 
     private ObservableAckMsg ackMessages = new ObservableAckMsg();
+    
+    private final String sessionName;
 
     private boolean isShutdown = false;
 
@@ -57,17 +59,18 @@ public class LogReplicationSourceManager {
     @VisibleForTesting
     public LogReplicationSourceManager(LogReplicationMetadataManager metadataManager, DataSender dataSender,
                                        LogReplicationSession session, LogReplicationContext replicationContext) {
+        this.sessionName = replicationContext.getSessionName(session);
 
         Set<String> streamsToReplicate = replicationContext.getConfig(session).getStreamsToReplicate();
         if (streamsToReplicate == null || streamsToReplicate.isEmpty()) {
             // Avoid FSM being initialized if there are no streams to replicate
-            throw new IllegalArgumentException("Invalid Log Replication: Streams to replicate is EMPTY");
+            throw new IllegalArgumentException(sessionName+" Invalid Log Replication: Streams to replicate is EMPTY");
         }
+
         this.metadataManager = metadataManager;
 
         // Ack Reader for Snapshot and LogEntry Sync
         this.ackReader = new LogReplicationAckReader(this.metadataManager, session, replicationContext);
-
         this.logReplicationFSM = new LogReplicationFSM(dataSender, ackReader, session, replicationContext);
         this.ackReader.setLogEntryReader(this.logReplicationFSM.getLogEntryReader());
         this.ackReader.setLogEntrySender(this.logReplicationFSM.getLogEntrySender());
@@ -85,7 +88,7 @@ public class LogReplicationSourceManager {
     }
 
     private UUID startSnapshotSync(LogReplicationEvent snapshotSyncRequest, boolean forced) {
-        log.info("Start Snapshot Sync, requestId={}, forced={}", snapshotSyncRequest.getEventId(), forced);
+        log.info("[{}]:: Start Snapshot Sync, requestId={}, forced={}", sessionName, snapshotSyncRequest.getEventId(), forced);
         // Enqueue snapshot sync request into Log Replication FSM
         logReplicationFSM.input(snapshotSyncRequest);
         return snapshotSyncRequest.getEventId();
@@ -109,7 +112,7 @@ public class LogReplicationSourceManager {
      */
     public void startReplication(LogReplicationEvent replicationEvent) {
         // Enqueue event into Log Replication FSM
-        log.info("Start replication event {}", replicationEvent);
+        log.info("[{}]:: Start replication event {}", sessionName, replicationEvent);
         logReplicationFSM.input(replicationEvent);
     }
 
@@ -117,7 +120,7 @@ public class LogReplicationSourceManager {
      * Stop Log Replication
      */
     public void stopLogReplication() {
-        log.info("Stop Log Replication");
+        log.info("[{}]:: Stop Log Replication", sessionName);
         logReplicationFSM.input(new LogReplicationEvent(LogReplicationEventType.REPLICATION_STOP));
     }
 
@@ -136,7 +139,7 @@ public class LogReplicationSourceManager {
                 logReplicationEvent.wait();
             }
         } catch (InterruptedException e) {
-            log.error("Caught an exception during source manager shutdown ", e);
+            log.error("[{}]:: Caught an exception during source manager shutdown ", sessionName, e);
         }
 
         log.info("Shutdown Log Replication.");

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -83,7 +83,6 @@ public class SnapshotSender {
 
     private volatile AtomicBoolean stopSnapshotSync = new AtomicBoolean(false);
 
-
     public SnapshotSender(LogReplicationContext replicationContext, SnapshotReader snapshotReader, DataSender dataSender,
                           LogReplicationFSM fsm) {
         this.runtime = replicationContext.getCorfuRuntime();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSenderBufferManager.java
@@ -21,8 +21,8 @@ import java.util.stream.Collectors;
 public class SnapshotSenderBufferManager extends SenderBufferManager {
     private LogReplicationAckReader ackReader;
 
-    public SnapshotSenderBufferManager(DataSender dataSender, LogReplicationAckReader ackReader) {
-        super(dataSender, configureAcksCounter());
+    public SnapshotSenderBufferManager(DataSender dataSender, LogReplicationAckReader ackReader, String sessionName) {
+        super(dataSender, configureAcksCounter(), sessionName);
         this.ackReader = ackReader;
     }
 
@@ -34,7 +34,7 @@ public class SnapshotSenderBufferManager extends SenderBufferManager {
     @Override
     public void updateAck(Long newAck) {
         if (maxAckTimestamp < newAck) {
-            log.debug("Ack Received for Snapshot Sync {}", newAck);
+            log.debug("[{}]:: Ack Received for Snapshot Sync {}", sessionName, newAck);
             maxAckTimestamp = newAck;
             pendingMessages.evictAccordingToSeqNum(maxAckTimestamp);
             pendingCompletableFutureForAcks = pendingCompletableFutureForAcks.entrySet().stream()

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
@@ -73,11 +73,15 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
     protected LogReplication.LogReplicationSession session;
 
     protected LogReplicationContext replicationContext;
+    
+    private final String sessionName;
 
     public BaseLogEntryReader(LogReplication.LogReplicationSession replicationSession,
                               LogReplicationContext replicationContext) {
         CorfuRuntime runtime = replicationContext.getCorfuRuntime();
         this.maxDataSizePerMsg = replicationContext.getConfig(replicationSession).getMaxMsgSize();
+        this.sessionName = replicationContext.getSessionName(replicationSession);
+
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         this.deltaCounter = configureDeltaCounter();
@@ -86,10 +90,9 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
         this.session = replicationSession;
         this.replicationContext = replicationContext;
 
-        log.info("Total of {} streams to replicate at initialization. Streams to replicate={}, Session={}",
-                getStreamUUIDs().size(),
-                replicationContext.getConfig(session).getStreamsToReplicate(),
-                TextFormat.shortDebugString(session));
+        log.info("[{}]:: Total of {} streams to replicate at initialization. Streams to replicate={}",
+                sessionName, getStreamUUIDs().size(),
+                replicationContext.getConfig(session).getStreamsToReplicate());
 
         //create an opaque stream for transaction stream
         modelBasedOpaqueStream = new ModelBasedOpaqueStream(runtime);
@@ -114,8 +117,8 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
 
         preMsgTs = currentMsgTs;
         sequence++;
-        log.trace("Generate a log entry message {} with {} transactions ",
-            TextFormat.shortDebugString(txMessage.getMetadata()), opaqueEntryList.size());
+        log.trace("[{}]:: Generate a log entry message {} with {} transactions ", sessionName,
+                TextFormat.shortDebugString(txMessage.getMetadata()), opaqueEntryList.size());
         return txMessage;
     }
 
@@ -137,7 +140,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
 
         // Sanity Check: discard if transaction stream opaque entry is empty (no streams are present)
         if (txEntryStreamIds.isEmpty()) {
-            log.debug("TX Stream entry[{}] :: EMPTY [ignored]", entry.getVersion());
+            log.debug("[{}]:: TX Stream entry[{}] :: EMPTY [ignored]", sessionName, entry.getVersion());
             return false;
         }
 
@@ -145,20 +148,20 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
         // was initialized. So these streams will be missing from the list of streams to replicate. Check the registry
         // table and add them to the list in that case.
         if (!getStreamUUIDs().containsAll(txEntryStreamIds)) {
-            log.info("There could be additional streams to replicate in tx stream. Checking with registry table.");
+            log.info("[{}]:: There could be additional streams to replicate in tx stream. Checking with registry table.", sessionName);
             replicationContext.refreshConfig(session, false);
             // TODO: Add log message here for the newly found streams when we support incremental refresh.
         }
         // If none of the streams in the transaction entry are specified to be replicated, this is an invalid entry, skip
         if (Collections.disjoint(getStreamUUIDs(), txEntryStreamIds)) {
-            log.trace("TX Stream entry[{}] :: contains none of the streams of interest, streams={} [ignored]",
-                    entry.getVersion(), txEntryStreamIds);
+            log.trace("[{}]:: TX Stream entry[{}] :: contains none of the streams of interest, streams={} [ignored]",
+                    sessionName, entry.getVersion(), txEntryStreamIds);
             return false;
         } else {
             Set<UUID> ignoredTxStreams = txEntryStreamIds.stream().filter(id -> !getStreamUUIDs().contains(id))
                 .collect(Collectors.toSet());
             txEntryStreamIds.removeAll(ignoredTxStreams);
-            log.debug("TX Stream entry[{}] :: replicate[{}]={}, ignore[{}]={} [valid]", entry.getVersion(),
+            log.debug("[{}]:: TX Stream entry[{}] :: replicate[{}]={}, ignore[{}]={} [valid]", sessionName, entry.getVersion(),
                 txEntryStreamIds.size(), txEntryStreamIds, ignoredTxStreams.size(), ignoredTxStreams);
             return true;
         }
@@ -167,7 +170,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
     public void setGlobalBaseSnapshot(long snapshot, long ackTimestamp) {
         globalBaseSnapshot = snapshot;
         preMsgTs = Math.max(snapshot, ackTimestamp);
-        log.info("snapshot {} ackTimestamp {} preMsgTs {} seek {}", snapshot, ackTimestamp, preMsgTs, preMsgTs + 1);
+        log.info("[{}]:: snapshot {} ackTimestamp {} preMsgTs {} seek {}", sessionName, snapshot, ackTimestamp, preMsgTs, preMsgTs + 1);
         modelBasedOpaqueStream.seek(preMsgTs + 1);
         sequence = 0;
     }
@@ -221,8 +224,8 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
                         lastOpaqueEntryValid);
             }
 
-            log.trace("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
-                currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
+            log.trace("[{}]:: Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
+                    sessionName, currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
             final double currentMsgSizeSnapshot = currentMsgSize;
 
             messageSizeDistributionSummary.ifPresent(distribution -> distribution.record(currentMsgSizeSnapshot));
@@ -238,7 +241,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
             return txMessage;
 
         } catch (Exception e) {
-            log.warn("Caught an exception while reading transaction stream", e);
+            log.warn("[{}]:: Caught an exception while reading transaction stream", sessionName, e);
             throw e;
         }
     }
@@ -324,7 +327,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
          * @param snapshot
          */
         private void streamUpTo(long snapshot) {
-            log.trace("StreamUpTo {}", snapshot);
+            log.trace("[{}]:: StreamUpTo {}", sessionName, snapshot);
             iterator = opaqueStream.streamUpTo(snapshot).iterator();
         }
 
@@ -354,7 +357,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
             }
 
             OpaqueEntry opaqueEntry = (OpaqueEntry) iterator.next();
-            log.trace("Address {} OpaqueEntry {}", opaqueEntry.getVersion(), opaqueEntry);
+            log.trace("[{}]:: Address {} OpaqueEntry {}", sessionName, opaqueEntry.getVersion(), opaqueEntry);
             return opaqueEntry;
         }
 
@@ -365,7 +368,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
          * @param firstAddress
          */
         public void seek(long firstAddress) {
-            log.trace("seek head {}", firstAddress);
+            log.trace("[{}]:: seek head {}", sessionName, firstAddress);
             opaqueStream.seek(firstAddress);
             streamUpTo();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -184,7 +184,7 @@ public class CorfuLogReplicationRuntime {
         states.put(LogReplicationRuntimeStateType.NEGOTIATING, new NegotiatingState(this, router, metadataManager));
         states.put(LogReplicationRuntimeStateType.REPLICATING, new ReplicatingState(this, sourceManager, router));
         states.put(LogReplicationRuntimeStateType.STOPPED, new StoppedState(sourceManager));
-        states.put(LogReplicationRuntimeStateType.UNRECOVERABLE, new UnrecoverableState(getSessionName()));
+        states.put(LogReplicationRuntimeStateType.UNRECOVERABLE, new UnrecoverableState(sessionName));
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -144,6 +144,9 @@ public class CorfuLogReplicationRuntime {
     private final FsmTaskManager taskManager;
 
 
+    @Getter
+    private final String sessionName;
+
     /**
      * Default Constructor
      */
@@ -151,6 +154,7 @@ public class CorfuLogReplicationRuntime {
                                       LogReplicationContext replicationContext, LogReplicationClientServerRouter router) {
         this.remoteClusterId = session.getSinkClusterId();
         this.session = session;
+        this.sessionName = replicationContext.getSessionName(session);
         this.router = router;
         this.sourceManager = new LogReplicationSourceManager(router, metadataManager,
                 session, replicationContext);
@@ -163,7 +167,7 @@ public class CorfuLogReplicationRuntime {
         initializeStates(metadataManager);
         this.state = states.get(LogReplicationRuntimeStateType.WAITING_FOR_CONNECTIVITY);
 
-        log.info("Log Replication Runtime State Machine initialized");
+        log.info("[{}]:: Log Replication Runtime State Machine initialized", sessionName);
     }
 
     /**
@@ -180,7 +184,7 @@ public class CorfuLogReplicationRuntime {
         states.put(LogReplicationRuntimeStateType.NEGOTIATING, new NegotiatingState(this, router, metadataManager));
         states.put(LogReplicationRuntimeStateType.REPLICATING, new ReplicatingState(this, sourceManager, router));
         states.put(LogReplicationRuntimeStateType.STOPPED, new StoppedState(sourceManager));
-        states.put(LogReplicationRuntimeStateType.UNRECOVERABLE, new UnrecoverableState());
+        states.put(LogReplicationRuntimeStateType.UNRECOVERABLE, new UnrecoverableState(getSessionName()));
     }
 
     /**
@@ -206,7 +210,7 @@ public class CorfuLogReplicationRuntime {
      * @param to   final state
      */
     public void transition(LogReplicationRuntimeState from, LogReplicationRuntimeState to) {
-        log.trace("Transition from {} to {}", from, to);
+        log.trace("[{}]:: Transition from {} to {}", sessionName, from, to);
         from.onExit(to);
         to.clear();
         to.onEntry(from);
@@ -221,17 +225,17 @@ public class CorfuLogReplicationRuntime {
     }
 
     public synchronized void setRemoteLeaderNodeId(String leaderId) {
-        log.debug("Set remote leader node id {}", leaderId);
+        log.debug("[{}]:: Set remote leader node id {}", sessionName, leaderId);
         leaderNodeId = Optional.ofNullable(leaderId);
     }
 
     public synchronized void resetRemoteLeaderNodeId() {
-        log.debug("Reset remote leader node id");
+        log.debug("[{}]:: Reset remote leader node id", sessionName);
         leaderNodeId = Optional.empty();
     }
 
     public synchronized Optional<String> getRemoteLeaderNodeId() {
-        log.trace("Retrieve remote leader node id {}", leaderNodeId);
+        log.trace("[{}]:: Retrieve remote leader node id {}", sessionName, leaderNodeId);
         return leaderNodeId;
     }
 
@@ -240,7 +244,7 @@ public class CorfuLogReplicationRuntime {
     }
 
     public synchronized void refresh(ClusterDescriptor clusterDescriptor, long topologyConfigId) {
-        log.warn("Update router's cluster descriptor {}", clusterDescriptor);
+        log.warn("[{}]:: Update router's cluster descriptor {}", sessionName, clusterDescriptor);
         router.onClusterChange(clusterDescriptor);
         sourceManager.getLogReplicationFSM().setTopologyConfigId(topologyConfigId);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -182,6 +182,7 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
     @Getter
     private Set<LogReplicationSession> connectedSessions = ConcurrentHashMap.newKeySet();
 
+    @Getter
     private LogReplicationContext replicationContext;
 
 
@@ -230,13 +231,14 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
                                             Set<LogReplicationSession> outgoingSession,
                                             LogReplicationServer msgHandler,
                                             IClientChannelAdapter clientChannelAdapter,
-                                            IServerChannelAdapter serverChannelAdapter) {
+                                            IServerChannelAdapter serverChannelAdapter, LogReplicationContext replicationContext) {
         this.timeoutResponse = timeout;
         this.localClusterId = localClusterId;
         this.localNodeId = localNodeId;
         this.incomingSession = incomingSession;
         this.outgoingSession = outgoingSession;
         this.msgHandler = msgHandler;
+        this.replicationContext = replicationContext;
 
         this.sessionToRemoteClusterDescriptor = new ConcurrentHashMap<>();
         this.sessionToRequestIdCounter = new ConcurrentHashMap<>();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -650,6 +650,7 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
             msgHandler.handleMessage(message, null, this);
         } catch (Throwable t) {
             log.error("[{}]:: channelRead: Handling {} failed due to {}:{}",
+                    sessionName,
                     message.getPayload().getPayloadCase(),
                     t.getClass().getSimpleName(),
                     t.getMessage(),

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/IllegalRuntimeTransitionException.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/IllegalRuntimeTransitionException.java
@@ -6,7 +6,7 @@ package org.corfudb.infrastructure.logreplication.runtime.fsm;
  *
  * @author annym
  */
-public class IllegalTransitionException extends Exception {
+public class IllegalRuntimeTransitionException extends Exception {
 
     /**
      * Constructor
@@ -14,7 +14,7 @@ public class IllegalTransitionException extends Exception {
      * @param event     incoming lock event
      * @param stateType current state type
      */
-    public IllegalTransitionException(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType event, LogReplicationRuntimeStateType stateType) {
+    public IllegalRuntimeTransitionException(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType event, LogReplicationRuntimeStateType stateType) {
         super(String.format("Illegal transition for event %s while in state %s", event, stateType));
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
@@ -28,19 +28,19 @@ public class LogReplicationFsmUtil {
      * If no leader is found, the verification will be attempted for LEADERSHIP_RETRIES times.
      */
     public static synchronized <T> void verifyRemoteLeader(Object fsm, Set<String> connectedNodes, String remoteClusterId,
-                                     LogReplicationClientServerRouter router, Class<T> clazz) {
-        log.debug("Enter :: leadership verification");
+                                     LogReplicationClientServerRouter router, Class<T> clazz, String sessionName) {
+        log.debug("[{}]:: Enter :: leadership verification", sessionName);
 
         String leader = "";
 
         Map<String, CompletableFuture<LogReplication.LogReplicationLeadershipResponseMsg>> pendingLeadershipQueries = new HashMap<>();
 
         // Verify leadership on remote cluster, only if no leader is currently selected.
-        log.debug("Verify leader on remote cluster {}", remoteClusterId);
+        log.debug("[{}]:: Verify leader on remote cluster {}", sessionName, remoteClusterId);
 
         try {
             for (String nodeId : connectedNodes) {
-                log.debug("Verify leadership status for node {}", nodeId);
+                log.debug("[{}]:: Verify leadership status for node {}", sessionName, nodeId);
                 // Check Leadership
                 CorfuMessage.RequestPayloadMsg payload =
                         CorfuMessage.RequestPayloadMsg.newBuilder().setLrLeadershipQuery(
@@ -62,7 +62,7 @@ public class LogReplicationFsmUtil {
                                 .get(CorfuLogReplicationRuntime.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
 
                 if (leadershipResponse.getIsLeader()) {
-                    log.info("Received Leadership Response :: leader for remote cluster, node={}", leadershipResponse.getNodeId());
+                    log.info("[{}]:: Received Leadership Response :: leader for remote cluster, node={}", sessionName, leadershipResponse.getNodeId());
                     leader = leadershipResponse.getNodeId();
                     clazz.getMethod("setRemoteLeaderNodeId",String.class).invoke(fsm, leader);
 
@@ -72,10 +72,10 @@ public class LogReplicationFsmUtil {
                     // A new leader has been found, start negotiation, to determine log replication
                     // continuation or start point
                     enqueueLeaderFound(fsm, clazz, leader);
-                    log.debug("Exit :: leadership verification");
+                    log.debug("[{}]:: Exit :: leadership verification", sessionName);
                     return;
                 } else {
-                    log.debug("Received Leadership Response :: node {} is not the leader", leadershipResponse.getNodeId());
+                    log.debug("[{}]:: Received Leadership Response :: node {} is not the leader", sessionName, leadershipResponse.getNodeId());
 
                     // Remove CF for completed request
                     pendingLeadershipQueries.remove(leadershipResponse.getNodeId());
@@ -88,14 +88,14 @@ public class LogReplicationFsmUtil {
         } catch (Exception ex) {
             try {
                 enqueueLeaderNotFound(fsm, clazz, leader);
-                log.warn("Exception caught while verifying remote leader.", ex);
+                log.warn("[{}]:: Exception caught while verifying remote leader.", sessionName, ex);
             } catch (Exception e) {
                 // The FSM will not move ahead if enqueuing events were unsuccessful.
-                log.warn("Exception caught while attempting to enqueue REMOTE_LEADER_NOT_FOUND event.", ex);
+                log.warn("[{}]:: Exception caught while attempting to enqueue REMOTE_LEADER_NOT_FOUND event.", sessionName, ex);
             }
         }
 
-        log.debug("Exit :: leadership verification");
+        log.debug("[{}]:: Exit :: leadership verification", sessionName);
     }
 
     private static <T> void enqueueLeaderFound(Object fsm, Class<T> clazz, String leader) throws NoSuchMethodException,
@@ -156,12 +156,12 @@ public class LogReplicationFsmUtil {
      */
     private static boolean sendLeadershipLossRequestMsg(LogReplicationClientServerRouter router, CorfuLogReplicationRuntime fsm) {
         if(fsm.getReplicationContext().getIsLeader().get()) {
-            log.debug("the local node acquired the leadership. Stop sending Leadership_loss msg");
+            log.debug("[{}]:: the local node acquired the leadership. Stop sending Leadership_loss msg", fsm.getSessionName());
             // do not transition to another state
             return false;
         }
         try {
-            log.debug("Sending LEADERSHIP_LOSS msg for session {}", fsm.getSession());
+            log.debug("[{}]:: Sending LEADERSHIP_LOSS msg", fsm.getSessionName());
             CompletableFuture<LogReplication.LogReplicationMetadataResponseMsg> cf = router
                     .sendRequestAndGetCompletable(fsm.session,
                             getLeadershipLossRequestPayloadMsg(router.getLocalNodeId()),
@@ -169,13 +169,13 @@ public class LogReplicationFsmUtil {
             cf.get(CorfuLogReplicationRuntime.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
             return true;
         } catch(TimeoutException | ExecutionException | InterruptedException ex) {
-            log.error("Retry sending leadership loss msg until an ACK is received ", ex);
+            log.error("[{}]:: Retry sending leadership loss msg until an ACK is received ", fsm.getSessionName(), ex);
             fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.LOCAL_LEADER_LOSS,
                     false));
         } catch (Exception ex) {
             // error occurring due to transport/network layer failure can be ignored as the remote will be notified. The
             // remote will then initiate a new connection. In this case, its safe to transition FSM to STOPPED state
-            log.error("Sending leadership loss msg failed. Transitioning the FSM to STOPPED state. ", ex);
+            log.error("[{}]:: Sending leadership loss msg failed. Transitioning the FSM to STOPPED state. ", fsm.getSessionName(), ex);
             return true;
         }
         return false;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationRuntimeState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationRuntimeState.java
@@ -19,7 +19,7 @@ public interface LogReplicationRuntimeState {
      *
      * @return next LogReplicationState to transition to.
      */
-    LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalTransitionException;
+    LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalRuntimeTransitionException;
 
     /**
      * On Entry

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -53,7 +53,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
     }
 
     @Override
-    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalTransitionException {
+    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalRuntimeTransitionException {
         switch (event.getType()) {
             case ON_CONNECTION_DOWN:
                 String nodeIdDown = event.getNodeId();
@@ -97,7 +97,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 return fsm.getStates().get(LogReplicationRuntimeStateType.UNRECOVERABLE);
             default: {
                 log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
-                throw new IllegalTransitionException(event.getType(), getType());
+                throw new IllegalRuntimeTransitionException(event.getType(), getType());
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -73,7 +73,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 fsm.updateConnectedNodes(event.getNodeId());
                 return null;
             case NEGOTIATION_COMPLETE:
-                log.info("Negotiation complete, result={}", event.getNegotiationResult());
+                log.info("[{}]:: Negotiation complete, result={}", fsm.getSessionName(), event.getNegotiationResult());
                 ((ReplicatingState)fsm.getStates().get(LogReplicationRuntimeStateType.REPLICATING)).setReplicationEvent(event.getNegotiationResult());
                 return fsm.getStates().get(LogReplicationRuntimeStateType.REPLICATING);
             case NEGOTIATION_FAILED:
@@ -96,7 +96,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 ((UnrecoverableState)fsm.getStates().get(LogReplicationRuntimeStateType.UNRECOVERABLE)).setThrowableCause(event.getT().getCause());
                 return fsm.getStates().get(LogReplicationRuntimeStateType.UNRECOVERABLE);
             default: {
-                log.warn("Unexpected communication event {} when in init state.", event.getType());
+                log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());
             }
         }
@@ -104,13 +104,13 @@ public class NegotiatingState implements LogReplicationRuntimeState {
 
     @Override
     public void onEntry(LogReplicationRuntimeState from) {
-        log.debug("OnEntry :: negotiating state from {}", from.getType());
+        log.debug("[{}]:: OnEntry :: negotiating state from {}", fsm.getSessionName(), from.getType());
         negotiate();
     }
 
     private void negotiate() {
 
-        log.debug("Enter :: negotiate");
+        log.debug("[{}]:: Enter :: negotiate", fsm.getSessionName());
 
         try {
             if(fsm.getRemoteLeaderNodeId().isPresent()) {
@@ -133,18 +133,18 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                     router.getSessionToLeaderConnectionFuture().get(fsm.getSession()).complete(null);
                 }
             } else {
-                log.debug("No leader found during negotiation.");
+                log.debug("[{}]:: No leader found during negotiation.", fsm.getSessionName());
                 // No leader found at the time of negotiation
                 fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS));
             }
         } catch (LogReplicationNegotiationException | TimeoutException ex) {
-            log.error("Negotiation failed. Retry, until negotiation succeeds or connection is marked as down.", ex);
+            log.error("[{}]:: Negotiation failed. Retry, until negotiation succeeds or connection is marked as down.", fsm.getSessionName(), ex);
             fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_FAILED));
         } catch (Exception e) {
-            log.error("Unexpected exception during negotiation, retry.", e);
+            log.error("[{}]:: Unexpected exception during negotiation, retry.", fsm.getSessionName(), e);
             fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_FAILED));
         } finally {
-            log.debug("Exit :: negotiate");
+            log.debug("[{}]:: Exit :: negotiate", fsm.getSessionName());
         }
     }
 
@@ -168,7 +168,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
     private void processNegotiationResponse(LogReplicationMetadataResponseMsg negotiationResponse)
             throws LogReplicationNegotiationException {
 
-        log.debug("Process negotiation response {} from {}", negotiationResponse, fsm.getRemoteClusterId());
+        log.debug("[{}]:: Process negotiation response {} from {}", fsm.getSessionName(), negotiationResponse, fsm.getRemoteClusterId());
 
         long topologyConfigId = metadataManager.getReplicationContext().getTopologyConfigId();
 
@@ -177,8 +177,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
          * getting a new notification of the site config change if this sink is in the new config.
          */
         if (negotiationResponse.getTopologyConfigID() < topologyConfigId) {
-            log.error("The source site configID {} is bigger than the sink configID {} ",
-                topologyConfigId, negotiationResponse.getTopologyConfigID());
+            log.error("[{}]:: The source site configID {} is bigger than the sink configID {} ", fsm.getSessionName(),
+                    topologyConfigId, negotiationResponse.getTopologyConfigID());
             throw new LogReplicationNegotiationException("Mismatch of configID");
         }
 
@@ -187,8 +187,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
          * it will be triggered by a notification of the site config change.
          */
         if (negotiationResponse.getTopologyConfigID() > topologyConfigId) {
-            log.error("The source site configID {} is smaller than the sink configID {} ",
-                topologyConfigId, negotiationResponse.getTopologyConfigID());
+            log.error("[{}]:: The source site configID {} is smaller than the sink configID {} ", fsm.getSessionName(),
+                    topologyConfigId, negotiationResponse.getTopologyConfigID());
             throw new LogReplicationNegotiationException("Mismatch of configID");
         }
 
@@ -209,7 +209,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
          * "lastLogEntryProcessed": "-1"
          */
         if (negotiationResponse.getSnapshotStart() == Address.NON_ADDRESS) {
-            log.info("No snapshot available in remote. Initiate SNAPSHOT sync to {}", fsm.getSession());
+            log.info("[{}]:: No snapshot available in remote. Initiate SNAPSHOT sync", fsm.getSessionName());
             startSnapshotSync();
             return;
         }
@@ -226,8 +226,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
          * "lastLogEntryProcessed": "-1"
          */
         if (negotiationResponse.getSnapshotStart() > negotiationResponse.getSnapshotTransferred()) {
-            log.info("Previous Snapshot Sync transfer did not complete. Restart SNAPSHOT sync, snapshotStart={}, snapshotTransferred={}",
-                    negotiationResponse.getSnapshotStart(), negotiationResponse.getSnapshotTransferred());
+            log.info("[{}]:: Previous Snapshot Sync transfer did not complete. Restart SNAPSHOT sync, snapshotStart={}, snapshotTransferred={}",
+                    fsm.getSessionName(), negotiationResponse.getSnapshotStart(), negotiationResponse.getSnapshotTransferred());
             startSnapshotSync();
             return;
         }
@@ -248,8 +248,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
          */
         if (negotiationResponse.getSnapshotStart() == negotiationResponse.getSnapshotTransferred() &&
                 negotiationResponse.getSnapshotTransferred() > negotiationResponse.getSnapshotApplied()) {
-            log.info("Previous Snapshot Sync transfer complete. Apply in progress, wait. snapshotStart={}, " +
-                            "snapshotTransferred={}, snapshotApply={}", negotiationResponse.getSnapshotStart(),
+            log.info("[{}]:: Previous Snapshot Sync transfer complete. Apply in progress, wait. snapshotStart={}, " +
+                            "snapshotTransferred={}, snapshotApply={}", fsm.getSessionName(), negotiationResponse.getSnapshotStart(),
                     negotiationResponse.getSnapshotTransferred(), negotiationResponse.getSnapshotApplied());
             fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                     new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE,
@@ -279,8 +279,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
              * otherwise, start snapshot full sync.
              */
             if (logHead <= negotiationResponse.getLastLogEntryTimestamp() + 1) {
-                log.info("Resume LOG ENTRY sync. Address space has not been trimmed, deltas are guaranteed to be available. " +
-                        "logHead={}, lastLogProcessed={}", logHead, negotiationResponse.getLastLogEntryTimestamp());
+                log.info("[{}]:: Resume LOG ENTRY sync. Address space has not been trimmed, deltas are guaranteed to be available. " +
+                        "logHead={}, lastLogProcessed={}", fsm.getSessionName(), logHead, negotiationResponse.getLastLogEntryTimestamp());
                 fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                         new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST,
                                 new LogReplicationEventMetadata(LogReplicationEventMetadata.getNIL_UUID(),
@@ -292,8 +292,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 //  the stream to replicate). So we might be doing a Snapshot (full) sync when next entry really
                 //  falls beyond the logHead. A more accurate approach would be to look for the next available entry
                 //  in the the transaction stream.
-                log.info(" Start SNAPSHOT sync. LOG ENTRY Sync cannot resume, address space has been trimmed." +
-                        "logHead={}, lastLogProcessed={}", logHead, negotiationResponse.getLastLogEntryTimestamp());
+                log.info("[{}]::  Start SNAPSHOT sync. LOG ENTRY Sync cannot resume, address space has been trimmed." +
+                        "logHead={}, lastLogProcessed={}", fsm.getSessionName(), logHead, negotiationResponse.getLastLogEntryTimestamp());
                 startSnapshotSync();
             }
 
@@ -305,8 +305,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
         /*
          * For other scenarios, the sink site is in a non-recognizable state, trigger a snapshot full sync.
          */
-        log.warn("Could not recognize the sink cluster state according to the response {}, will restart with a snapshot full sync event" ,
-                negotiationResponse);
+        log.warn("[{}]:: Could not recognize the sink cluster state according to the response {}, will restart with a snapshot full sync event" ,
+                fsm.getSessionName(), negotiationResponse);
         fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                 new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -38,7 +38,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
     }
 
     @Override
-    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalTransitionException {
+    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalRuntimeTransitionException {
         switch (event.getType()) {
             case ON_CONNECTION_DOWN:
                 String nodeIdDown = event.getNodeId();
@@ -77,7 +77,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 return null;
             default: {
                 log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
-                throw new IllegalTransitionException(event.getType(), getType());
+                throw new IllegalRuntimeTransitionException(event.getType(), getType());
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -47,7 +47,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
 
                 // If the leader is the node that became unavailable, verify new leader and attempt to reconnect.
                 if (fsm.getRemoteLeaderNodeId().isPresent() && fsm.getRemoteLeaderNodeId().get().equals(nodeIdDown)) {
-                    log.warn("Connection to remote leader id={} is down. Attempt to reconnect ONLY if connection starter.", nodeIdDown);
+                    log.warn("[{}]:: Connection to remote leader id={} is down. Attempt to reconnect ONLY if connection starter.", fsm.getSessionName(), nodeIdDown);
                     fsm.resetRemoteLeaderNodeId();
                     // If remaining connections verify leadership on connected endpoints, otherwise, return to init
                     // state, until a connection is available.
@@ -55,12 +55,12 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                             fsm.getStates().get(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER);
                 }
 
-                log.debug("Connection lost to non-leader node {}", nodeIdDown);
+                log.debug("[{}]:: Connection lost to non-leader node {}", fsm.getSessionName(), nodeIdDown);
                 // If a non-leader node loses connectivity, reconnect async and continue.
                 return null;
             case REMOTE_LEADER_LOSS:
                 if (fsm.getRemoteLeaderNodeId().get().equals(event.getNodeId())) {
-                    log.warn("Remote node {} lost leadership, stop replication & discover new leader.", event.getNodeId());
+                    log.warn("[{}]:: Remote node {} lost leadership, stop replication & discover new leader.", fsm.getSessionName(), event.getNodeId());
                     fsm.resetRemoteLeaderNodeId();
                     replicationSourceManager.stopLogReplication();
                     return fsm.getStates().get(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER);
@@ -76,7 +76,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 }
                 return null;
             default: {
-                log.warn("Unexpected communication event {} when in init state.", event.getType());
+                log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());
             }
         }
@@ -88,29 +88,29 @@ public class ReplicatingState implements LogReplicationRuntimeState {
         switch (replicationEvent.getType()) {
             case SNAPSHOT_SYNC_REQUEST:
                 UUID snapshotSyncRequestId = replicationSourceManager.startSnapshotSync();
-                log.trace("Start Snapshot Sync[{}]", snapshotSyncRequestId);
+                log.trace("[{}]:: Start Snapshot Sync[{}]", fsm.getSessionName(), snapshotSyncRequestId);
                 break;
             case SNAPSHOT_TRANSFER_COMPLETE:
                 replicationSourceManager.resumeSnapshotSync(replicationEvent.getMetadata());
-                log.trace("Wait Snapshot Sync to complete, request={}", replicationEvent.getMetadata().getRequestId());
+                log.trace("[{}]:: Wait Snapshot Sync to complete, request={}", fsm.getSessionName(), replicationEvent.getMetadata().getRequestId());
                 break;
             case LOG_ENTRY_SYNC_REQUEST:
                 replicationSourceManager.startReplication(replicationEvent);
-                log.trace("Start Log Entry Sync Replication");
+                log.trace("[{}]:: Start Log Entry Sync Replication", fsm.getSessionName());
                 break;
             default:
-                log.info("Invalid Negotiation result. Re-trigger discovery.");
+                log.info("[{}]:: Invalid Negotiation result. Re-trigger discovery.", fsm.getSessionName());
                 break;
         }
     }
 
     @Override
     public void onExit(LogReplicationRuntimeState to) {
-        log.debug("Transition to {} from replicating state.", to.getType());
+        log.debug("[{}]:: Transition to {} from replicating state.", fsm.getSessionName(), to.getType());
         switch (to.getType()) {
             case VERIFYING_REMOTE_LEADER:
             case WAITING_FOR_CONNECTIVITY:
-                log.debug("onExit :: transition to {} state", to.getType());
+                log.debug("[{}]:: onExit :: transition to {} state", fsm.getSessionName(), to.getType());
                 replicationSourceManager.stopLogReplication();
                 break;
             default:

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/UnrecoverableState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/UnrecoverableState.java
@@ -12,7 +12,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class UnrecoverableState implements LogReplicationRuntimeState {
 
-    public UnrecoverableState() {}
+    private String sessionName;
+    public UnrecoverableState(String sessionName) {
+        this.sessionName = sessionName;
+    }
 
     @Override
     public LogReplicationRuntimeStateType getType() {
@@ -25,7 +28,7 @@ public class UnrecoverableState implements LogReplicationRuntimeState {
             case ERROR:
                 return this;
             default: {
-                log.warn("Unexpected communication event {} when in init state.", event.getType());
+                log.warn("[{}]:: Unexpected communication event {} when in init state.", sessionName, event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());
             }
         }
@@ -42,6 +45,6 @@ public class UnrecoverableState implements LogReplicationRuntimeState {
      * @param cause
      */
     public void setThrowableCause(Throwable cause) {
-        log.error("Log Replication will NOT continue. Entered UNRECOVERABLE state, cause={}", cause);
+        log.error("[{}]:: Log Replication will NOT continue. Entered UNRECOVERABLE state, cause={}", sessionName, cause);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/UnrecoverableState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/UnrecoverableState.java
@@ -23,13 +23,13 @@ public class UnrecoverableState implements LogReplicationRuntimeState {
     }
 
     @Override
-    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalTransitionException {
+    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalRuntimeTransitionException {
         switch (event.getType()) {
             case ERROR:
                 return this;
             default: {
                 log.warn("[{}]:: Unexpected communication event {} when in init state.", sessionName, event.getType());
-                throw new IllegalTransitionException(event.getType(), getType());
+                throw new IllegalRuntimeTransitionException(event.getType(), getType());
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
@@ -39,7 +39,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
                 return fsm.getStates().get(LogReplicationRuntimeStateType.NEGOTIATING);
             case ON_CONNECTION_DOWN:
                 String nodeIdDown = event.getNodeId();
-                log.debug("Detected connection down from node={}", nodeIdDown);
+                log.debug("[{}]:: Detected connection down from node={}", fsm.getSessionName(), nodeIdDown);
                 fsm.updateDisconnectedNodes(nodeIdDown);
 
                 // If no connection exists, return to init state, until a connection is established.
@@ -50,7 +50,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
             case REMOTE_LEADER_NOT_FOUND:
                 return this;
             case ON_CONNECTION_UP:
-                log.debug("Detected connection up from endpoint={}", event.getNodeId());
+                log.debug("[{}]:: Detected connection up from endpoint={}", fsm.getSessionName(), event.getNodeId());
                 // Add new connected node, for leadership verification
                 fsm.updateConnectedNodes(event.getNodeId());
                 return this;
@@ -60,7 +60,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
                 }
                 return null;
             default: {
-                log.warn("Unexpected communication event {} when in init state.", event.getType());
+                log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());
             }
         }
@@ -68,7 +68,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
 
     @Override
     public void onEntry(LogReplicationRuntimeState from) {
-        log.debug("onEntry :: Verifying Remote Leader, transition from {}", from.getType());
+        log.debug("[{}]:: onEntry :: Verifying Remote Leader, transition from {}", fsm.getSessionName(), from.getType());
 
         // Proceed if remoteLeader is known. Only if local is connection starter for the session and the remoteLeader is
         // not known, verify Leadership on connected nodes
@@ -77,11 +77,11 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
                     LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_FOUND,
                     fsm.getRemoteLeaderNodeId().get())
             );
-            log.debug("Exit :: leadership verification");
+            log.debug("[{}]:: Exit :: leadership verification", fsm.getSessionName());
         } else if (router.isConnectionStarterForSession(fsm.session)){
             // Leadership verification is done only if connection starter.
             verifyRemoteLeader(fsm, fsm.getConnectedNodes(), fsm.getRemoteClusterId(), router,
-                    CorfuLogReplicationRuntime.class);
+                    CorfuLogReplicationRuntime.class, fsm.getSessionName());
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteSinkLeaderState.java
@@ -32,7 +32,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
     }
 
     @Override
-    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalTransitionException {
+    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalRuntimeTransitionException {
         switch (event.getType()) {
             case REMOTE_LEADER_FOUND:
                 ((NegotiatingState)fsm.getStates().get(LogReplicationRuntimeStateType.NEGOTIATING)).setLeaderNodeId(event.getNodeId());
@@ -61,7 +61,7 @@ public class VerifyingRemoteSinkLeaderState implements LogReplicationRuntimeStat
                 return null;
             default: {
                 log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
-                throw new IllegalTransitionException(event.getType(), getType());
+                throw new IllegalRuntimeTransitionException(event.getType(), getType());
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/WaitingForConnectionsState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/WaitingForConnectionsState.java
@@ -26,14 +26,14 @@ public class WaitingForConnectionsState implements LogReplicationRuntimeState {
     public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalTransitionException {
         switch (event.getType()) {
             case ON_CONNECTION_UP:
-                log.info("On connection up, event={}", event);
+                log.info("[{}]:: On connection up, event={}", fsm.getSessionName(), event);
                 // Set Connected Endpoint for event transition.
                 fsm.updateConnectedNodes(event.getNodeId());
                 return fsm.getStates().get(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER);
             case LOCAL_LEADER_LOSS:
                 return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
             default: {
-                log.warn("Unexpected communication event {} when in init state.", event.getType());
+                log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
                 throw new IllegalTransitionException(event.getType(), getType());
             }
         }
@@ -42,6 +42,6 @@ public class WaitingForConnectionsState implements LogReplicationRuntimeState {
     @Override
     public void onEntry(LogReplicationRuntimeState from) {
         // Wait for connections to come up ..
-        log.info("Waiting for connections to remote cluster to be established..");
+        log.info("[{}]:: Waiting for connections to remote cluster to be established..", fsm.getSessionName());
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/WaitingForConnectionsState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/WaitingForConnectionsState.java
@@ -23,7 +23,7 @@ public class WaitingForConnectionsState implements LogReplicationRuntimeState {
     }
 
     @Override
-    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalTransitionException {
+    public LogReplicationRuntimeState processEvent(LogReplicationRuntimeEvent event) throws IllegalRuntimeTransitionException {
         switch (event.getType()) {
             case ON_CONNECTION_UP:
                 log.info("[{}]:: On connection up, event={}", fsm.getSessionName(), event);
@@ -34,7 +34,7 @@ public class WaitingForConnectionsState implements LogReplicationRuntimeState {
                 return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
             default: {
                 log.warn("[{}]:: Unexpected communication event {} when in init state.", fsm.getSessionName(), event.getType());
-                throw new IllegalTransitionException(event.getType(), getType());
+                throw new IllegalRuntimeTransitionException(event.getType(), getType());
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/sink/RemoteSourceLeadershipManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/sink/RemoteSourceLeadershipManager.java
@@ -56,7 +56,8 @@ public class RemoteSourceLeadershipManager {
     private volatile Optional<String> leaderNodeId = Optional.empty();
 
     private final String localNodeId;
-    
+
+    @Getter
     private final String sessionName;
 
     //TODO v2: tune thread count;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -216,19 +216,19 @@ public class LogReplicationConfigManager {
      * @param session session for which to generate config.
      * @param updateGroupDestinationConfig True if group destination config needs to be updated.
      */
-    public void generateConfig(LogReplicationSession session, boolean updateGroupDestinationConfig, String sessionNameForLogging) {
+    public void generateConfig(LogReplicationSession session, boolean updateGroupDestinationConfig, String sessionName) {
         switch (session.getSubscriber().getModel()) {
             case FULL_TABLE:
-                log.debug("[{}]:: Generating FULL_TABLE config", sessionNameForLogging);
-                generateFullTableConfig(session, sessionNameForLogging);
+                log.debug("[{}]:: Generating FULL_TABLE config", sessionName);
+                generateFullTableConfig(session, sessionName);
                 break;
             case LOGICAL_GROUPS:
-                log.debug("[{}]:: Generating LOGICAL_GROUP config", sessionNameForLogging);
-                generateLogicalGroupConfig(session, updateGroupDestinationConfig, sessionNameForLogging);
+                log.debug("[{}]:: Generating LOGICAL_GROUP config", sessionName);
+                generateLogicalGroupConfig(session, updateGroupDestinationConfig, sessionName);
                 break;
             case ROUTING_QUEUES:
-                log.debug("[{}]:: Generating ROUTING_QUEUE config",sessionNameForLogging);
-                generateRoutingQueueConfig(session, sessionNameForLogging);
+                log.debug("[{}]:: Generating ROUTING_QUEUE config",sessionName);
+                generateRoutingQueueConfig(session, sessionName);
                 break;
             default:
                 throw new IllegalArgumentException("Invalid replication model: " +

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -2,7 +2,6 @@ package org.corfudb.infrastructure.logreplication.utils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
-import com.google.protobuf.TextFormat;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.ServerContext;
@@ -214,46 +213,41 @@ public class LogReplicationConfigManager {
     /**
      * Generate LogReplicationConfig for all given sessions based on there replication model.
      *
-     * @param sessions set of sessions for which to generate config.
+     * @param session session for which to generate config.
      * @param updateGroupDestinationConfig True if group destination config needs to be updated.
      */
-    public void generateConfig(Set<LogReplicationSession> sessions, boolean updateGroupDestinationConfig) {
-        sessions.forEach(session -> {
-                switch (session.getSubscriber().getModel()) {
-                    case FULL_TABLE:
-                        log.debug("Generating FULL_TABLE config for session {}",
-                                TextFormat.shortDebugString(session));
-                        generateFullTableConfig(session);
-                        break;
-                    case LOGICAL_GROUPS:
-                        log.debug("Generating LOGICAL_GROUP config for session {}",
-                                TextFormat.shortDebugString(session));
-                        generateLogicalGroupConfig(session, updateGroupDestinationConfig);
-                        break;
-                    case ROUTING_QUEUES:
-                        log.debug("Generating ROUTING_QUEUE config for session {}",
-                                TextFormat.shortDebugString(session));
-                        generateRoutingQueueConfig(session);
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Invalid replication model: " +
-                                session.getSubscriber().getModel());
-                }
-        });
+    public void generateConfig(LogReplicationSession session, boolean updateGroupDestinationConfig, String sessionNameForLogging) {
+        switch (session.getSubscriber().getModel()) {
+            case FULL_TABLE:
+                log.debug("[{}]:: Generating FULL_TABLE config", sessionNameForLogging);
+                generateFullTableConfig(session, sessionNameForLogging);
+                break;
+            case LOGICAL_GROUPS:
+                log.debug("[{}]:: Generating LOGICAL_GROUP config", sessionNameForLogging);
+                generateLogicalGroupConfig(session, updateGroupDestinationConfig, sessionNameForLogging);
+                break;
+            case ROUTING_QUEUES:
+                log.debug("[{}]:: Generating ROUTING_QUEUE config",sessionNameForLogging);
+                generateRoutingQueueConfig(session, sessionNameForLogging);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid replication model: " +
+                        session.getSubscriber().getModel());
+        }
     }
 
-    private void generateRoutingQueueConfig(LogReplicationSession session) {
+    private void generateRoutingQueueConfig(LogReplicationSession session, String sessionName) {
         if (!sessionToConfigMap.containsKey(session)) {
             LogReplicationRoutingQueueConfig routingQueueConfig =
                     new LogReplicationRoutingQueueConfig(session, serverContext);
             sessionToConfigMap.put(session, routingQueueConfig);
-            log.info("Routing queue session {} config generated.", session);
+            log.info("[{}]:: Routing queue config generated.", sessionName);
         } else {
-            log.warn("Routing queue config for session {} already exists!", session);
+            log.warn("[{}]:: Routing queue config already exists!", sessionName);
         }
     }
 
-    private void generateLogicalGroupConfig(LogReplicationSession session, boolean updateGroupDestinationConfig) {
+    private void generateLogicalGroupConfig(LogReplicationSession session, boolean updateGroupDestinationConfig, String sessionName) {
         Map<UUID, List<UUID>> streamToTagsMap = new HashMap<>();
         Set<String> streamsToReplicate = new HashSet<>();
         // Check if the local cluster is the Sink for this session. Sink side will honor whatever Source side send
@@ -271,7 +265,7 @@ public class LogReplicationConfigManager {
                     .filter(entry -> entry.getValue().contains(session.getSinkClusterId()))
                     .map(Map.Entry::getKey)
                     .forEach(group -> logicalGroupToStreams.put(group, new HashSet<>()));
-            log.debug("Targeted logical groups={}", logicalGroupToStreams.keySet());
+            log.debug("[{}]:: Targeted logical groups={}", sessionName, logicalGroupToStreams.keySet());
         }
 
         registryTableEntries.forEach(entry -> {
@@ -310,18 +304,18 @@ public class LogReplicationConfigManager {
             config.setStreamsToReplicate(streamsToReplicate);
             config.setDataStreamToTagsMap(streamToTagsMap);
             config.setLogicalGroupToStreams(logicalGroupToStreams);
-            log.info("LogReplicationLogicalGroupConfig updated for session={}, streams to replicate={}, groups={}",
-                    TextFormat.shortDebugString(session), streamsToReplicate, logicalGroupToStreams);
+            log.info("[{}]:: LogReplicationLogicalGroupConfig updated, streams to replicate={}, groups={}",
+                    sessionName, streamsToReplicate, logicalGroupToStreams);
         } else {
             LogReplicationLogicalGroupConfig logicalGroupConfig = new LogReplicationLogicalGroupConfig(session,
                     streamsToReplicate, streamToTagsMap, serverContext, logicalGroupToStreams);
             sessionToConfigMap.put(session, logicalGroupConfig);
-            log.info("LogReplicationLogicalGroupConfig generated for session={}, streams to replicate={}, groups={}",
-                    TextFormat.shortDebugString(session), streamsToReplicate, logicalGroupToStreams);
+            log.info("[{}]:: LogReplicationLogicalGroupConfig generated, streams to replicate={}, groups={}",
+                    sessionName, streamsToReplicate, logicalGroupToStreams);
         }
     }
 
-    private void generateFullTableConfig(LogReplicationSession session) {
+    private void generateFullTableConfig(LogReplicationSession session, String sessionName) {
         Map<UUID, List<UUID>> streamToTagsMap = new HashMap<>();
         Set<UUID> streamsToDrop = new HashSet<>();
         Set<String> streamsToReplicate = new HashSet<>();
@@ -355,14 +349,14 @@ public class LogReplicationConfigManager {
             config.setStreamsToReplicate(streamsToReplicate);
             config.setDataStreamToTagsMap(streamToTagsMap);
             config.setStreamsToDrop(streamsToDrop);
-            log.info("LogReplicationFullTableConfig updated for session={}, streams to replicate={}, streamsToDrop={}",
-                    TextFormat.shortDebugString(session), streamsToReplicate, streamsToDrop);
+            log.info("[{}]:: LogReplicationFullTableConfig updated, streams to replicate={}, streamsToDrop={}",
+                    sessionName, streamsToReplicate, streamsToDrop);
         } else {
             LogReplicationFullTableConfig fullTableConfig = new LogReplicationFullTableConfig(session, streamsToReplicate,
                     streamToTagsMap, serverContext, streamsToDrop);
             sessionToConfigMap.put(session, fullTableConfig);
-            log.info("LogReplicationFullTableConfig generated for session={}, streams to replicate={}, streamsToDrop={}",
-                    TextFormat.shortDebugString(session), streamsToReplicate, streamsToDrop);
+            log.info("[{}]:: LogReplicationFullTableConfig generated, streams to replicate={}, streamsToDrop={}",
+                    sessionName, streamsToReplicate, streamsToDrop);
         }
     }
 
@@ -372,19 +366,19 @@ public class LogReplicationConfigManager {
      * @param session LogReplicationSession to get updated config for.
      * @param updateGroupDestinationConfig True if group destination config needs to be updated.
      */
-    public void getUpdatedConfig(LogReplicationSession session, boolean updateGroupDestinationConfig) {
+    public void getUpdatedConfig(LogReplicationSession session, boolean updateGroupDestinationConfig, String sessionName) {
         syncWithRegistryTable();
 
         switch (session.getSubscriber().getModel()) {
             case FULL_TABLE:
-                generateConfig(Collections.singleton(session), updateGroupDestinationConfig);
+                generateConfig(session, updateGroupDestinationConfig, sessionName);
                 break;
             case LOGICAL_GROUPS:
                 syncWithClientConfigTable();
-                generateConfig(Collections.singleton(session), updateGroupDestinationConfig);
+                generateConfig(session, updateGroupDestinationConfig, sessionName);
                 break;
             case ROUTING_QUEUES:
-                generateRoutingQueueConfig(session);
+                generateRoutingQueueConfig(session, sessionName);
                 break;
             default:
                 throw new IllegalArgumentException("Invalid replication model: " +

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
@@ -50,9 +50,10 @@ public class LogEntryWriterTest extends AbstractViewTest {
             getDefaultSession());
         Mockito.doReturn(getDefaultMetadata()).when(metadataManager).getReplicationMetadata(getDefaultSession());
 
-        logEntryWriter = new LogEntryWriter(metadataManager, getDefaultSession(),
-                new LogReplicationContext(new LogReplicationConfigManager(corfuRuntime, LOCAL_SINK_CLUSTER_ID), topologyConfigId,
-                        getEndpoint(SERVERS.PORT_0), Mockito.mock(LogReplicationPluginConfig.class), corfuRuntime));
+        LogReplicationContext context = new LogReplicationContext(new LogReplicationConfigManager(corfuRuntime, LOCAL_SINK_CLUSTER_ID), topologyConfigId,
+                getEndpoint(SERVERS.PORT_0), Mockito.mock(LogReplicationPluginConfig.class), corfuRuntime);
+        logEntryWriter = new LogEntryWriter(metadataManager, getDefaultSession(), context);
+        context.addSessionNameForLogging(getDefaultSession(), "session_1");
     }
 
     @After

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
@@ -136,7 +136,7 @@ public class LogReplicationConfigManagerTest extends AbstractViewTest {
                 .setSinkClusterId(REMOTE_SINK_CLUSTER_ID)
                 .setSubscriber(LogReplicationConfigManager.getDefaultSubscriber())
                 .build();
-        configManager.generateConfig(Collections.singleton(sampleSession), true);
+        configManager.generateConfig(sampleSession, true, "session_1");
         verifyExpectedConfigGenerated((LogReplicationFullTableConfig) configManager.getSessionToConfigMap()
                 .get(sampleSession));
     }
@@ -155,21 +155,24 @@ public class LogReplicationConfigManagerTest extends AbstractViewTest {
                 .setSinkClusterId(REMOTE_SINK_CLUSTER_ID)
                 .setSubscriber(LogReplicationConfigManager.getDefaultSubscriber())
                 .build();
-        configManager.generateConfig(Collections.singleton(sampleSession), true);
+        String sessionName = "session_1";
+        configManager.generateConfig(sampleSession, true, sessionName);
         verifyExpectedConfigGenerated((LogReplicationFullTableConfig) configManager.getSessionToConfigMap()
                 .get(sampleSession));
 
         // Open new tables and update the expected streams to replicate map, streams to drop and stream tags
         setupStreamsToReplicateAndTagsMap(Collections.singleton(TABLE5), SampleSchema.ValueFieldTagOne.class);
         setupStreamsToDrop(Collections.singleton(TABLE6), SampleSchema.Uuid.class);
-        configManager.getUpdatedConfig(sampleSession, true);
-        configManager.generateConfig(Collections.singleton(sampleSession), true);
+
+        configManager.getUpdatedConfig(sampleSession, true, sessionName);
+        configManager.generateConfig(sampleSession, true, sessionName);
         // After synchronization with RegistryTable, these 2 streams will be found in streamsToDrop field of
         // FULL_TABLE log replication config
         streamsToDrop.add(CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
                 GUID_STREAM_NAME)));
         streamsToDrop.add(CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
                 LOG_ENTRY_SYNC_QUEUE_NAME_SENDER)));
+
         verifyExpectedConfigGenerated((LogReplicationFullTableConfig) configManager.getSessionToConfigMap()
                 .get(sampleSession));
     }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -869,7 +869,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // Manually initialize the replication status table, needed for tests that check the
         // source status so incoming needs to be set to false
         metadataManager.addSession(DEFAULT_SESSION, 0, false);
-
+        
         ackReader = new LogReplicationAckReader(metadataManager, DEFAULT_SESSION, context);
         fsm = new LogReplicationFSM(snapshotReader, dataSender, logEntryReader,
                 ackReader, DEFAULT_SESSION, context);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -869,7 +869,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // Manually initialize the replication status table, needed for tests that check the
         // source status so incoming needs to be set to false
         metadataManager.addSession(DEFAULT_SESSION, 0, false);
-        
+
         ackReader = new LogReplicationAckReader(metadataManager, DEFAULT_SESSION, context);
         fsm = new LogReplicationFSM(snapshotReader, dataSender, logEntryReader,
                 ackReader, DEFAULT_SESSION, context);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -829,7 +829,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(runtime, LOCAL_SOURCE_CLUSTER_ID);
         LogReplicationPluginConfig pluginConfig = new LogReplicationPluginConfig(pluginConfigFilePath);
         LogReplicationSession session = DefaultClusterConfig.getSessions().get(0);
-        configManager.generateConfig(Collections.singleton(session), false);
+        configManager.generateConfig(session, false, "session_1");
 
         switch(readerImpl) {
             case EMPTY:
@@ -869,7 +869,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // Manually initialize the replication status table, needed for tests that check the
         // source status so incoming needs to be set to false
         metadataManager.addSession(DEFAULT_SESSION, 0, false);
-        
+
         ackReader = new LogReplicationAckReader(metadataManager, DEFAULT_SESSION, context);
         fsm = new LogReplicationFSM(snapshotReader, dataSender, logEntryReader,
                 ackReader, DEFAULT_SESSION, context);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -853,9 +853,10 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 break;
             case STREAMS:
                 CorfuRuntime runtime = getNewRuntime(getDefaultNode()).connect();
-                snapshotReader = new StreamsSnapshotReader(DEFAULT_SESSION,
-                        new LogReplicationContext(configManager, TEST_TOPOLOGY_CONFIG_ID,
-                                "test:" + SERVERS.PORT_0, pluginConfig, runtime));
+                LogReplicationContext context = new LogReplicationContext(configManager, TEST_TOPOLOGY_CONFIG_ID,
+                        "test:" + SERVERS.PORT_0, pluginConfig, runtime);
+                context.addSessionNameForLogging(session, "session_1");
+                snapshotReader = new StreamsSnapshotReader(DEFAULT_SESSION,context);
                 dataSender = new TestDataSender(waitInSnapshotSync);
                 break;
             default:
@@ -864,6 +865,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         context = new LogReplicationContext(configManager, TEST_TOPOLOGY_CONFIG_ID,
                 "test:" + SERVERS.PORT_0, true, pluginConfig, runtime);
+        context.addSessionNameForLogging(DEFAULT_SESSION, "session_1");
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(runtime, context);
 
         // Manually initialize the replication status table, needed for tests that check the

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
@@ -53,6 +53,7 @@ public class MetadataManagerTest extends AbstractViewTest {
         replicationContext = new LogReplicationContext(new LogReplicationConfigManager(corfuRuntime,
                 LOCAL_SOURCE_CLUSTER_ID), topologyConfigId, getEndpoint(SERVERS.PORT_0), true,
                 Mockito.mock(LogReplicationPluginConfig.class), corfuRuntime);
+        replicationContext.addSessionNameForLogging(defaultSession, "session_1");
         metadataManager = new LogReplicationMetadataManager(corfuRuntime, replicationContext);
         metadataManager.addSession(defaultSession, topologyConfigId, true);
     }
@@ -70,6 +71,7 @@ public class MetadataManagerTest extends AbstractViewTest {
     public void testMetadataAfterLogEntrySync() {
         LogReplicationContext context = new LogReplicationContext(configManager, topologyConfigId,
                 getEndpoint(SERVERS.PORT_0), Mockito.mock(LogReplicationPluginConfig.class), corfuRuntime);
+        context.addSessionNameForLogging(defaultSession, "session_1");
         LogEntryWriter writer = new LogEntryWriter(metadataManager, defaultSession, context);
 
         long numOpaqueEntries = 3L;
@@ -127,6 +129,7 @@ public class MetadataManagerTest extends AbstractViewTest {
         metadataManager.addSession(defaultSession, topologyConfigId, true);
         LogReplicationContext context = new LogReplicationContext(configManager, 0,
                 defaultSession.getSourceClusterId(), Mockito.mock(LogReplicationPluginConfig.class), corfuRuntime);
+        context.addSessionNameForLogging(defaultSession, "session_1");
         LogEntryWriter writer = new LogEntryWriter(metadataManager, defaultSession, context);
 
         // Create a message with 50 opaque entries

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
@@ -65,7 +65,7 @@ public class RoutingQueuesSnapshotReaderTest extends AbstractViewTest {
             session.getSourceClusterId());
         replicationContext = new LogReplicationContext(configManager, 5,
             session.getSourceClusterId(), true, new LogReplicationPluginConfig(""), lrRuntime);
-        configManager.generateConfig(Collections.singleton(session), false);
+        configManager.generateConfig(session, false, "session_1");
         snapshotReader = new RoutingQueuesSnapshotReader(session, replicationContext);
         snapshotReader.reset(lrRuntime.getAddressSpaceView().getLogTail());
     }
@@ -89,7 +89,7 @@ public class RoutingQueuesSnapshotReaderTest extends AbstractViewTest {
 
         // 2. Write data to a different session and read for that session, ensure the timeout window moves.
         LogReplication.LogReplicationSession anotherSession = DefaultClusterConfig.getRoutingQueueSessions().get(1);
-        configManager.generateConfig(Collections.singleton(anotherSession), false);
+        configManager.generateConfig(anotherSession, false, "session_1");
         BaseSnapshotReader anotherSnapshotReader = new RoutingQueuesSnapshotReader(anotherSession, replicationContext);
 
         generateData(anotherSession);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/SessionManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/SessionManagerTest.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.logreplication;
 import com.google.common.collect.Sets;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.SessionManager;
 import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.msghandlers.LogReplicationServer;
@@ -169,13 +170,15 @@ public class SessionManagerTest extends AbstractViewTest {
 
         IClientChannelAdapter clientChannelAdapter = Mockito.mock(IClientChannelAdapter.class);
         IServerChannelAdapter serverChannelAdapter = Mockito.mock(IServerChannelAdapter.class);
+        LogReplicationContext context = Mockito.mock(LogReplicationContext.class);
         this.router = new LogReplicationClientServerRouter(0L,
                 topology.getLocalNodeDescriptor().getClusterId(), topology.getLocalNodeDescriptor().getNodeId(),
-                new HashSet<>(), new HashSet<>(), msgHandler, clientChannelAdapter, serverChannelAdapter);
+                new HashSet<>(), new HashSet<>(), msgHandler, clientChannelAdapter, serverChannelAdapter, context);
 
         SessionManager sessionManager = new SessionManager(topology, corfuRuntime, replicationManager, router,
                 msgHandler, pluginConfig);
         sessionManager.refresh(topology);
+        addSessionNames(sessionManager.getSessions(), context);
         sessionManager.connectToRemoteClusters();
         Mockito.verify(clientChannelAdapter, Mockito.times(3)).connectAsync(ArgumentMatchers.any(), ArgumentMatchers.any());
 
@@ -192,14 +195,24 @@ public class SessionManagerTest extends AbstractViewTest {
                 topology.getRemoteSourceClusterToReplicationModels(), newAllClusters, newRemoteClusterEndpoints,
                 topology.getLocalNodeDescriptor().getNodeId());
         sessionManager.refresh(newTopology);
+        addSessionNames(sessionManager.getSessions(), context);
         Assert.assertTrue(router.getConnectedSessions().size() == 2);
 
         Mockito.clearInvocations(clientChannelAdapter);
         //simulate adding a cluster back to topology. ConnectAsync should be called for the newly added cluster only.
         sessionManager.refresh(topology);
+        addSessionNames(sessionManager.getSessions(), context);
         sessionManager.connectToRemoteClusters();
         Mockito.verify(clientChannelAdapter, Mockito.times(1)).connectAsync(ArgumentMatchers.any(), ArgumentMatchers.any());
 
+    }
+
+    private void addSessionNames(Set<LogReplication.LogReplicationSession> sessions, LogReplicationContext context) {
+        int counter = 0;
+        for(LogReplication.LogReplicationSession session : sessions) {
+            context.addSessionNameForLogging(session, "session_"+counter);
+            ++counter;
+        }
     }
 }
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -257,14 +257,18 @@ public class LogReplicationIT extends AbstractIT implements Observer {
 
         pluginConfig = new LogReplicationPluginConfig(pluginConfigFilePath);
 
-        destMetadataManager = new LogReplicationMetadataManager(dstTestRuntime,
-                new LogReplicationContext(new LogReplicationConfigManager(dstTestRuntime, session.getSinkClusterId()), 0,
-                "test" + SERVERS.PORT_0, true, pluginConfig, dstTestRuntime));
+        LogReplicationContext destContext = new LogReplicationContext(new LogReplicationConfigManager(dstTestRuntime, session.getSinkClusterId()), 0,
+                "test" + SERVERS.PORT_0, true, pluginConfig, dstTestRuntime);
+        destContext.addSessionNameForLogging(session, "session_1");
+
+        destMetadataManager = new LogReplicationMetadataManager(dstTestRuntime, destContext);
         destMetadataManager.addSession(session, 0, true);
 
-        srcMetadataManager = new LogReplicationMetadataManager(srcTestRuntime,
-                new LogReplicationContext(new LogReplicationConfigManager(srcTestRuntime, session.getSourceClusterId()), 0,
-                        "test" + SERVERS.PORT_0, true, pluginConfig, srcTestRuntime));
+        LogReplicationContext srcContext = new LogReplicationContext(new LogReplicationConfigManager(srcTestRuntime, session.getSourceClusterId()), 0,
+                "test" + SERVERS.PORT_0, true, pluginConfig, srcTestRuntime);
+        srcContext.addSessionNameForLogging(session, "session_1");
+
+        srcMetadataManager = new LogReplicationMetadataManager(srcTestRuntime, srcContext);
         srcMetadataManager.addSession(session, 0, true);
 
         expectedAckTimestamp = new AtomicLong(Long.MAX_VALUE);
@@ -1283,7 +1287,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         LogReplicationConfigManager sinkConfigManager = new LogReplicationConfigManager(dstTestRuntime, session.getSinkClusterId());
         sinkConfigManager.generateConfig(session, false, "session_1");
         LogReplicationContext sinkContext = new LogReplicationContext(sinkConfigManager, 0, DEFAULT_ENDPOINT, pluginConfig, dstTestRuntime);
-
+        sinkContext.addSessionNameForLogging(session, "session_1");
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used
         sinkContext.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);
@@ -1296,6 +1300,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         LogReplicationConfigManager srcConfigManager = new LogReplicationConfigManager(srcTestRuntime, LOCAL_SOURCE_CLUSTER_ID);
         srcConfigManager.generateConfig(session, false, "session_1");
         LogReplicationContext srcContext = new LogReplicationContext(srcConfigManager, 0, DEFAULT_ENDPOINT, pluginConfig, srcTestRuntime);
+        srcContext.addSessionNameForLogging(session, "session_1");
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used
         srcContext.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1281,8 +1281,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         TransitionSource function) throws InterruptedException {
 
         LogReplicationConfigManager sinkConfigManager = new LogReplicationConfigManager(dstTestRuntime, session.getSinkClusterId());
-        sinkConfigManager.generateConfig(Collections.singleton(session), false);
+        sinkConfigManager.generateConfig(session, false, "session_1");
         LogReplicationContext sinkContext = new LogReplicationContext(sinkConfigManager, 0, DEFAULT_ENDPOINT, pluginConfig, dstTestRuntime);
+
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used
         sinkContext.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);
@@ -1293,7 +1294,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                 function, sinkContext, dstTestRuntime);
 
         LogReplicationConfigManager srcConfigManager = new LogReplicationConfigManager(srcTestRuntime, LOCAL_SOURCE_CLUSTER_ID);
-        srcConfigManager.generateConfig(Collections.singleton(session), false);
+        srcConfigManager.generateConfig(session, false, "session_1");
         LogReplicationContext srcContext = new LogReplicationContext(srcConfigManager, 0, DEFAULT_ENDPOINT, pluginConfig, srcTestRuntime);
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -84,7 +84,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     private static final String REMOTE_CLUSTER_ID = UUID.randomUUID().toString();
     private static final int CORFU_PORT = 9000;
     private static final String TABLE_PREFIX = "test";
-
+    private static final String SESSION_NAME = "session_1";
     private static final String TEST_NAMESPACE = "LR-Test";
 
     private static final String LOCAL_SOURCE_CLUSTER_ID = DefaultClusterConfig.getSourceClusterIds().get(0);
@@ -259,14 +259,14 @@ public class LogReplicationIT extends AbstractIT implements Observer {
 
         LogReplicationContext destContext = new LogReplicationContext(new LogReplicationConfigManager(dstTestRuntime, session.getSinkClusterId()), 0,
                 "test" + SERVERS.PORT_0, true, pluginConfig, dstTestRuntime);
-        destContext.addSessionNameForLogging(session, "session_1");
+        destContext.addSessionNameForLogging(session, SESSION_NAME);
 
         destMetadataManager = new LogReplicationMetadataManager(dstTestRuntime, destContext);
         destMetadataManager.addSession(session, 0, true);
 
         LogReplicationContext srcContext = new LogReplicationContext(new LogReplicationConfigManager(srcTestRuntime, session.getSourceClusterId()), 0,
                 "test" + SERVERS.PORT_0, true, pluginConfig, srcTestRuntime);
-        srcContext.addSessionNameForLogging(session, "session_1");
+        srcContext.addSessionNameForLogging(session, SESSION_NAME);
 
         srcMetadataManager = new LogReplicationMetadataManager(srcTestRuntime, srcContext);
         srcMetadataManager.addSession(session, 0, true);
@@ -1285,9 +1285,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         TransitionSource function) throws InterruptedException {
 
         LogReplicationConfigManager sinkConfigManager = new LogReplicationConfigManager(dstTestRuntime, session.getSinkClusterId());
-        sinkConfigManager.generateConfig(session, false, "session_1");
+        sinkConfigManager.generateConfig(session, false, SESSION_NAME);
         LogReplicationContext sinkContext = new LogReplicationContext(sinkConfigManager, 0, DEFAULT_ENDPOINT, pluginConfig, dstTestRuntime);
-        sinkContext.addSessionNameForLogging(session, "session_1");
+        sinkContext.addSessionNameForLogging(session, SESSION_NAME);
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used
         sinkContext.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);
@@ -1298,9 +1298,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                 function, sinkContext, dstTestRuntime);
 
         LogReplicationConfigManager srcConfigManager = new LogReplicationConfigManager(srcTestRuntime, LOCAL_SOURCE_CLUSTER_ID);
-        srcConfigManager.generateConfig(session, false, "session_1");
+        srcConfigManager.generateConfig(session, false, SESSION_NAME);
         LogReplicationContext srcContext = new LogReplicationContext(srcConfigManager, 0, DEFAULT_ENDPOINT, pluginConfig, srcTestRuntime);
-        srcContext.addSessionNameForLogging(session, "session_1");
+        srcContext.addSessionNameForLogging(session, SESSION_NAME);
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used
         srcContext.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -233,6 +233,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         configManager.generateConfig(getDefaultSession(), false, "session_1");
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
+        context.addSessionNameForLogging(getDefaultSession(), "session_1");
 
         StreamsSnapshotReader reader = new StreamsSnapshotReader(getDefaultSession(), context);
 
@@ -270,9 +271,11 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
                 getReplicationContext(configManager, 0, "test", true, rt));
         logReplicationMetadataManager.addSession(getDefaultSession(), 0, true);
 
+        LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
+                Mockito.mock(LogReplicationPluginConfig.class), rt);
+        context.addSessionNameForLogging(getDefaultSession(), "session_1");
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, logReplicationMetadataManager,
-            getDefaultSession(), new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
-                Mockito.mock(LogReplicationPluginConfig.class), rt));
+            getDefaultSession(), context);
 
         if (msgQ.isEmpty()) {
             log.debug("msgQ is empty");
@@ -305,9 +308,10 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SOURCE_CLUSTER_ID);
         configManager.generateConfig(getDefaultSession(), false, "session_1");
 
-        StreamsLogEntryReader reader = new StreamsLogEntryReader(getDefaultSession(),
-                new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
-                        Mockito.mock(LogReplicationPluginConfig.class), rt));
+        LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
+                Mockito.mock(LogReplicationPluginConfig.class), rt);
+        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        StreamsLogEntryReader reader = new StreamsLogEntryReader(getDefaultSession(), context);
         reader.setGlobalBaseSnapshot(Address.NON_ADDRESS, Address.NON_ADDRESS);
 
         LogReplicationEntryMsg entry;
@@ -343,9 +347,10 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
                 getReplicationContext(configManager, 0, "test", true, rt));
         logReplicationMetadataManager.addSession(getDefaultSession(),0, true);
-        LogEntryWriter writer = new LogEntryWriter(logReplicationMetadataManager, getDefaultSession(),
-                new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
-                        Mockito.mock(LogReplicationPluginConfig.class), rt));
+        LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
+                Mockito.mock(LogReplicationPluginConfig.class), rt);
+        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        LogEntryWriter writer = new LogEntryWriter(logReplicationMetadataManager, getDefaultSession(), context);
 
         if (msgQ.isEmpty()) {
             log.debug("msgQ is EMPTY");
@@ -358,8 +363,10 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
 
     private LogReplicationContext getReplicationContext(LogReplicationConfigManager configManager, long topologyConfigId,
                                                         String localCorfuEndpoint, boolean isLeader, CorfuRuntime rt) {
-        return new LogReplicationContext(configManager, topologyConfigId, localCorfuEndpoint, isLeader,
+        LogReplicationContext context = new LogReplicationContext(configManager, topologyConfigId, localCorfuEndpoint, isLeader,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
+        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        return context;
     }
 
     private void accessTxStream(Iterator<ILogData> iterator, int num) {

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -72,6 +72,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     private static final String SINK_CLUSTER_ID = "Cluster-London";
     private static final String SHADOW_SUFFIX = "_SHADOW";
     private static final String TEST_NAMESPACE = "LR-Test";
+    private static final String SESSION_NAME = "session_1";
     private static final String LOCAL_SOURCE_CLUSTER_ID = DefaultClusterConfig.getSourceClusterIds().get(0);
     private static final String LOCAL_SINK_CLUSTER_ID = DefaultClusterConfig.getSinkClusterIds().get(0);
 
@@ -230,10 +231,10 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public static void readSnapshotMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt, boolean blockOnSem) {
         int cnt = 0;
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SOURCE_CLUSTER_ID);
-        configManager.generateConfig(getDefaultSession(), false, "session_1");
+        configManager.generateConfig(getDefaultSession(), false, SESSION_NAME);
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
-        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        context.addSessionNameForLogging(getDefaultSession(), SESSION_NAME);
 
         StreamsSnapshotReader reader = new StreamsSnapshotReader(getDefaultSession(), context);
 
@@ -265,7 +266,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public void writeSnapshotMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SINK_CLUSTER_ID);
-        configManager.generateConfig(getDefaultSession(), false, "session_1");
+        configManager.generateConfig(getDefaultSession(), false, SESSION_NAME);
 
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
                 getReplicationContext(configManager, 0, "test", true, rt));
@@ -273,7 +274,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
 
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
-        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        context.addSessionNameForLogging(getDefaultSession(), SESSION_NAME);
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, logReplicationMetadataManager,
             getDefaultSession(), context);
 
@@ -306,11 +307,11 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
                                         boolean blockOnce) throws TrimmedException {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SOURCE_CLUSTER_ID);
-        configManager.generateConfig(getDefaultSession(), false, "session_1");
+        configManager.generateConfig(getDefaultSession(), false, SESSION_NAME);
 
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
-        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        context.addSessionNameForLogging(getDefaultSession(), SESSION_NAME);
         StreamsLogEntryReader reader = new StreamsLogEntryReader(getDefaultSession(), context);
         reader.setGlobalBaseSnapshot(Address.NON_ADDRESS, Address.NON_ADDRESS);
 
@@ -342,14 +343,14 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     private void writeLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SINK_CLUSTER_ID);
-        configManager.generateConfig(getDefaultSession(), false, "session_1");
+        configManager.generateConfig(getDefaultSession(), false, SESSION_NAME);
 
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
                 getReplicationContext(configManager, 0, "test", true, rt));
         logReplicationMetadataManager.addSession(getDefaultSession(),0, true);
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
-        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        context.addSessionNameForLogging(getDefaultSession(), SESSION_NAME);
         LogEntryWriter writer = new LogEntryWriter(logReplicationMetadataManager, getDefaultSession(), context);
 
         if (msgQ.isEmpty()) {
@@ -365,7 +366,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
                                                         String localCorfuEndpoint, boolean isLeader, CorfuRuntime rt) {
         LogReplicationContext context = new LogReplicationContext(configManager, topologyConfigId, localCorfuEndpoint, isLeader,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
-        context.addSessionNameForLogging(getDefaultSession(), "session_1");
+        context.addSessionNameForLogging(getDefaultSession(), SESSION_NAME);
         return context;
     }
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -230,7 +230,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public static void readSnapshotMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt, boolean blockOnSem) {
         int cnt = 0;
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SOURCE_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
+        configManager.generateConfig(getDefaultSession(), false, "session_1");
         LogReplicationContext context = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
                 Mockito.mock(LogReplicationPluginConfig.class), rt);
 
@@ -264,7 +264,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public void writeSnapshotMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SINK_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
+        configManager.generateConfig(getDefaultSession(), false, "session_1");
 
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
                 getReplicationContext(configManager, 0, "test", true, rt));
@@ -303,7 +303,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
                                         boolean blockOnce) throws TrimmedException {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SOURCE_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
+        configManager.generateConfig(getDefaultSession(), false, "session_1");
 
         StreamsLogEntryReader reader = new StreamsLogEntryReader(getDefaultSession(),
                 new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT,
@@ -338,7 +338,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     private void writeLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt, LOCAL_SINK_CLUSTER_ID);
-        configManager.generateConfig(Collections.singleton(getDefaultSession()), false);
+        configManager.generateConfig(getDefaultSession(), false, "session_1");
 
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
                 getReplicationContext(configManager, 0, "test", true, rt));


### PR DESCRIPTION
1. Generate unique name for session. Convention: "session_<id>"
2. prefix the log statements with the unique name generated

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
