### PR TITLE
Delay Execution for Repeat Empty Log Entry Reads

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 
 
 /**
@@ -145,7 +146,7 @@ public class LogReplicationFSM {
      * Executor service for FSM state tasks (it can be shared across several LogReplicationFSMs)
      */
     @Getter
-    private final ExecutorService logReplicationFSMWorkers;
+    private final ScheduledExecutorService logReplicationFSMWorkers;
 
     /**
      * Executor service for FSM event queue consume
@@ -219,7 +220,7 @@ public class LogReplicationFSM {
      * @param session           Replication Session to the remote(Sink) cluster
      * @param replicationContext Replication context
      */
-    public LogReplicationFSM(DataSender dataSender,ExecutorService workers, LogReplicationAckReader ackReader,
+    public LogReplicationFSM(DataSender dataSender, ScheduledExecutorService workers, LogReplicationAckReader ackReader,
                              LogReplicationSession session, LogReplicationContext replicationContext) {
         this.snapshotReader = createSnapshotReader(session, replicationContext);
         this.logEntryReader = createLogEntryReader(session, replicationContext);
@@ -251,7 +252,7 @@ public class LogReplicationFSM {
      */
     @VisibleForTesting
     public LogReplicationFSM(SnapshotReader snapshotReader, DataSender dataSender,
-                             LogEntryReader logEntryReader, ExecutorService workers, LogReplicationAckReader ackReader,
+                             LogEntryReader logEntryReader, ScheduledExecutorService workers, LogReplicationAckReader ackReader,
                              LogReplicationSession session, LogReplicationContext replicationContext) {
 
         this.snapshotReader = snapshotReader;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
@@ -44,6 +44,7 @@ public class LogEntrySender {
      */
     private final LogReplicationFSM logReplicationFSM;
 
+    @Getter
     private volatile boolean taskActive = false;
 
     /**
@@ -110,7 +111,6 @@ public class LogEntrySender {
                     } else {
                         dataSenderBufferManager.sendWithBuffering(message);
                     }
-
                 } else {
                     /*
                      * If no message is returned we can break out and enqueue a CONTINUE, so other processes can
@@ -120,6 +120,7 @@ public class LogEntrySender {
                     // TODO V2: When log entries to send are sparse, the CPU usage spikes because we keep checking with
                     //  the sequencer if there is any data to be sent continuously.  Add a backoff or delay mechanism
                     //  to avoid the repeated sequencer query.
+
                     break;
                     // Request full sync (something is wrong I cant deliver)
                     // (Optimization):

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationSourceManager.java
@@ -18,8 +18,8 @@ import org.corfudb.runtime.LogReplication.LogReplicationSession;
 
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * This class represents the Log Replication Manager at the source cluster.
@@ -65,7 +65,7 @@ public class LogReplicationSourceManager {
             throw new IllegalArgumentException("Invalid Log Replication: Streams to replicate is EMPTY");
         }
 
-        ExecutorService logReplicationFSMWorkers = Executors.newFixedThreadPool(DEFAULT_FSM_WORKER_THREADS,
+        ScheduledExecutorService logReplicationFSMWorkers = Executors.newScheduledThreadPool(DEFAULT_FSM_WORKER_THREADS,
                 new ThreadFactoryBuilder().setNameFormat("state-machine-worker-" + session.hashCode()).build());
 
         this.metadataManager = metadataManager;

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -872,7 +872,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         ackReader = new LogReplicationAckReader(metadataManager, DEFAULT_SESSION, context);
         fsm = new LogReplicationFSM(snapshotReader, dataSender, logEntryReader,
-                Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("fsm-worker").build()),
+                Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat("fsm-worker").build()),
                 ackReader, DEFAULT_SESSION, context);
         ackReader.setLogEntryReader(fsm.getLogEntryReader());
         transitionObservable = fsm.getNumTransitions();


### PR DESCRIPTION
## Overview

Description:

Adds progressive delay to task that executes the read and send of next log entry message when the former had not found entires to send. This addresses a known CPU hotspot when log entries to send are sparse.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
