### PR TITLE
Move the Event Table protobufs to the runtime package from infrastructure and handle its upgrade.

### DIFF
--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -119,23 +119,13 @@ message ReplicationEventKey {
   string key = 1;
 }
 
-/*------- Key Schema V2 ----------*/
-message ReplicationEventInfoKey {
-  org.corfudb.runtime.LogReplicationSession session = 1;
-}
-
 message ReplicationEvent {
   option (org.corfudb.runtime.table_schema).stream_tag = "log_replication";
 
   enum ReplicationEventType {
     FORCE_SNAPSHOT_SYNC = 0;
-    UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC = 1; // Intent to queue force sync for all full table sessions
-    RECEIVER_OUT_OF_SYNC_FORCE_SNAPSHOT_SYNC = 2;
-    ROLE_CHANGE_FORCE_SNAPSHOT_SYNC = 3;
-    CLIENT_REQUESTED_FORCED_SNAPSHOT_SYNC = 4;
   }
   string clusterId = 1;
   string eventId = 2;
   ReplicationEventType type = 3;
-  google.protobuf.Timestamp eventTimestamp = 4;
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -147,14 +147,14 @@ public class LogReplicationMetadataManager {
      * 2. LogReplicationStatus
      * Type: Schema change for key AND value types with NO table name change
      * (ReplicationStatusKey, ReplicationStatusVal) ->
-     * (LogReplicationSession.class, ReplicationMetadata.class)
+     * (LogReplicationSession, ReplicationMetadata)
      * Action: Make serializer aware of old types, open table with new type, clear it
      *
      * 3. LogReplicationEventTable
-     * Type: Schema change for Key type only
-     * (ReplicationEventKey, ReplicationEvent) ->
-     * (ReplicationEventInfoKey, ReplicationEvent)
-     * Action: Make serializer aware of old key type, open table with new type, clear it
+     * Type: Schema change for Key type and path of Value type
+     * (ReplicationEventKey, LogReplicationMetadata.ReplicationEvent) ->
+     * (ReplicationEventInfoKey, LogReplication.ReplicationEvent)
+     * Action: Make serializer aware of old key and value types, open table with new types, clear it
      * @param corfuStore - the same runtime used by LogReplicationMetadataManager
      */
     public static void addLegacyTypesToSerializer(CorfuStore corfuStore) {
@@ -164,6 +164,9 @@ public class LogReplicationMetadataManager {
                 .addTypeToClassMap(LogReplicationMetadata.ReplicationStatusVal.getDefaultInstance());
         corfuStore.getRuntime().getTableRegistry()
                 .addTypeToClassMap(LogReplicationMetadata.ReplicationEventKey.getDefaultInstance());
+        corfuStore.getRuntime().getTableRegistry()
+                .addTypeToClassMap(LogReplicationMetadata.ReplicationEvent.getDefaultInstance());
+
     }
 
     public static void migrateData(TxnContext txnContext) {


### PR DESCRIPTION
## Overview
In the Routing Queue model, the Event table is accessed by the client from the runtime package.  The protobuf schema was copied to the runtime package for PoC but it must instead be moved to this package and migrated on an upgrade.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
