### PR TITLE
cleanup: remove a TODO + a variable that is no longer needed

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
@@ -29,9 +29,6 @@ public interface CorfuReplicationDiscoveryServiceAdapter {
      * Enforce snapshotFullSync
      */
     UUID forceSnapshotSync(LogReplicationSession session) throws LogReplicationDiscoveryServiceException;
-
-    // TODO [V2]: Remove this when localNodeId moves to plugin
-    String getLocalNodeId();
     
     /**
      * Get outgoing sessions

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -345,7 +345,6 @@ public class SessionManager {
                         if (supportedModels.contains(subscriber.getModel())) {
                             LogReplicationSession session =
                                     constructSession(remoteSourceCluster.clusterId, localClusterId, subscriber);
-                            // TODO: (V2 / Chris) this is still not thread-safe, need to synchronize on sessions
                             if (!sessions.contains(session)) {
                                 sessionsToAdd.add(session);
                                 metadataManager.addSession(txn, session, topology.getTopologyConfigId(), true);


### PR DESCRIPTION
## Overview
1. The data structures which contain sessions are all thread safe, sow writes are blocking but reads are non-blocking. And our logic takes care of scenarios where we are reading (iterator/get) in one thread and currently a session is updated (added/removed) by another thread.
2. the localNodeId is coming from the clusterManager plugin now. The removal of the member in the interface is a cleanup that was missed before

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
