### PR TITLE
@rocksdb: Bound the size of LOG files

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/DiskBackedCorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/DiskBackedCorfuTable.java
@@ -96,6 +96,9 @@ public class DiskBackedCorfuTable<K, V> implements
 
     public static final Options defaultOptions = getDiskBackedCorfuTableOptions();
     private static final HashFunction murmurHash3 = Hashing.murmur3_32();
+    private static final long NUM_LOG_FILES = 2;
+    private static final long LOG_FILE_SIZE = 1024 * 1024 * 5; // 5MB.
+
     private static final String DISK_BACKED = "diskBacked";
     private static final String TRUE = "true";
     private static final int BOUND = 100;
@@ -197,6 +200,11 @@ public class DiskBackedCorfuTable<K, V> implements
 
         options.setCreateIfMissing(true);
         options.setCompressionType(CompressionType.LZ4_COMPRESSION);
+
+        // For long-running processes, limit the amount of space
+        // that the log files can occupy.
+        options.setKeepLogFileNum(NUM_LOG_FILES);
+        options.setMaxLogFileSize(LOG_FILE_SIZE);
 
         BlockBasedTableConfig blockBasedTableConfig = new BlockBasedTableConfig();
         blockBasedTableConfig.setFilterPolicy(new BloomFilter(10));


### PR DESCRIPTION
By default, there is no limit on how much space LOG files can occupy. Bound the maximum number of LOG files that can be created and the maximum size of any LOG file.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
