### PR TITLE
Gate FSM transition

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -55,25 +55,28 @@ public class InLogEntrySyncState implements LogReplicationState {
                         "snapshot sync request";
                 cancelLogEntrySync(cancelCause);
                 LogReplicationState snapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
-                snapshotSyncState.setTransitionEventId(event.getEventId());
+                // set the ID of the new snapshot sync to the incoming request ID
+                snapshotSyncState.setTransitionEventId(event.getMetadata().getRequestId());
                 ((InSnapshotSyncState)snapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                 return snapshotSyncState;
             case SYNC_CANCEL:
                 // If cancel was intended for current log entry sync task, cancel and transition to new state
                 // In the case of log entry sync, cancel is caused by an encountered trimmed exception or any
                 // other exception while reading/sending.
-                if (transitionEventId == event.getMetadata().getRequestId()) {
+                if (fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
                     cancelLogEntrySync("sync cancel.");
                     LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
+                    // new ID for new snapshot_sync request
                     inSnapshotSyncState.setTransitionEventId(UUID.randomUUID());
                     ((InSnapshotSyncState)inSnapshotSyncState).setForcedSnapshotSync(false);
                     return inSnapshotSyncState;
                 }
-
-                log.warn("Log Entry Sync cancel for eventId {}, but running log entry sync for {}",
-                        event.getEventId(), transitionEventId);
+                log.warn("Ignoring Log Entry Sync cancel for eventId {}, while running log entry sync for {}",
+                        event.getMetadata().getRequestId(), transitionEventId);
                 return this;
             case REPLICATION_STOP:
+                // No need to validate transitionId as REPLICATION_STOP comes either from enforceSnapshotSync or when
+                // the runtime FSM transitions back to VERIFYING_REMOTE_LEADER from REPLICATING state
                 cancelLogEntrySync("replication being stopped.");
                 return fsm.getStates().get(LogReplicationStateType.INITIALIZED);
             case REPLICATION_SHUTDOWN:
@@ -81,7 +84,7 @@ public class InLogEntrySyncState implements LogReplicationState {
                 return fsm.getStates().get(LogReplicationStateType.ERROR);
             case LOG_ENTRY_SYNC_REPLICATED:
                 // Verify the replicated entry corresponds to the current log entry sync cycle (and not a previous/old one)
-                if (transitionEventId.equals(event.getMetadata().getRequestId())) {
+                if (fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
                     log.debug("Log Entry Sync ACK, update last ack timestamp to {}", event.getMetadata().getLastLogEntrySyncedTimestamp());
                     fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 }
@@ -93,12 +96,12 @@ public class InLogEntrySyncState implements LogReplicationState {
                 // corresponding to this snapshot sync. This is done to accommodate the case
                 // of multi-cluster replication sharing a common thread pool, continuation allows to send another
                 // batch of updates for the current snapshot sync.
-                if (event.getMetadata().getRequestId() == transitionEventId) {
-                    log.trace("Continuation of log entry sync for {}", event.getEventId());
+                if (fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
+                    log.trace("Continuation of log entry sync for {}", event.getMetadata().getRequestId());
                     return this;
                 } else {
-                    log.warn("Unexpected log entry sync continue event {} when in log entry sync state {}.",
-                            event.getEventId(), transitionEventId);
+                    log.warn("Ignoring log entry sync continue event {} while in log entry sync state {}.",
+                            event.getMetadata().getRequestId(), transitionEventId);
                 }
             default: {
                 log.warn("Unexpected log replication event {} when in log entry sync state.", event.getType());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -31,10 +31,10 @@ public class InLogEntrySyncState implements LogReplicationState {
     private Future<?> logEntrySyncFuture = CompletableFuture.completedFuture(null);
 
     /**
-     * Unique Identifier of the event that caused the transition to this state,
-     * i.e., current event/request being processed.
+     * Uniquely identifies the sync that caused the transition to this state.
+     * This is required to validate if the incoming FSM event is for the current sync.
      */
-    private UUID transitionEventId;
+    private UUID transitionSyncId;
 
     /**
      * Constructor
@@ -56,23 +56,23 @@ public class InLogEntrySyncState implements LogReplicationState {
                 cancelLogEntrySync(cancelCause);
                 LogReplicationState snapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
                 // set the ID of the new snapshot sync to the incoming request ID
-                snapshotSyncState.setTransitionEventId(event.getMetadata().getRequestId());
+                snapshotSyncState.setTransitionSyncId(event.getMetadata().getSyncId());
                 ((InSnapshotSyncState)snapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                 return snapshotSyncState;
             case SYNC_CANCEL:
                 // If cancel was intended for current log entry sync task, cancel and transition to new state
                 // In the case of log entry sync, cancel is caused by an encountered trimmed exception or any
                 // other exception while reading/sending.
-                if (fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
+                if (fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     cancelLogEntrySync("sync cancel.");
                     LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
                     // new ID for new snapshot_sync request
-                    inSnapshotSyncState.setTransitionEventId(UUID.randomUUID());
+                    inSnapshotSyncState.setTransitionSyncId(UUID.randomUUID());
                     ((InSnapshotSyncState)inSnapshotSyncState).setForcedSnapshotSync(false);
                     return inSnapshotSyncState;
                 }
                 log.warn("Ignoring Log Entry Sync cancel for eventId {}, while running log entry sync for {}",
-                        event.getMetadata().getRequestId(), transitionEventId);
+                        event.getMetadata().getSyncId(), transitionSyncId);
                 return this;
             case REPLICATION_STOP:
                 // No need to validate transitionId as REPLICATION_STOP comes either from enforceSnapshotSync or when
@@ -84,7 +84,7 @@ public class InLogEntrySyncState implements LogReplicationState {
                 return fsm.getStates().get(LogReplicationStateType.ERROR);
             case LOG_ENTRY_SYNC_REPLICATED:
                 // Verify the replicated entry corresponds to the current log entry sync cycle (and not a previous/old one)
-                if (fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
+                if (fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     log.debug("Log Entry Sync ACK, update last ack timestamp to {}", event.getMetadata().getLastLogEntrySyncedTimestamp());
                     fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 }
@@ -96,12 +96,12 @@ public class InLogEntrySyncState implements LogReplicationState {
                 // corresponding to this snapshot sync. This is done to accommodate the case
                 // of multi-cluster replication sharing a common thread pool, continuation allows to send another
                 // batch of updates for the current snapshot sync.
-                if (fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
-                    log.trace("Continuation of log entry sync for {}", event.getMetadata().getRequestId());
+                if (fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
+                    log.trace("Continuation of log entry sync for {}", event.getMetadata().getSyncId());
                     return this;
                 } else {
                     log.warn("Ignoring log entry sync continue event {} while in log entry sync state {}.",
-                            event.getMetadata().getRequestId(), transitionEventId);
+                            event.getMetadata().getSyncId(), transitionSyncId);
                 }
             default: {
                 log.warn("Unexpected log replication event {} when in log entry sync state.", event.getType());
@@ -152,7 +152,7 @@ public class InLogEntrySyncState implements LogReplicationState {
             }
 
             logEntrySyncFuture = fsm.getLogReplicationFSMWorkers().submit(() ->
-                    logEntrySender.send(transitionEventId));
+                    logEntrySender.send(transitionSyncId));
 
         } catch (Throwable t) {
             log.error("Error on entry of InLogEntrySyncState", t);
@@ -160,13 +160,13 @@ public class InLogEntrySyncState implements LogReplicationState {
     }
 
     @Override
-    public void setTransitionEventId(UUID eventId) {
-        transitionEventId = eventId;
+    public void setTransitionSyncId(UUID eventId) {
+        transitionSyncId = eventId;
     }
 
     @Override
-    public UUID getTransitionEventId() {
-        return transitionEventId;
+    public UUID getTransitionSyncId() {
+        return transitionSyncId;
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -147,7 +147,7 @@ public class InSnapshotSyncState implements LogReplicationState {
                 return fsm.getStates().get(LogReplicationStateType.ERROR);
             default: {
                 if (!fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
-                    log.warn("Ignoring log replication event {} for sync {} when in wait snapshot sync apply state for sync {}",
+                    log.warn("Ignoring log replication event {} for sync {} when in snapshot sync state for sync {}",
                             event.getType(), event.getMetadata().getRequestId(), transitionEventId);
                     return this;
                 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -31,27 +31,27 @@ public class InitializedState implements LogReplicationState {
     public LogReplicationState processEvent(LogReplicationEvent event) throws IllegalTransitionException {
         switch (event.getType()) {
             case SNAPSHOT_SYNC_REQUEST:
-                log.info("Start Snapshot Sync, requestId={}", event.getEventId());
+                log.info("Start Snapshot Sync, requestId={}", event.getMetadata().getRequestId());
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState snapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
-                snapshotSyncState.setTransitionEventId(event.getEventId());
+                snapshotSyncState.setTransitionEventId(event.getMetadata().getRequestId());
                 ((InSnapshotSyncState)snapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                 return snapshotSyncState;
             case SNAPSHOT_TRANSFER_COMPLETE:
                 log.info("Snapshot Sync transfer completed. Wait for snapshot apply to complete.");
                 WaitSnapshotApplyState waitSnapshotApplyState = (WaitSnapshotApplyState)fsm.getStates().get(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
-                waitSnapshotApplyState.setTransitionEventId(event.getEventId());
+                waitSnapshotApplyState.setTransitionEventId(event.getMetadata().getRequestId());
                 waitSnapshotApplyState.setBaseSnapshotTimestamp(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 return waitSnapshotApplyState;
             case LOG_ENTRY_SYNC_REQUEST:
-                log.info("Start Log Entry Sync, requestId={}", event.getEventId());
+                log.info("Start Log Entry Sync, requestId={}", event.getMetadata().getRequestId());
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState logEntrySyncState = fsm.getStates().get(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
-                logEntrySyncState.setTransitionEventId(event.getEventId());
+                logEntrySyncState.setTransitionEventId(event.getMetadata().getRequestId());
                 fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 return logEntrySyncState;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -31,27 +31,27 @@ public class InitializedState implements LogReplicationState {
     public LogReplicationState processEvent(LogReplicationEvent event) throws IllegalTransitionException {
         switch (event.getType()) {
             case SNAPSHOT_SYNC_REQUEST:
-                log.info("Start Snapshot Sync, requestId={}", event.getMetadata().getRequestId());
+                log.info("Start Snapshot Sync, requestId={}", event.getMetadata().getSyncId());
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState snapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
-                snapshotSyncState.setTransitionEventId(event.getMetadata().getRequestId());
+                snapshotSyncState.setTransitionSyncId(event.getMetadata().getSyncId());
                 ((InSnapshotSyncState)snapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                 return snapshotSyncState;
             case SNAPSHOT_TRANSFER_COMPLETE:
                 log.info("Snapshot Sync transfer completed. Wait for snapshot apply to complete.");
                 WaitSnapshotApplyState waitSnapshotApplyState = (WaitSnapshotApplyState)fsm.getStates().get(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
-                waitSnapshotApplyState.setTransitionEventId(event.getMetadata().getRequestId());
+                waitSnapshotApplyState.setTransitionSyncId(event.getMetadata().getSyncId());
                 waitSnapshotApplyState.setBaseSnapshotTimestamp(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 return waitSnapshotApplyState;
             case LOG_ENTRY_SYNC_REQUEST:
-                log.info("Start Log Entry Sync, requestId={}", event.getMetadata().getRequestId());
+                log.info("Start Log Entry Sync, requestId={}", event.getMetadata().getSyncId());
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState logEntrySyncState = fsm.getStates().get(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
-                logEntrySyncState.setTransitionEventId(event.getMetadata().getRequestId());
+                logEntrySyncState.setTransitionSyncId(event.getMetadata().getSyncId());
                 fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 return logEntrySyncState;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
@@ -59,22 +59,7 @@ public class LogReplicationEvent {
     public LogReplicationEvent(LogReplicationEventType type) {
         this.type = type;
         this.eventId = Utils.genPseudorandomUUID();
-        this.metadata = new LogReplicationEventMetadata(eventId);
-    }
-
-    /**
-     * Constructor used when an event identifier is given in advance.
-     * This is used for the case of force snapshot sync for which an
-     * identifier was previously computed in order to provide the caller
-     * with a tracking identifier.
-     *
-     * @param type log replication event type
-     * @param eventId event unique identifier
-     */
-    public LogReplicationEvent(LogReplicationEventType type, UUID eventId) {
-        this.type = type;
-        this.eventId = eventId;
-        this.metadata = new LogReplicationEventMetadata(true);
+        this.metadata = new LogReplicationEventMetadata(Utils.genPseudorandomUUID());
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
@@ -57,7 +57,9 @@ public class LogReplicationEvent {
      * @param type log replication event type
      */
     public LogReplicationEvent(LogReplicationEventType type) {
-        this(type, LogReplicationEventMetadata.empty());
+        this.type = type;
+        this.eventId = Utils.genPseudorandomUUID();
+        this.metadata = new LogReplicationEventMetadata(eventId);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -28,6 +28,7 @@ import org.corfudb.runtime.view.Address;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -198,6 +199,8 @@ public class LogReplicationFSM {
     /**
      * Snapshot Sender (send snapshot cut to remote cluster)
      */
+    @Getter
+    @VisibleForTesting
     private final SnapshotSender snapshotSender;
 
     /**
@@ -446,5 +449,9 @@ public class LogReplicationFSM {
         this.ackReader.shutdown();
         this.logReplicationFSMConsumer.shutdown();
         this.logReplicationFSMWorkers.shutdown();
+    }
+
+    public boolean isValidTransition(UUID currentSyncId, UUID newSyncID) {
+        return currentSyncId.equals(newSyncID);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationState.java
@@ -45,12 +45,12 @@ public interface LogReplicationState {
      *
      * @param eventId event identifier
      */
-    default void setTransitionEventId(UUID eventId) {}
+    default void setTransitionSyncId(UUID eventId) {}
 
     /**
      * Retrieve the id of the event that caused the transition to this state.
      */
-    default UUID getTransitionEventId() { return null; }
+    default UUID getTransitionSyncId() { return null; }
 }
 
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -44,9 +44,10 @@ public class WaitSnapshotApplyState implements LogReplicationState {
     private final LogReplicationFSM fsm;
 
     /**
-     Uniquely identifies the snapshot sync to which this wait state is associated.
+     * Uniquely identifies the snapshot sync to which this wait state is associated.
+     * This is required to validate if the incoming FSM event is for the current sync.
      */
-    private UUID transitionEventId;
+    private UUID transitionSyncId;
 
     /**
      * Route query metadata messages to the remote cluster
@@ -83,30 +84,30 @@ public class WaitSnapshotApplyState implements LogReplicationState {
         switch (event.getType()) {
             case SNAPSHOT_SYNC_REQUEST:
                 log.info("Snapshot Sync requested {} while waiting for {} to complete.",
-                        event.getMetadata().getRequestId(), getTransitionEventId());
+                        event.getMetadata().getSyncId(), getTransitionSyncId());
                 LogReplicationState snapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
-                snapshotSyncState.setTransitionEventId(event.getMetadata().getRequestId());
+                snapshotSyncState.setTransitionSyncId(event.getMetadata().getSyncId());
                 ((InSnapshotSyncState)snapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                 return snapshotSyncState;
             case SYNC_CANCEL:
-                if(fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
-                    log.debug("Sync has been canceled while waiting for Snapshot Sync {} to complete apply. Restart.", transitionEventId);
+                if(fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
+                    log.debug("Sync has been canceled while waiting for Snapshot Sync {} to complete apply. Restart.", transitionSyncId);
                     LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
                     // new ID for new snapshot sync ID
-                    inSnapshotSyncState.setTransitionEventId(UUID.randomUUID());
+                    inSnapshotSyncState.setTransitionSyncId(UUID.randomUUID());
                     ((InSnapshotSyncState) inSnapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                     return inSnapshotSyncState;
                 }
                 log.info("Ignoring Sync cancel event for snapshot sync {}, as ongoing snapshot sync is {}",
-                        event.getMetadata().getRequestId(), transitionEventId);
+                        event.getMetadata().getSyncId(), transitionSyncId);
                 return this;
             case SNAPSHOT_APPLY_IN_PROGRESS:
-                if(fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
-                    log.debug("Snapshot Apply in progress {}. Verify status.", transitionEventId);
+                if(fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
+                    log.debug("Snapshot Apply in progress {}. Verify status.", transitionSyncId);
                     return this;
                 }
                 log.info("Ignoring Snapshot Apply in Progress event for snapshot sync {}, as ongoing snapshot sync is {}",
-                        event.getMetadata().getRequestId(), transitionEventId);
+                        event.getMetadata().getSyncId(), transitionSyncId);
                 return this;
             case SNAPSHOT_APPLY_COMPLETE:
                 /*
@@ -120,39 +121,39 @@ public class WaitSnapshotApplyState implements LogReplicationState {
                  as 4, attempting to process a completion event for the incorrect snapshot sync.
                  */
 
-                if (fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
+                if (fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     LogReplicationState logEntrySyncState = fsm.getStates()
                             .get(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
                     // We need to set a new transition event Id, so anything happening on this new state
                     // is marked with this unique Id and correlated to cancel or trimmed events.
-                    logEntrySyncState.setTransitionEventId(transitionEventId);
+                    logEntrySyncState.setTransitionSyncId(transitionSyncId);
                     fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                     fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                     log.info("Snapshot Sync apply completed, syncRequestId={}, baseSnapshot={}. Transition to LOG_ENTRY_SYNC",
-                            event.getMetadata().getRequestId(), event.getMetadata().getLastTransferredBaseSnapshot());
+                            event.getMetadata().getSyncId(), event.getMetadata().getLastTransferredBaseSnapshot());
                     return logEntrySyncState;
                 }
 
                 log.warn("Ignoring snapshot sync apply complete event for snapshot sync {}, as ongoing snapshot sync is {}",
-                        event.getMetadata().getRequestId(), transitionEventId);
+                        event.getMetadata().getSyncId(), transitionSyncId);
                 return this;
             case REPLICATION_STOP:
                 // No need to validate transitionId as REPLICATION_STOP comes either from enforceSnapshotSync or when
                 // the runtime FSM transitions back to VERIFYING_REMOTE_LEADER from REPLICATING state
-                log.debug("Stop Log Replication while waiting for snapshot sync apply to complete id={}", transitionEventId);
+                log.debug("Stop Log Replication while waiting for snapshot sync apply to complete id={}", transitionSyncId);
                 stopSnapshotApply.set(true);
                 return fsm.getStates().get(LogReplicationStateType.INITIALIZED);
             case REPLICATION_SHUTDOWN:
-                log.debug("Shutdown Log Replication while waiting for snapshot sync apply to complete id={}", transitionEventId);
+                log.debug("Shutdown Log Replication while waiting for snapshot sync apply to complete id={}", transitionSyncId);
                 return fsm.getStates().get(LogReplicationStateType.ERROR);
             default: {
-                if (!fsm.isValidTransition(transitionEventId, event.getMetadata().getRequestId())) {
+                if (!fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     log.warn("Ignoring log replication event {} for sync {} when in wait snapshot sync apply state for sync {}",
-                            event.getType(), event.getMetadata().getRequestId(), transitionEventId);
+                            event.getType(), event.getMetadata().getSyncId(), transitionSyncId);
                     return this;
                 }
                 log.warn("Unexpected log replication event {} for sync {} when in wait snapshot sync apply state for sync {}",
-                        event.getType(), event.getMetadata().getRequestId(), transitionEventId);
+                        event.getType(), event.getMetadata().getSyncId(), transitionSyncId);
                 throw new IllegalTransitionException(event.getType(), getType());
             }
         }
@@ -186,7 +187,7 @@ public class WaitSnapshotApplyState implements LogReplicationState {
 
     private void verifyStatusOfSnapshotSyncApply() {
         try {
-            log.info("Verify snapshot sync apply status, sync={}", transitionEventId);
+            log.info("Verify snapshot sync apply status, sync={}", transitionSyncId);
 
             // Query metadata on remote cluster to verify the status of the snapshot sync apply
             CompletableFuture<LogReplicationMetadataResponseMsg>
@@ -201,10 +202,10 @@ public class WaitSnapshotApplyState implements LogReplicationState {
                 log.info("Snapshot sync apply is complete appliedTs={}, baseTs={}", metadataResponse.getSnapshotApplied(),
                         baseSnapshotTimestamp);
                 fsm.input(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_APPLY_COMPLETE,
-                        new LogReplicationEventMetadata(transitionEventId, baseSnapshotTimestamp, baseSnapshotTimestamp)));
+                        new LogReplicationEventMetadata(transitionSyncId, baseSnapshotTimestamp, baseSnapshotTimestamp)));
             } else {
                 log.debug("Snapshot sync apply is still in progress, appliedTs={}, baseTs={}, sync_id={}", metadataResponse.getSnapshotApplied(),
-                        baseSnapshotTimestamp, transitionEventId);
+                        baseSnapshotTimestamp, transitionSyncId);
                 if (!stopSnapshotApply.get()) {
                     // Schedule a one time action which will verify the snapshot apply status after a given delay
                     this.snapshotSyncApplyMonitorExecutor.schedule(this::scheduleSnapshotApplyVerification, SCHEDULE_APPLY_MONITOR_DELAY,
@@ -231,18 +232,18 @@ public class WaitSnapshotApplyState implements LogReplicationState {
     }
 
     private void scheduleSnapshotApplyVerification() {
-        log.debug("Schedule verification of snapshot sync apply id={}", transitionEventId);
+        log.debug("Schedule verification of snapshot sync apply id={}", transitionSyncId);
         fsm.input(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_APPLY_IN_PROGRESS,
-                new LogReplicationEventMetadata(transitionEventId)));
+                new LogReplicationEventMetadata(transitionSyncId)));
     }
 
     @Override
-    public void setTransitionEventId(UUID eventId) {
-        this.transitionEventId = eventId;
+    public void setTransitionSyncId(UUID eventId) {
+        this.transitionSyncId = eventId;
     }
 
     @Override
-    public UUID getTransitionEventId() { return transitionEventId; }
+    public UUID getTransitionSyncId() { return transitionSyncId; }
 
     @Override
     public LogReplicationStateType getType() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
@@ -13,12 +13,12 @@ public class LogReplicationEventMetadata {
     private static final UUID NIL_UUID = new UUID(0,0);
 
     /*
-     * Represents the request ID of snapshot_sync or log_entry_sync state
+     * Represents the ID of snapshot_sync or log_entry_sync.
      *
-     * This is used to correlate the sync and the event.
-     * For example, a snapshot sync ID 1 , event E1 and a snapshot sync ID2 with event E2
+     * This is used to correlate the sync ID and the FSM event, and if an FSM event is received for some other sync,
+     * it is effectively ignored.
      */
-    private UUID requestId;
+    private UUID syncId;
 
     /*
      * Represents the last log entry synced timestamp.
@@ -33,69 +33,49 @@ public class LogReplicationEventMetadata {
     private boolean forceSnapshotSync = false;
 
     /**
-     * Empty Metadata
+     * Constructor
      *
-     * @return an empty instance of log replication event metadata
+     * @param syncId identifier of the request that preceded this event.
      */
-    public static LogReplicationEventMetadata empty() {
-        return new LogReplicationEventMetadata(NIL_UUID, -1L);
+    public LogReplicationEventMetadata(UUID syncId) {
+        this.syncId = syncId;
     }
 
     /**
      * Constructor
      *
-     * @param requestId identifier of the request that preceded this event.
+     * @param syncId identifier of the request that preceded this event.
      */
-    public LogReplicationEventMetadata(UUID requestId) {
-        this.requestId = requestId;
-    }
-
-    /**
-     * Constructor
-     *
-     * @param requestId identifier of the request that preceded this event.
-     */
-    public LogReplicationEventMetadata(UUID requestId, boolean forceSnapshotSync) {
-        this.requestId = requestId;
+    public LogReplicationEventMetadata(UUID syncId, boolean forceSnapshotSync) {
+        this.syncId = syncId;
         this.forceSnapshotSync = forceSnapshotSync;
     }
 
     /**
      * Constructor
      *
-     * @param requestId identifier of the request that preceded this event.
+     * @param syncId identifier of the request that preceded this event.
      * @param syncTimestamp last synced timestamp.
      */
-    public LogReplicationEventMetadata(UUID requestId, long syncTimestamp) {
-        this.requestId = requestId;
+    public LogReplicationEventMetadata(UUID syncId, long syncTimestamp) {
+        this.syncId = syncId;
         this.lastLogEntrySyncedTimestamp = syncTimestamp;
     }
 
     /**
      * Constructor
      *
-     * @param requestId identifier of the request that preceded this event.
+     * @param syncId identifier of the request that preceded this event.
      * @param syncTimestamp last synced timestamp.
      * @param baseSnapshot last base snapshot
      */
-    public LogReplicationEventMetadata(UUID requestId, long syncTimestamp, long baseSnapshot) {
-        this(requestId, syncTimestamp);
+    public LogReplicationEventMetadata(UUID syncId, long syncTimestamp, long baseSnapshot) {
+        this(syncId, syncTimestamp);
         this.lastTransferredBaseSnapshot = baseSnapshot;
     }
 
-    /**
-     * Constructor
-     *
-     * @param forceSnapshotSync true, if snapshot sync has been forced by caller.
-     *                          false, otherwise.
-     */
-    public LogReplicationEventMetadata(boolean forceSnapshotSync) {
-        this(NIL_UUID, -1L);
-        this.forceSnapshotSync = forceSnapshotSync;
-    }
-
-    public UUID getRequestId() {
-        return this.requestId;
+    public UUID getSyncId() {
+        return this.syncId;
     }
 
     public long getLastLogEntrySyncedTimestamp() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
@@ -13,10 +13,10 @@ public class LogReplicationEventMetadata {
     private static final UUID NIL_UUID = new UUID(0,0);
 
     /*
-     * Represents the request/event Id that preceded this event.
+     * Represents the request ID of snapshot_sync or log_entry_sync state
      *
-     * This is used to correlate the event with the state in which it was originated.
-     * For example, a trimmed exception from state A vs. a trimmed exception from state B.
+     * This is used to correlate the sync and the event.
+     * For example, a snapshot sync ID 1 , event E1 and a snapshot sync ID2 with event E2
      */
     private UUID requestId;
 
@@ -48,6 +48,16 @@ public class LogReplicationEventMetadata {
      */
     public LogReplicationEventMetadata(UUID requestId) {
         this.requestId = requestId;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param requestId identifier of the request that preceded this event.
+     */
+    public LogReplicationEventMetadata(UUID requestId, boolean forceSnapshotSync) {
+        this.requestId = requestId;
+        this.forceSnapshotSync = forceSnapshotSync;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
@@ -120,11 +120,11 @@ public class LogReplicationSourceManager {
     }
 
     private UUID startSnapshotSync(LogReplicationEvent snapshotSyncRequest) {
-        log.info("Start Snapshot Sync, requestId={}, forced={}", snapshotSyncRequest.getMetadata().getRequestId(),
+        log.info("Start Snapshot Sync, requestId={}, forced={}", snapshotSyncRequest.getMetadata().getSyncId(),
                 snapshotSyncRequest.getMetadata().isForcedSnapshotSync());
         // Enqueue snapshot sync request into Log Replication FSM
         logReplicationFSM.input(snapshotSyncRequest);
-        return snapshotSyncRequest.getMetadata().getRequestId();
+        return snapshotSyncRequest.getMetadata().getSyncId();
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
@@ -116,14 +116,15 @@ public class LogReplicationSourceManager {
      * @return unique identifier for this snapshot sync request.
      */
     public UUID startSnapshotSync() {
-        return startSnapshotSync(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST), false);
+        return startSnapshotSync(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST));
     }
 
-    private UUID startSnapshotSync(LogReplicationEvent snapshotSyncRequest, boolean forced) {
-        log.info("Start Snapshot Sync, requestId={}, forced={}", snapshotSyncRequest.getEventId(), forced);
+    private UUID startSnapshotSync(LogReplicationEvent snapshotSyncRequest) {
+        log.info("Start Snapshot Sync, requestId={}, forced={}", snapshotSyncRequest.getMetadata().getRequestId(),
+                snapshotSyncRequest.getMetadata().isForcedSnapshotSync());
         // Enqueue snapshot sync request into Log Replication FSM
         logReplicationFSM.input(snapshotSyncRequest);
-        return snapshotSyncRequest.getEventId();
+        return snapshotSyncRequest.getMetadata().getRequestId();
     }
 
     /**
@@ -132,7 +133,8 @@ public class LogReplicationSourceManager {
      * @param snapshotSyncRequestId unique identifier of the forced snapshot sync (already provided to the caller)
      */
     public void startForcedSnapshotSync(UUID snapshotSyncRequestId) {
-        startSnapshotSync(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, snapshotSyncRequestId), true);
+        startSnapshotSync(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST,
+                new LogReplicationEventMetadata(snapshotSyncRequestId, true)));
     }
 
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -246,13 +246,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
         }
 
         if (!currentStreamHasNext()) {
-            // Since FSM is a perpetually running machine, InSnapshotSync.onEntry() is called even when an incoming
-            // event is ignored for any reason.
-            // This translates to read() being called even if currentStreamInfo was set to null after sending all the
-            // snapshot sync data but before transitioning to the next state.
-            if(currentStreamInfo != null) {
-                log.debug("Snapshot log reader finished reading stream id={}, name={}", currentStreamInfo.uuid, currentStreamInfo.name);
-            }
+            log.debug("Snapshot log reader finished reading stream id={}, name={}", currentStreamInfo.uuid, currentStreamInfo.name);
             currentStreamInfo = null;
 
             if (streamsToSend.isEmpty()) {
@@ -265,9 +259,6 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     }
 
     private boolean currentStreamHasNext() {
-        if (currentStreamInfo == null) {
-            return false;
-        }
         return currentStreamInfo.iterator.hasNext() || lastEntry != null;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -92,7 +92,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 break;
             case SNAPSHOT_TRANSFER_COMPLETE:
                 replicationSourceManager.resumeSnapshotSync(replicationEvent.getMetadata());
-                log.trace("Wait Snapshot Sync to complete, request={}", replicationEvent.getMetadata().getRequestId());
+                log.trace("Wait Snapshot Sync to complete, request={}", replicationEvent.getMetadata().getSyncId());
                 break;
             case LOG_ENTRY_SYNC_REQUEST:
                 replicationSourceManager.startReplication(replicationEvent);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -150,7 +150,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     @Test
     public void testLogReplicationFSMTransitions() throws Exception {
 
-        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
+        initLogReplicationFSM(ReaderImplementation.STREAMS, false);
 
         // Initial state: Initialized
         LogReplicationState initState = fsm.getState();
@@ -431,7 +431,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
      */
     @Test
     public void testSyncStatusUpdatesForSnapshotToLogEntryTransition() throws Exception {
-        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
+        initLogReplicationFSM(ReaderImplementation.STREAMS, false);
 
         final Table<LogReplicationSession, ReplicationStatus, Message> statusTable =
                 this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE_NAME);
@@ -460,7 +460,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Assert.assertEquals(SyncStatus.ONGOING, currentReplicationVal.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus());
 
         // Transition #2: Wait Snapshot Apply
-        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, snapshotSyncId, false);
+        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, snapshotSyncId, true);
 
         // Transition #3: Log Entry Sync Start
         transition(LogReplicationEventType.SNAPSHOT_APPLY_COMPLETE, LogReplicationStateType.IN_LOG_ENTRY_SYNC, snapshotSyncId, true);
@@ -798,7 +798,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     public void testTransitionFromInSnapshotSyncWhenMultipleSnapshotSync() throws Exception {
         observeTransitions = true;
 
-        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
+        initLogReplicationFSM(ReaderImplementation.STREAMS, false);
 
         // Initial state: Initialized
         LogReplicationState initState = fsm.getState();
@@ -856,7 +856,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     @Test
     public void testTransitionFromWaitSnapshotApplyWhenMultipleSnapshotSync() throws Exception {
 
-        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
+        initLogReplicationFSM(ReaderImplementation.STREAMS, false);
 
         // Initial state: Initialized
         LogReplicationState initState = fsm.getState();
@@ -1040,7 +1040,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         assertThat(fsm.getState().getType()).isEqualTo(expectedState);
 
-        return event.getEventId();
+        return event.getMetadata().getSyncId();
     }
 
     /**

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -171,7 +171,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSyncId, true);
 
         // Transition #5: Snapshot Sync Transfer Complete
-        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, snapshotSyncId, false);
+        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, snapshotSyncId, true);
 
         // Transition #6: Snapshot Sync Apply still in progress
         transition(LogReplicationEventType.SNAPSHOT_APPLY_IN_PROGRESS, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, false);
@@ -774,6 +774,119 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         }
 
         assertThat(incrementalUpdates).isEqualTo(NUM_ENTRIES);
+    }
+
+    /**
+     * Verify state machine behavior when there are multiple snapshot sync request in IN_SNAPSHOT_SYNC state.
+     *
+     * This is the sequence of events triggered and expected state change:
+     *
+     * (1) None -> verify FSM initial state is INITIALIZED
+     * (2) Snapshot sync request -> IN_SNAPSHOT_SYNC state
+     * (3) Snapshot sync continue -> IN_SNAPSHOT_SYNC state
+     * // simulate snapshot_sync request
+     * (4) New Snapshot Sync incoming -> cancel the old snapshot Sync, stay in IN_SNAPSHOT_SYNC state
+     * // clear the states of the old snapshot request, but continue checking interleaving possibilities
+     * (5) ensure the buffer is cleared and the snapshot reader thread stopped.
+     * (6) Snapshot sync continue from older request -> ignore the state.
+     * (7) Snapshot sync continue from new request -> IN_SNAPSHOT_SYNC state
+     * (8) Transfer completed -> WAIT_SNAPSHOT_APPLY state
+     * (9) Snapshot sync continue from older request -> Ignore, stay in WAIT_SNAPSHOT_APPLY
+     *
+     */
+    @Test
+    public void testTransitionFromInSnapshotSyncWhenMultipleSnapshotSync() throws Exception {
+        observeTransitions = true;
+
+        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
+
+        // Initial state: Initialized
+        LogReplicationState initState = fsm.getState();
+        assertThat(initState.getType()).isEqualTo(LogReplicationStateType.INITIALIZED);
+
+        transitionAvailable.acquire();
+
+        // Transition #1: Snapshot sync request -> IN_SNAPSHOT_SYNC state
+        UUID snapshotSync1 = transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC);
+
+        // Transition #2: Snapshot sync continue -> IN_SNAPSHOT_SYNC state
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync1, true);
+
+        // Simulate a new incoming Snapshot sync request
+        UUID snapshotSync2 = UUID.randomUUID();
+        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync1);
+
+        // Transition #3: Snapshot sync continue -> IN_SNAPSHOT_SYNC state
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync2, true);
+
+        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync2);
+
+        // Transition #4: old sync's snapshot sync continue -> ignored by FSM
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync1, false);
+
+        // Transition #5: new sync's snapshot sync continue
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync2, false);
+
+        // Transition #6: new sync's transfer completed -> WAIT_SNAPSHOT_APPLY
+        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY,snapshotSync2, true);
+
+        // Transition #7: old sync's snapshot sync continue -> ignored by FSM
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, snapshotSync1, false);
+
+        assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
+
+        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync2);
+    }
+
+    /**
+     * Verify state machine behavior when there are multiple snapshot sync request in IN_SNAPSHOT_SYNC state.
+     *
+     * This is the sequence of events triggered and expected state change:
+     *
+     * (1) None -> verify FSM initial state is INITIALIZED
+     * (2) Snapshot sync request -> IN_SNAPSHOT_SYNC state
+     * (3) Snapshot sync continue -> IN_SNAPSHOT_SYNC state
+     * (4) Transfer completed -> WAIT_SNAPSHOT_APPLY state
+     * (5) simulate a sync_stop event for a different snapshot sync -> WAIT_SNAPSHOT_APPLY state
+     * // simulate a new snapshot sync, forced = true
+     * (5) stop existing replication -> INITIALIZED state
+     * (6) start snapshot request -> IN_SNAPSHOT_SYNC state
+     *
+     */
+    @Test
+    public void testTransitionFromWaitSnapshotApplyWhenMultipleSnapshotSync() throws Exception {
+
+        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
+
+        // Initial state: Initialized
+        LogReplicationState initState = fsm.getState();
+        assertThat(initState.getType()).isEqualTo(LogReplicationStateType.INITIALIZED);
+
+        transitionAvailable.acquire();
+
+        // Transition #1: Snapshot sync request -> IN_SNAPSHOT_SYNC state
+        UUID snapshotSync = transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC);
+
+        // Transition #2: Snapshot sync continue -> IN_SNAPSHOT_SYNC state
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync, true);
+
+        // Transition #3: transfer completed -> WAIT_SNAPSHOT_APPLY
+        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY,snapshotSync, true);
+
+        // Transition #4: sync cancel from a different snapshot event -> Ignored, reaming in WAIT_SNAPSHOT_APPLY
+        transition(LogReplicationEventType.SYNC_CANCEL, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, UUID.randomUUID(), false);
+
+        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync);
+
+        UUID forceSnapshotID = UUID.randomUUID();
+        // Transition #5: stop the running snapshot sync -> INITIALIZED state
+        transition(LogReplicationEventType.REPLICATION_STOP, LogReplicationStateType.INITIALIZED, forceSnapshotID, true);
+
+        // Transition #6: Snapshot sync request -> IN_SNAPSHOT_SYNC state
+        transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, forceSnapshotID, true);
+
+        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(forceSnapshotID);
+
     }
 
     private void writeToMap() throws Exception {

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -563,7 +563,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         // Transition #3: Trimmed Exception
         // Because this is an internal state, we need to capture the actual event id internally generated
-        UUID logEntrySyncID = fsm.getStates().get(LogReplicationStateType.IN_LOG_ENTRY_SYNC).getTransitionEventId();
+        UUID logEntrySyncID = fsm.getStates().get(LogReplicationStateType.IN_LOG_ENTRY_SYNC).getTransitionSyncId();
         transition(LogReplicationEventType.SYNC_CANCEL, LogReplicationStateType.IN_SNAPSHOT_SYNC, logEntrySyncID, true);
     }
 
@@ -814,12 +814,12 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         // Simulate a new incoming Snapshot sync request
         UUID snapshotSync2 = UUID.randomUUID();
-        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync1);
+        assertThat(fsm.getState().getTransitionSyncId()).isEqualTo(snapshotSync1);
 
         // Transition #3: Snapshot sync continue -> IN_SNAPSHOT_SYNC state
         transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync2, true);
 
-        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync2);
+        assertThat(fsm.getState().getTransitionSyncId()).isEqualTo(snapshotSync2);
 
         // Transition #4: old sync's snapshot sync continue -> ignored by FSM
         transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync1, false);
@@ -835,7 +835,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
 
-        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync2);
+        assertThat(fsm.getState().getTransitionSyncId()).isEqualTo(snapshotSync2);
     }
 
     /**
@@ -876,7 +876,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // Transition #4: sync cancel from a different snapshot event -> Ignored, reaming in WAIT_SNAPSHOT_APPLY
         transition(LogReplicationEventType.SYNC_CANCEL, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, UUID.randomUUID(), false);
 
-        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(snapshotSync);
+        assertThat(fsm.getState().getTransitionSyncId()).isEqualTo(snapshotSync);
 
         UUID forceSnapshotID = UUID.randomUUID();
         // Transition #5: stop the running snapshot sync -> INITIALIZED state
@@ -885,7 +885,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // Transition #6: Snapshot sync request -> IN_SNAPSHOT_SYNC state
         transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, forceSnapshotID, true);
 
-        assertThat(fsm.getState().getTransitionEventId()).isEqualTo(forceSnapshotID);
+        assertThat(fsm.getState().getTransitionSyncId()).isEqualTo(forceSnapshotID);
 
     }
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -142,8 +142,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     @Parameterized.Parameters
     public static List<ClusterUuidMsg> input() {
         return Arrays.asList(
-                TP_SINGLE_SOURCE_SINK
-                //TP_SINGLE_SOURCE_SINK_REV_CONNECTION
+                TP_SINGLE_SOURCE_SINK,
+                TP_SINGLE_SOURCE_SINK_REV_CONNECTION
         );
 
     }


### PR DESCRIPTION
This change aims to gate the transition of the replication FSM. Since the consumption of events and the processing of events are done by different threads concurrently, its possible to get an event from an old sync. In that case, we should ignore the event and not transition out of the current state.

**Example**: a snapshot-sync-1 is canceled and snapshot-sync-2 is triggered. Now snapshot-sync-2 is in WAIT_SNAPSHOT_APPLY state, and we receive sync_cancel event from snapshot-sync-1. 
With the current code, we will cancel snapshot-sync-2 because we blindly consume the event and transition to INITIALIZED state. 
This change introduces a check before before we consume the event. The check uses the sync-id to understand if the current event has been processed by the ongoing sync and not by a stale sync.

**This change includes:**
(0) the various ID: eventID, event.getMetadata.getRequestID are not consistently set...currently this has various values. Fixing this by using the event.getMetadata.RequestID to identify snapshot/logEntry sync, and eventID to identify the events themselves
(1) Verify the validity of replicationFSM state transition: check if the incoming event is for the same sync as the one currently running.
(2) Synchronize sinkManager -> synchronize the completeApply tasks and start_snapshot tasks (the full fix of increasing the thread count of LogReplicationServer is in PR 3750)

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
