### PR TITLE
Validate maxWriteSize of a transaction before compression

### DIFF
--- a/common/src/main/java/org/corfudb/common/compression/ZSTDCompression.java
+++ b/common/src/main/java/org/corfudb/common/compression/ZSTDCompression.java
@@ -31,13 +31,13 @@ public class ZSTDCompression implements Codec {
         Objects.requireNonNull(uncompressed);
         checkArgument(uncompressed.hasRemaining());
 
-        final int decompressedLength = uncompressed.remaining();
-        MicroMeterUtils.measure(decompressedLength, "logdata.decompressed.size");
-        final int maxCompressedLength = (int) Zstd.compressBound(decompressedLength);
+        final int uncompressedLength = uncompressed.remaining();
+        MicroMeterUtils.measure(uncompressedLength, "logdata.uncompressed.size");
+        final int maxCompressedLength = (int) Zstd.compressBound(uncompressedLength);
 
         byte[] compressed = new byte[maxCompressedLength + Integer.BYTES];
         ByteBuffer wrappedBuf = ByteBuffer.wrap(compressed);
-        wrappedBuf.putInt(decompressedLength);
+        wrappedBuf.putInt(uncompressedLength);
 
         long compressedLen = Zstd.compressByteArray(compressed, Integer.BYTES, maxCompressedLength,
                 uncompressed.array(), uncompressed.position(), uncompressed.remaining(),
@@ -47,7 +47,7 @@ public class ZSTDCompression implements Codec {
             throw new IllegalStateException("Compression failed with error code " + compressedLen);
         }
 
-        double compressionRatio = (double) decompressedLength/compressedLen;
+        double compressionRatio = (double) uncompressedLength/compressedLen;
         MicroMeterUtils.measure(compressionRatio, "logdata.compression.ratio");
         if (compressionRatio > EXPECTED_COMPRESSION_RATIO) {
             log.debug("High compression ratio: {}", compressionRatio);

--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 @Slf4j
 public class CompactorBaseConfig {
 
-    // Reduce checkpoint batch size due to disk-based nature and for smaller compactor JVM size
-    public static final int DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE = 1 << 20;
-    public static final int DEFAULT_CP_MAX_WRITE_SIZE = 25 << 20;
+    // Since the maxWriteSize now validates the uncompressed limit, the value can be made
+    // same as the maxUncompressedCpEntrySize
+    public static final int DEFAULT_CP_MAX_WRITE_SIZE = 100_000_000;
     public static final int SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT = 100;  // Corfu default is 20
     public static final int CORFU_LOG_CHECKPOINT_ERROR = 3;
     private static final int SYSTEM_EXIT_ERROR_CODE = -3;
@@ -71,20 +71,7 @@ public class CompactorBaseConfig {
             }
         });
 
-        Optional<String> maybeMaxWriteSize = getOpt("--maxWriteSize");
-        int maxWriteSize;
-        if (maybeMaxWriteSize.isPresent()) {
-            maxWriteSize = Integer.parseInt(maybeMaxWriteSize.get());
-        } else {
-            if (!persistedCacheRoot.isPresent()) {
-                // in-memory compaction
-                maxWriteSize = DEFAULT_CP_MAX_WRITE_SIZE;
-            } else {
-                // disk-backed compaction
-                maxWriteSize = DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE;
-            }
-        }
-        builder.maxWriteSize(maxWriteSize);
+        builder.maxWriteSize(getOpt("--maxWriteSize").map(Integer::parseInt).orElse(DEFAULT_CP_MAX_WRITE_SIZE));
 
         getOpt("--bulkReadSize").ifPresent(bulkReadSizeStr -> {
             builder.bulkReadSize(Integer.parseInt(bulkReadSizeStr));

--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 @Slf4j
 public class CompactorBaseConfig {
 
-    // Since the maxWriteSize now validates the uncompressed limit, the value can be made
-    // same as the maxUncompressedCpEntrySize
-    public static final int DEFAULT_CP_MAX_WRITE_SIZE = 100_000_000;
+    // Reduce checkpoint batch size due to disk-based nature and for smaller compactor JVM size
+    public static final int DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE = 1 << 20;
+    public static final int DEFAULT_CP_MAX_WRITE_SIZE = 25 << 20;
     public static final int SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT = 100;  // Corfu default is 20
     public static final int CORFU_LOG_CHECKPOINT_ERROR = 3;
     private static final int SYSTEM_EXIT_ERROR_CODE = -3;
@@ -71,7 +71,8 @@ public class CompactorBaseConfig {
             }
         });
 
-        builder.maxWriteSize(getOpt("--maxWriteSize").map(Integer::parseInt).orElse(DEFAULT_CP_MAX_WRITE_SIZE));
+        builder.maxWriteSize(getOpt("--maxWriteSize").map(Integer::parseInt).orElse(
+                persistedCacheRoot.isPresent() ? DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE : DEFAULT_CP_MAX_WRITE_SIZE));
 
         getOpt("--bulkReadSize").ifPresent(bulkReadSizeStr -> {
             builder.bulkReadSize(Integer.parseInt(bulkReadSizeStr));

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -3,6 +3,7 @@ package org.corfudb.protocols.wireprotocol;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -50,11 +51,12 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
          * to the log data.
          *
          * @param data     the log data to manage
+         * @param limit if a value is passed, validate size of data against the limit
          * @param metadata whether metadata needs to be serialized
          */
-        public SerializationHandle(ILogData data, boolean metadata) {
+        public SerializationHandle(ILogData data, boolean metadata, Optional<Integer> limit) {
             this.data = data;
-            data.acquireBuffer(metadata);
+            data.acquireBuffer(metadata, limit);
         }
 
         /**
@@ -74,7 +76,19 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * @return a serialization handle of this entry
      */
     default SerializationHandle getSerializedForm(boolean metadata) {
-        return new SerializationHandle(this, metadata);
+        return getSerializedForm(metadata, Optional.empty());
+    }
+
+    /**
+     * Get the serialization handle of this entry that manages
+     * the lifetime of the serialized copy.
+     *
+     * @param metadata whether metadata needs to be serialized
+     * @param limit if a value is passed, validate size of data against the limit
+     * @return a serialization handle of this entry
+     */
+    default SerializationHandle getSerializedForm(boolean metadata, Optional<Integer> limit) {
+        return new SerializationHandle(this, metadata, limit);
     }
 
     /**
@@ -86,8 +100,9 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * Acquire the serialization buffer.
      *
      * @param metadata whether metadata needs to be serialized
+     * @param limit if a value is passed, validate size of data against the limit
      */
-    void acquireBuffer(boolean metadata);
+    void acquireBuffer(boolean metadata, Optional<Integer> limit);
 
     /**
      * Return the payload as a log entry.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -19,6 +19,7 @@ import org.corfudb.util.serializer.Serializers;
 import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -149,9 +150,9 @@ public class LogData implements IMetadata, ILogData {
     }
 
     @Override
-    public synchronized void acquireBuffer(boolean metadata) {
+    public synchronized void acquireBuffer(boolean metadata, Optional<Integer> limit) {
         if (serializedCache == null) {
-            acquireBufferInternal(metadata);
+            acquireBufferInternal(metadata, limit);
         } else {
             if (metadata) {
                 serializedCache.buffer.resetReaderIndex();
@@ -165,16 +166,16 @@ public class LogData implements IMetadata, ILogData {
     public synchronized void updateAcquiredBuffer(boolean metadata) {
         Preconditions.checkState(serializedCache != null,
                 "updateAcquiredBuffer requires serialized form");
-        acquireBufferInternal(metadata);
+        acquireBufferInternal(metadata, Optional.empty());
     }
 
-    private void acquireBufferInternal(boolean metadata) {
+    private void acquireBufferInternal(boolean metadata, Optional<Integer> limit) {
         ByteBuf buf = Unpooled.buffer();
         if (metadata) {
-            int metadataOffset = doSerializeInternal(buf);
+            int metadataOffset = doSerializeInternal(buf, limit);
             serializedCache = new SerializedCache(buf, metadataOffset);
         } else {
-            doSerializePayloadInternal(buf);
+            doSerializePayloadInternal(buf, limit);
             serializedCache = new SerializedCache(buf, buf.writerIndex());
         }
     }
@@ -299,19 +300,19 @@ public class LogData implements IMetadata, ILogData {
             serializedCache.buffer.resetReaderIndex();
             buf.writeBytes(serializedCache.buffer);
         } else {
-            doSerializeInternal(buf);
+            doSerializeInternal(buf, Optional.empty());
         }
     }
 
-    private int doSerializeInternal(ByteBuf buf) {
-        doSerializePayloadInternal(buf);
+    private int doSerializeInternal(ByteBuf buf, Optional<Integer> limit) {
+        doSerializePayloadInternal(buf, limit);
         int metadataOffset = buf.writerIndex();
         doSerializeMetadataInternal(buf);
 
         return metadataOffset;
     }
 
-    private void doSerializePayloadInternal(ByteBuf buf) {
+    private void doSerializePayloadInternal(ByteBuf buf, Optional<Integer> limit) {
         CorfuProtocolCommon.serialize(buf, type.asByte());
         if (type == DataType.DATA) {
             if (data == null) {
@@ -321,9 +322,11 @@ public class LogData implements IMetadata, ILogData {
                     // If the payload has a codec we need to also compress the payload
                     ByteBuf serializeBuf = Unpooled.buffer();
                     Serializers.CORFU.serialize(payload.get(), serializeBuf);
+                    checkMaxWriteSizeIfRequired(limit, serializeBuf.writerIndex() - (lengthIndex + 4));
                     doCompressInternal(serializeBuf, buf);
                 } else {
                     Serializers.CORFU.serialize(payload.get(), buf);
+                    checkMaxWriteSizeIfRequired(limit, buf.writerIndex() - (lengthIndex + 4));
                 }
                 int size = buf.writerIndex() - (lengthIndex + 4);
                 buf.writerIndex(lengthIndex);
@@ -382,24 +385,13 @@ public class LogData implements IMetadata, ILogData {
         return "LogData[" + getGlobalAddress() + "]";
     }
 
-    /**
-     * Verify that max payload is enforced for the specified limit.
-     *
-     * @param limit Max write limit
-     * @return the serialized size of the payload
-     */
-    public int checkMaxWriteSize(int limit) {
-        Preconditions.checkState(serializedCache != null, "checkMaxWriteSize requires serialized form");
-
-        int payloadSize = getSizeEstimate();
-        if (log.isTraceEnabled()) {
-            log.trace("checkMaxWriteSize: payload size is {} bytes.", payloadSize);
+    private void checkMaxWriteSizeIfRequired(Optional<Integer> limit, int payloadSize) {
+        if (!limit.isPresent()) {
+            return;
         }
-
-        if (payloadSize > limit) {
-            throw new WriteSizeException(payloadSize, limit);
+        log.trace("checkMaxWriteSize: payload size is {} bytes.", payloadSize);
+        if (payloadSize > limit.get()) {
+            throw new WriteSizeException(payloadSize, limit.get());
         }
-
-        return payloadSize;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -203,7 +203,12 @@ public class CorfuRuntime {
         /*
          * Max uncompressed size for a write request.
          */
-        int maxWriteSize = 26214400;
+        int maxUncompressedWriteSize = 100 << 20;
+
+        /*
+         * Max compressed size for a write request.
+         */
+        int maxWriteSize = 25 << 20;
 
         /*
          * Set the bulk read size.
@@ -425,7 +430,9 @@ public class CorfuRuntime {
         public static class CorfuRuntimeParametersBuilder extends RuntimeParametersBuilder {
 
             //Max uncompressed size for a write request.
-            private int maxWriteSize = 26214400;
+            private int maxUncompressedWriteSize = 100 << 20;
+            //Max compressed size for a write request
+            private int maxWriteSize = 25 << 20;
             private int bulkReadSize = 10;
             private int holeFillRetry = 10;
             private Duration holeFillRetryThreshold = Duration.ofSeconds(1L);
@@ -613,6 +620,11 @@ public class CorfuRuntime {
                 return this;
             }
 
+            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder maxUncompressedWriteSize(int maxUncompressedWriteSize) {
+                this.maxUncompressedWriteSize = maxUncompressedWriteSize;
+                return this;
+            }
+
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder bulkReadSize(int bulkReadSize) {
                 this.bulkReadSize = bulkReadSize;
                 return this;
@@ -797,6 +809,7 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setSystemDownHandler(systemDownHandler);
                 corfuRuntimeParameters.setBeforeRpcHandler(beforeRpcHandler);
                 corfuRuntimeParameters.setMaxWriteSize(maxWriteSize);
+                corfuRuntimeParameters.setMaxUncompressedWriteSize(maxUncompressedWriteSize);
                 corfuRuntimeParameters.setBulkReadSize(bulkReadSize);
                 corfuRuntimeParameters.setHoleFillRetry(holeFillRetry);
                 corfuRuntimeParameters.setHoleFillRetryThreshold(holeFillRetryThreshold);

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -201,9 +201,9 @@ public class CorfuRuntime {
     public static class CorfuRuntimeParameters extends RuntimeParameters {
 
         /*
-         * Max size for a write request.
+         * Max uncompressed size for a write request.
          */
-        int maxWriteSize = Integer.MAX_VALUE;
+        int maxWriteSize = 26214400;
 
         /*
          * Set the bulk read size.
@@ -301,11 +301,6 @@ public class CorfuRuntime {
          * The maximum number of SMR entries that will be grouped in a CheckpointEntry.CONTINUATION
          */
         int checkpointBatchSize = 50;
-
-        /*
-         * The maximum size of an uncompressed CheckpointEntry.CONTINUATION that can be written
-         */
-        long maxUncompressedCpEntrySize = 100_000_000;
 
         /*
          * The maximum number of SMR entries that will be grouped in a MultiSMREntry during Restore
@@ -428,7 +423,9 @@ public class CorfuRuntime {
         }
 
         public static class CorfuRuntimeParametersBuilder extends RuntimeParametersBuilder {
-            private int maxWriteSize = Integer.MAX_VALUE;
+
+            //Max uncompressed size for a write request.
+            private int maxWriteSize = 26214400;
             private int bulkReadSize = 10;
             private int holeFillRetry = 10;
             private Duration holeFillRetryThreshold = Duration.ofSeconds(1L);
@@ -446,7 +443,6 @@ public class CorfuRuntime {
             private int trimRetry = 2;
             private int checkpointRetries = 5;
             private int checkpointBatchSize = 50;
-            private long maxUncompressedCpEntrySize = 100_000_000;
             private int restoreBatchSize = 50;
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 1;
@@ -702,11 +698,6 @@ public class CorfuRuntime {
                 return this;
             }
 
-            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder maxUncompressedCpEntrySize(long maxUncompressedCpEntrySize) {
-                this.maxUncompressedCpEntrySize = maxUncompressedCpEntrySize;
-                return this;
-            }
-
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder restoreBatchSize(int restoreBatchSize) {
                 this.restoreBatchSize = restoreBatchSize;
                 return this;
@@ -823,7 +814,6 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setTrimRetry(trimRetry);
                 corfuRuntimeParameters.setCheckpointRetries(checkpointRetries);
                 corfuRuntimeParameters.setCheckpointBatchSize(checkpointBatchSize);
-                corfuRuntimeParameters.setMaxUncompressedCpEntrySize(maxUncompressedCpEntrySize);
                 corfuRuntimeParameters.setRestoreBatchSize(restoreBatchSize);
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/WriteSizeException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/WriteSizeException.java
@@ -8,4 +8,8 @@ public class WriteSizeException extends RuntimeException {
     public WriteSizeException(int size, int max) {
         super("Trying to write " + size + " bytes but max write limit is " + max + " bytes");
     }
+
+    public WriteSizeException(String message) {
+        super(message);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -188,8 +188,8 @@ public abstract class AbstractQueuedStreamView extends
         // writer will append the serialized metadata to the buffer.
         // Also, validate if the  size of the log data is under max write size.
         try (ILogData.SerializationHandle sh = ld.getSerializedForm(false,
-                Optional.of(runtime.getParameters().getMaxWriteSize()))) {
-            int payloadSize = ld.getSizeEstimate();
+                Optional.of(runtime.getParameters().getMaxUncompressedWriteSize()))) {
+            int payloadSize = ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
 
             // First, we get a token from the sequencer.
             TokenResponse tokenResponse = runtime.getSequencerView().next(id);

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Function;
@@ -185,9 +186,10 @@ public abstract class AbstractQueuedStreamView extends
         // The serialization here only serializes the payload because the token is not
         // acquired yet, thus metadata is incomplete. Once a token is acquired, the
         // writer will append the serialized metadata to the buffer.
-        try (ILogData.SerializationHandle sh = ld.getSerializedForm(false)) {
-            // Validate if the  size of the log data is under max write size.
-            int payloadSize = ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
+        // Also, validate if the  size of the log data is under max write size.
+        try (ILogData.SerializationHandle sh = ld.getSerializedForm(false,
+                Optional.of(runtime.getParameters().getMaxWriteSize()))) {
+            int payloadSize = ld.getSizeEstimate();
 
             // First, we get a token from the sequencer.
             TokenResponse tokenResponse = runtime.getSequencerView().next(id);

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -473,9 +473,6 @@ public class CheckpointSmokeTest extends AbstractViewTest {
                 .isEqualTo(CheckpointEntry.CheckpointEntryType.CONTINUATION);
         final long cont3Recordffset = startAddress + 5;
         assertThat(r.getAddressSpaceView().read(cont3Recordffset).getCheckpointType())
-                .isEqualTo(CheckpointEntry.CheckpointEntryType.CONTINUATION);
-        final long finishRecord1Offset = startAddress + 7;
-        assertThat(r.getAddressSpaceView().read(finishRecord1Offset).getCheckpointType())
                 .isEqualTo(CheckpointEntry.CheckpointEntryType.END);
 
         // Write last keys
@@ -822,7 +819,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
      * Test checkpoint of a large transaction
      * <p>
      * CheckpointWriter should be able to write CheckpointEntries even if the size
-     * of a single transaction is larger than the compressed and uncompressed size limits.
+     * of a single transaction is larger than the maxWriteSize limit.
      */
     @Test
     @SuppressWarnings("checkstyle:magicnumber")
@@ -834,7 +831,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         PersistentCorfuTable<String, String> m = instantiateStringTable(streamName);
 
         //8 MB of data
-        String repeatedCharString = StringUtils.repeat("a", (1 << 23));
+        String repeatedCharString = StringUtils.repeat("a", (1 << 22));
 
         for (int i = 0; i < numKeys; i++) {
             String key = String.valueOf(i);
@@ -843,7 +840,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         }
 
         getRuntime().getParameters().setCodecType(Codec.Type.ZSTD);
-        getRuntime().getParameters().setMaxUncompressedCpEntrySize(2_000_000);
+        getRuntime().getParameters().setMaxWriteSize(2_000_000);
         CheckpointWriter<PersistentCorfuTable<String, String>> cpw = new CheckpointWriter<>(getRuntime(), streamId, "author", m);
         cpw.setSerializer(serializer);
 
@@ -873,7 +870,6 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         ILogData logData = r.getAddressSpaceView().read(contRecordffset);
         CheckpointEntry cpEntry = (CheckpointEntry) logData.getPayload(r);
         long logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
         assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
         assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(0);
 
@@ -881,7 +877,6 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         logData = r.getAddressSpaceView().read(cont2Recordffset);
         cpEntry = (CheckpointEntry) logData.getPayload(r);
         logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
         assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
         assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
 
@@ -889,86 +884,6 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         logData = r.getAddressSpaceView().read(cont3Recordffset);
         cpEntry = (CheckpointEntry) logData.getPayload(r);
         logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
-        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
-    }
-
-    /**
-     * Test the CheckpointWriter's uncompressed size check
-     * <p>
-     * CheckpointWriter aggregates a batch of SMREntries into one CheckpointEntry.
-     * This test verifies that it batches only SMR entries that are lesser
-     * in size when aggregated than the maxUncompressedSize limit, even if the
-     * compressedSize limit is not reached
-     *
-     */
-    @Test
-    @SuppressWarnings("checkstyle:magicnumber")
-    public void checkpointUnompressedSizeTest() {
-        final String streamName = "mystream8";
-        final UUID streamId = CorfuRuntime.getStreamID(streamName);
-        final int numKeys = 5;
-
-        PersistentCorfuTable<String, String> m = instantiateStringTable(streamName);
-
-        //8 MB of data
-        String repeatedCharString = StringUtils.repeat("a", (1 << 23));
-
-        for (int i = 0; i < numKeys; i++) {
-            String key = String.valueOf(i);
-            String payload = repeatedCharString;
-            m.insert(key, payload);
-        }
-
-        getRuntime().getParameters().setCodecType(Codec.Type.ZSTD);
-        getRuntime().getParameters().setMaxUncompressedCpEntrySize(25_000_000);
-        CheckpointWriter<PersistentCorfuTable<String, String>> cpw = new CheckpointWriter<>(getRuntime(), streamId, "author", m);
-        cpw.setSerializer(serializer);
-
-        // Write all CP data.
-        r.getObjectsView().TXBuild()
-                .type(TransactionType.SNAPSHOT)
-                .build()
-                .begin();
-        Token snapshot = TransactionalContext
-                .getCurrentContext()
-                .getSnapshotTimestamp();
-        try {
-            cpw.startCheckpoint(snapshot);
-            cpw.appendObjectState(m.entryStream());
-            cpw.finishCheckpoint();
-        } finally {
-            r.getObjectsView().TXEnd();
-        }
-
-        setRuntime();
-        r.getSerializers().registerSerializer(serializer);
-        long startAddress = snapshot.getSequence() + 1;
-        assertThat(r.getAddressSpaceView().read(startAddress).getCheckpointType())
-                .isEqualTo(CheckpointEntry.CheckpointEntryType.START);
-
-        final long contRecordffset = startAddress + 1;
-        ILogData logData = r.getAddressSpaceView().read(contRecordffset);
-        CheckpointEntry cpEntry = (CheckpointEntry) logData.getPayload(r);
-        long logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
-        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(2);
-
-        final long cont2Recordffset = startAddress + 2;
-        logData = r.getAddressSpaceView().read(cont2Recordffset);
-        cpEntry = (CheckpointEntry) logData.getPayload(r);
-        logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
-        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(2);
-
-        final long cont3Recordffset = startAddress + 3;
-        logData = r.getAddressSpaceView().read(cont3Recordffset);
-        cpEntry = (CheckpointEntry) logData.getPayload(r);
-        logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxUncompressedCpEntrySize());
         assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
         assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
     }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -471,8 +471,11 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         final long cont2Recordffset = startAddress + 3;
         assertThat(r.getAddressSpaceView().read(cont2Recordffset).getCheckpointType())
                 .isEqualTo(CheckpointEntry.CheckpointEntryType.CONTINUATION);
-        final long cont3Recordffset = startAddress + 5;
+        final long cont3Recordffset = startAddress + 3;
         assertThat(r.getAddressSpaceView().read(cont3Recordffset).getCheckpointType())
+                .isEqualTo(CheckpointEntry.CheckpointEntryType.CONTINUATION);
+        final long finishRecord1Offset = startAddress + 7;
+        assertThat(r.getAddressSpaceView().read(finishRecord1Offset).getCheckpointType())
                 .isEqualTo(CheckpointEntry.CheckpointEntryType.END);
 
         // Write last keys
@@ -819,7 +822,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
      * Test checkpoint of a large transaction
      * <p>
      * CheckpointWriter should be able to write CheckpointEntries even if the size
-     * of a single transaction is larger than the maxWriteSize limit.
+     * of a single transaction is larger than the maxWriteSize and/or maxUncompressedWriteSize limit.
      */
     @Test
     @SuppressWarnings("checkstyle:magicnumber")
@@ -831,7 +834,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         PersistentCorfuTable<String, String> m = instantiateStringTable(streamName);
 
         //8 MB of data
-        String repeatedCharString = StringUtils.repeat("a", (1 << 22));
+        String repeatedCharString = StringUtils.repeat("a", (1 << 23));
 
         for (int i = 0; i < numKeys; i++) {
             String key = String.valueOf(i);
@@ -840,7 +843,75 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         }
 
         getRuntime().getParameters().setCodecType(Codec.Type.ZSTD);
-        getRuntime().getParameters().setMaxWriteSize(2_000_000);
+        getRuntime().getParameters().setMaxUncompressedWriteSize(1);
+        getRuntime().getParameters().setMaxWriteSize(1);
+        CheckpointWriter<PersistentCorfuTable<String, String>> cpw = new CheckpointWriter<>(getRuntime(), streamId, "author", m);
+        cpw.setSerializer(serializer);
+
+        // Write all CP data.
+        r.getObjectsView().TXBuild()
+                .type(TransactionType.SNAPSHOT)
+                .build()
+                .begin();
+        Token snapshot = TransactionalContext
+                .getCurrentContext()
+                .getSnapshotTimestamp();
+        try {
+            cpw.startCheckpoint(snapshot);
+            cpw.appendObjectState(m.entryStream());
+            cpw.finishCheckpoint();
+        } finally {
+            r.getObjectsView().TXEnd();
+        }
+
+        setRuntime();
+        r.getSerializers().registerSerializer(serializer);
+        long startAddress = snapshot.getSequence() + 1;
+        assertThat(r.getAddressSpaceView().read(startAddress).getCheckpointType())
+                .isEqualTo(CheckpointEntry.CheckpointEntryType.START);
+
+        final long contRecordffset = startAddress + 1;
+        CheckpointEntry cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(contRecordffset).getPayload(r);
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(0);
+
+        final long cont2Recordffset = startAddress + 2;
+        cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(cont2Recordffset).getPayload(r);
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
+
+        final long cont3Recordffset = startAddress + 3;
+        cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(cont3Recordffset).getPayload(r);
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
+    }
+
+    /**
+     * Test the CheckpointWriter's uncompressed size check
+     * <p>
+     * CheckpointWriter aggregates a batch of SMREntries into one CheckpointEntry.
+     * This test verifies that it batches only SMR entries that are less
+     * in size when aggregated than the maxUncompressedSize limit, even if the
+     * compressedSize limit is not reached
+     *
+     */
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void checkpointUnompressedSizeTest() {
+        final String streamName = "mystream8";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final int numKeys = 5;
+
+        PersistentCorfuTable<String, String> m = instantiateStringTable(streamName);
+
+        //8 MB of data
+        String repeatedCharString = StringUtils.repeat("a", (1 << 23));
+
+        for (int i = 0; i < numKeys; i++) {
+            String key = String.valueOf(i);
+            String payload = repeatedCharString;
+            m.insert(key, payload);
+        }
+
+        getRuntime().getParameters().setCodecType(Codec.Type.ZSTD);
+        getRuntime().getParameters().setMaxUncompressedWriteSize(25_000_000);
         CheckpointWriter<PersistentCorfuTable<String, String>> cpw = new CheckpointWriter<>(getRuntime(), streamId, "author", m);
         cpw.setSerializer(serializer);
 
@@ -870,21 +941,22 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         ILogData logData = r.getAddressSpaceView().read(contRecordffset);
         CheckpointEntry cpEntry = (CheckpointEntry) logData.getPayload(r);
         long logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
-        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(0);
+        assertThat(logDataSize).isLessThanOrEqualTo(getRuntime().getParameters().getMaxWriteSize());
+        //If there was no uncompressed size check in CheckpointWriter, there would be 5 entries in one txn
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(2);
 
         final long cont2Recordffset = startAddress + 2;
         logData = r.getAddressSpaceView().read(cont2Recordffset);
         cpEntry = (CheckpointEntry) logData.getPayload(r);
         logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
-        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
+        assertThat(logDataSize).isLessThanOrEqualTo(getRuntime().getParameters().getMaxWriteSize());
+        assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(2);
 
         final long cont3Recordffset = startAddress + 3;
         logData = r.getAddressSpaceView().read(cont3Recordffset);
         cpEntry = (CheckpointEntry) logData.getPayload(r);
         logDataSize = logData.getSizeEstimate();
-        assertThat(logDataSize).isLessThanOrEqualTo(r.getParameters().getMaxWriteSize());
+        assertThat(logDataSize).isLessThanOrEqualTo(getRuntime().getParameters().getMaxWriteSize());
         assertThat(cpEntry.getSmrEntries().getUpdates().size()).isEqualTo(1);
     }
 


### PR DESCRIPTION
Limiting the LogData payload size after compression does not give a clear idea of the payload that is uncompressed as the compression ratio for each transaction data will be varied. This change avoids OOM issues in a client due to a single transaction exceeding the memory limits.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
