### PR TITLE
Validate maxWriteSize of a transaction before compression

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
@@ -20,9 +20,9 @@ import java.util.Optional;
 @Slf4j
 public class CompactorBaseConfig {
 
-    // Reduce checkpoint batch size due to disk-based nature and for smaller compactor JVM size
-    public static final int DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE = 1 << 20;
-    public static final int DEFAULT_CP_MAX_WRITE_SIZE = 25 << 20;
+    // Since the maxWriteSize now validates the uncompressed limit, the value can be made
+    // same as the maxUncompressedCpEntrySize
+    public static final int DEFAULT_CP_MAX_WRITE_SIZE = 100_000_000;
     public static final int SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT = 100;  // Corfu default is 20
     public static final int CORFU_LOG_CHECKPOINT_ERROR = 3;
     private static final int SYSTEM_EXIT_ERROR_CODE = -3;
@@ -77,13 +77,7 @@ public class CompactorBaseConfig {
         if (maybeMaxWriteSize.isPresent()) {
             maxWriteSize = Integer.parseInt(maybeMaxWriteSize.get());
         } else {
-            if (!persistedCacheRoot.isPresent()) {
-                // in-memory compaction
-                maxWriteSize = DEFAULT_CP_MAX_WRITE_SIZE;
-            } else {
-                // disk-backed compaction
-                maxWriteSize = DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE;
-            }
+            maxWriteSize = DEFAULT_CP_MAX_WRITE_SIZE;
         }
         builder.maxWriteSize(maxWriteSize);
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -52,9 +52,9 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
          * @param data     the log data to manage
          * @param metadata whether metadata needs to be serialized
          */
-        public SerializationHandle(ILogData data, boolean metadata) {
+        public SerializationHandle(ILogData data, boolean metadata, boolean checkSize, int limit) {
             this.data = data;
-            data.acquireBuffer(metadata);
+            data.acquireBuffer(metadata, checkSize, limit);
         }
 
         /**
@@ -74,7 +74,11 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * @return a serialization handle of this entry
      */
     default SerializationHandle getSerializedForm(boolean metadata) {
-        return new SerializationHandle(this, metadata);
+        return getSerializedForm(metadata, false, 0);
+    }
+
+    default SerializationHandle getSerializedForm(boolean metadata, boolean checkSize, int limit) {
+        return new SerializationHandle(this, metadata, checkSize, limit);
     }
 
     /**
@@ -87,7 +91,7 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      *
      * @param metadata whether metadata needs to be serialized
      */
-    void acquireBuffer(boolean metadata);
+    void acquireBuffer(boolean metadata, boolean checkSize, int limit);
 
     /**
      * Return the payload as a log entry.

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -203,7 +203,7 @@ public class CorfuRuntime {
         /*
          * Max size for a write request.
          */
-        int maxWriteSize = Integer.MAX_VALUE;
+        int maxWriteSize = 10_000_000;
 
         /*
          * Set the bulk read size.
@@ -299,11 +299,6 @@ public class CorfuRuntime {
          * The maximum number of SMR entries that will be grouped in a CheckpointEntry.CONTINUATION
          */
         int checkpointBatchSize = 50;
-
-        /*
-         * The maximum size of an uncompressed CheckpointEntry.CONTINUATION that can be written
-         */
-        long maxUncompressedCpEntrySize = 100_000_000;
 
         /*
          * The maximum number of SMR entries that will be grouped in a MultiSMREntry during Restore
@@ -426,7 +421,7 @@ public class CorfuRuntime {
         }
 
         public static class CorfuRuntimeParametersBuilder extends RuntimeParametersBuilder {
-            private int maxWriteSize = Integer.MAX_VALUE;
+            private int maxWriteSize = 10_000_000;
             private int bulkReadSize = 10;
             private int holeFillRetry = 10;
             private Duration holeFillRetryThreshold = Duration.ofSeconds(1L);
@@ -443,7 +438,6 @@ public class CorfuRuntime {
             private int trimRetry = 2;
             private int checkpointRetries = 5;
             private int checkpointBatchSize = 50;
-            private long maxUncompressedCpEntrySize = 100_000_000;
             private int restoreBatchSize = 50;
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 1;
@@ -694,11 +688,6 @@ public class CorfuRuntime {
                 return this;
             }
 
-            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder maxUncompressedCpEntrySize(long maxUncompressedCpEntrySize) {
-                this.maxUncompressedCpEntrySize = maxUncompressedCpEntrySize;
-                return this;
-            }
-
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder restoreBatchSize(int restoreBatchSize) {
                 this.restoreBatchSize = restoreBatchSize;
                 return this;
@@ -814,7 +803,6 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setTrimRetry(trimRetry);
                 corfuRuntimeParameters.setCheckpointRetries(checkpointRetries);
                 corfuRuntimeParameters.setCheckpointBatchSize(checkpointBatchSize);
-                corfuRuntimeParameters.setMaxUncompressedCpEntrySize(maxUncompressedCpEntrySize);
                 corfuRuntimeParameters.setRestoreBatchSize(restoreBatchSize);
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -186,9 +186,10 @@ public abstract class AbstractQueuedStreamView extends
         // The serialization here only serializes the payload because the token is not
         // acquired yet, thus metadata is incomplete. Once a token is acquired, the
         // writer will append the serialized metadata to the buffer.
-        try (ILogData.SerializationHandle sh = ld.getSerializedForm(false)) {
-            // Validate if the  size of the log data is under max write size.
-            int payloadSize = ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
+        // Also, validate if the  size of the log data is under max write size.
+        try (ILogData.SerializationHandle sh = ld.getSerializedForm(false, true,
+                runtime.getParameters().getMaxWriteSize())) {
+            int payloadSize = ld.getSizeEstimate();
 
             // First, we get a token from the sequencer.
             TokenResponse tokenResponse = runtime.getSequencerView().next(id);


### PR DESCRIPTION
Limiting the LogData payload size after compression does not give a clear idea of the payload that is uncompressed as the compression ratio for each transaction data will be varied. This change avoids OOM issues in a client due to a single transaction exceeding the memory limits.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
