### PR TITLE
Improve the usage of LAST_SNAPSHOT_SYNC_ENTRY in LiteRoutingQueueListener.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -458,14 +458,14 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
             // For Routing Queue replication model, write a dummy entry indicating the end of Snapshot sync
             // TODO: This is a temporary workaround according to the client behavior.  It must be removed in future.
             if (session.getSubscriber().getModel().equals(ROUTING_QUEUES)) {
-                writeDummyEntryToLogEntrySyncQueue();
+                writeLastSnapshotSyncEntry();
             }
         }
     }
 
-    private void writeDummyEntryToLogEntrySyncQueue() {
+    private void writeLastSnapshotSyncEntry() {
         try {
-            // For ROUTING_QUEUES model, write a dummy entry with type LOG_ENTRY_SYNC to indicate
+            // For ROUTING_QUEUES model, write a dummy entry with type LAST_SNAPSHOT_SYNC_ENTRY to indicate
             // subscribers to complete snapshot sync.
             IRetry.build(IntervalRetry.class, () -> {
                 try {
@@ -484,7 +484,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
                         Queue.RoutingTableEntryMsg dummyQueueMsg = Queue.RoutingTableEntryMsg.newBuilder()
                                 .setSourceClusterId(session.getSourceClusterId())
                                 .addAllDestinations(Collections.singleton(session.getSinkClusterId()))
-                                .setReplicationType(Queue.ReplicationType.LOG_ENTRY_SYNC).build();
+                                .setReplicationType(Queue.ReplicationType.LAST_SNAPSHOT_SYNC_ENTRY).build();
 
                         CorfuRecord<Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> dummyEntry =
                                 new CorfuRecord<>(dummyQueueMsg,

--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -20,7 +20,7 @@ enum ReplicationType {
     NONE = 0;
     LOG_ENTRY_SYNC = 1; // This entry was made during a delta sync
     SNAPSHOT_SYNC = 2; // This entry was made during a snapshot sync
-    LAST_FULL_SYNC_ENTRY = 3; // Last entry denoting the end marker of a full sync
+    LAST_SNAPSHOT_SYNC_ENTRY = 3; // Used for Routing Queue Model only.  Last entry denoting the end of a snapshot sync
 }
 
 enum OperationType {

--- a/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
@@ -86,7 +86,7 @@ public abstract class LiteRoutingQueueListener extends StreamListenerResumeOrFul
         // For snapshot sync, the first message will be CLEAR so get the next message, if any.
         // For log entry sync, get the first message.
         CorfuStreamEntry firstUpdateEntry = null;
-        if (entries.get(0).getOperation() == CorfuStreamEntry.OperationType.CLEAR  && entries.size() > 1) {
+        if (entries.get(0).getOperation() == CorfuStreamEntry.OperationType.CLEAR && entries.size() > 1) {
             firstUpdateEntry = entries.get(1);
         } else if (entries.get(0).getOperation() == CorfuStreamEntry.OperationType.UPDATE) {
             firstUpdateEntry = entries.get(0);

--- a/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
@@ -42,7 +42,7 @@ public abstract class LiteRoutingQueueListener extends StreamListenerResumeOrFul
     @Getter
     private String clientName;
 
-    protected ReplicationType currentReplicationType;
+    private ReplicationType currentReplicationType = LOG_ENTRY_SYNC;
 
     public LiteRoutingQueueListener(CorfuStore corfuStore, String sourceSiteId, String clientName) {
         super(corfuStore, CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_TAG,
@@ -50,7 +50,6 @@ public abstract class LiteRoutingQueueListener extends StreamListenerResumeOrFul
         this.corfuStore = corfuStore;
         this.sourceSiteId = sourceSiteId;
         this.clientName = clientName;
-        currentReplicationType = ReplicationType.LOG_ENTRY_SYNC;
         Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> recvQLcl = null;
         int numRetries = 8;
         while (numRetries-- > 0) {

--- a/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LiteRoutingQueueListener.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime;
 
+import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.collections.CorfuStore;
@@ -9,8 +10,8 @@ import org.corfudb.runtime.collections.StreamListenerResumeOrFullSync;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.runtime.exceptions.LogReplicationClientException;
 import org.corfudb.runtime.view.CorfuGuid;
+import org.corfudb.runtime.Queue.ReplicationType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,6 +23,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATED_QUEUE_TAG;
+import static org.corfudb.runtime.Queue.ReplicationType.LAST_SNAPSHOT_SYNC_ENTRY;
+import static org.corfudb.runtime.Queue.ReplicationType.LOG_ENTRY_SYNC;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 // TODO: As the name suggests, this is a simplistic listener which delivers replicated data as received on LR Sink
@@ -39,12 +42,15 @@ public abstract class LiteRoutingQueueListener extends StreamListenerResumeOrFul
     @Getter
     private String clientName;
 
+    protected ReplicationType currentReplicationType;
+
     public LiteRoutingQueueListener(CorfuStore corfuStore, String sourceSiteId, String clientName) {
         super(corfuStore, CORFU_SYSTEM_NAMESPACE, REPLICATED_QUEUE_TAG,
                 Arrays.asList(LogReplicationUtils.REPLICATED_RECV_Q_PREFIX + sourceSiteId + "_" + clientName));
         this.corfuStore = corfuStore;
         this.sourceSiteId = sourceSiteId;
         this.clientName = clientName;
+        currentReplicationType = ReplicationType.LOG_ENTRY_SYNC;
         Table<Queue.CorfuGuidMsg, Queue.RoutingTableEntryMsg, Queue.CorfuQueueMetadataMsg> recvQLcl = null;
         int numRetries = 8;
         while (numRetries-- > 0) {
@@ -52,7 +58,7 @@ public abstract class LiteRoutingQueueListener extends StreamListenerResumeOrFul
                 try {
                     recvQLcl = corfuStore.getTable(CORFU_SYSTEM_NAMESPACE,
                             LogReplicationUtils.REPLICATED_RECV_Q_PREFIX + sourceSiteId + "_" + clientName);
-                } catch(NoSuchElementException | IllegalArgumentException e) {
+                } catch (NoSuchElementException | IllegalArgumentException e) {
                     recvQLcl = corfuStore.openQueue(CORFU_SYSTEM_NAMESPACE,
                             LogReplicationUtils.REPLICATED_RECV_Q_PREFIX + sourceSiteId + "_" + clientName,
                             Queue.RoutingTableEntryMsg.class,
@@ -72,105 +78,95 @@ public abstract class LiteRoutingQueueListener extends StreamListenerResumeOrFul
 
     @Override
     public void onNext(CorfuStreamEntries results) {
-        log.debug("LRQListener received {} updates at address {}!",
-                results.getEntries().size(), results.getTimestamp());
-        List<CorfuStreamEntry> entries = results.getEntries().entrySet().stream()
-                .map(Map.Entry::getValue).findFirst().get();
+        log.debug("LRQListener received {} updates at address {}!", results.getEntries().size(), results.getTimestamp());
+        List<CorfuStreamEntry> entries = results.getEntries().entrySet().stream().map(Map.Entry::getValue)
+                .findFirst().get();
         List<Table.CorfuQueueRecord> allEntries = new ArrayList<>(entries.size());
-        Queue.ReplicationType currentType = Queue.ReplicationType.LAST_FULL_SYNC_ENTRY;
+
         for (CorfuStreamEntry entry : entries) {
-            if (!entry.getOperation().equals(CorfuStreamEntry.OperationType.UPDATE)) {
-                continue;
-            }
+            // The Source always 'adds' replicated data to the queue.  So the op type must be UPDATE
+            Preconditions.checkState(entry.getOperation() == CorfuStreamEntry.OperationType.UPDATE);
             Queue.CorfuGuidMsg key = (Queue.CorfuGuidMsg) entry.getKey();
             Queue.RoutingTableEntryMsg msg = (Queue.RoutingTableEntryMsg) entry.getPayload();
             Queue.CorfuQueueMetadataMsg metadataMsg = (Queue.CorfuQueueMetadataMsg) entry.getMetadata();
             allEntries.add(new Table.CorfuQueueRecord(key, metadataMsg, msg));
-            if (currentType.equals(Queue.ReplicationType.LAST_FULL_SYNC_ENTRY)) {
-                currentType = msg.getReplicationType();
-            } else if (!currentType.equals(msg.getReplicationType())) {
-                throw new LogReplicationClientException("Not expecting mixed event types "+ currentType +" vs "
-                    +msg.getReplicationType());
-            }
+            currentReplicationType = msg.getReplicationType();
         }
         if (allEntries.isEmpty()) {
             return;
         }
-        boolean entriesProcessed;
+        boolean entriesProcessed = false;
         long now = System.currentTimeMillis();
-        long whenQrecordWasCreated = CorfuGuid.getTimestampFromGuid(allEntries.get(0).getRecordId().getInstanceId(), now);
-        if (currentType.equals(Queue.ReplicationType.LOG_ENTRY_SYNC)) {
-            log.info("LRQRecvListener delivering {} LOG_ENTRY updates took {}ms end to end",
-                    allEntries.size(), now - whenQrecordWasCreated);
-            entriesProcessed = processUpdatesInLogEntrySync(allEntries.stream().sorted().map(q ->
+        long whenQRecordWasCreated = CorfuGuid.getTimestampFromGuid(allEntries.get(0).getRecordId().getInstanceId(),
+            now);
+
+        switch (currentReplicationType) {
+            case LOG_ENTRY_SYNC:
+                log.info("LRQRecvListener delivering {} LOG_ENTRY updates took {}ms end to end",
+                    allEntries.size(), now - whenQRecordWasCreated);
+                entriesProcessed = processUpdatesInLogEntrySync(allEntries.stream().map(q ->
+                    (Queue.RoutingTableEntryMsg) q.getEntry()).collect(Collectors.toList()));
+                break;
+            case SNAPSHOT_SYNC:
+                log.info("LRQRecvListener delivering {} SNAPSHOT SYNC updates took {}ms end to end",
+                    allEntries.size(), now - whenQRecordWasCreated);
+                entriesProcessed = processUpdatesInSnapshotSync(allEntries.stream().map(q ->
                     (Queue.RoutingTableEntryMsg)q.getEntry()).collect(Collectors.toList()));
-        } else {
-            log.info("LRQRecvListener delivering {} FULLSYNC updates took {}ms end to end",
-                    allEntries.size(), now - whenQrecordWasCreated);
-            entriesProcessed = processUpdatesInSnapshotSync(allEntries.stream().sorted().map(q ->
-                    (Queue.RoutingTableEntryMsg)q.getEntry()).collect(Collectors.toList()));
+                break;
+            case LAST_SNAPSHOT_SYNC_ENTRY:
+                log.info("Snapshot Sync completed.  Signalling the subscriber to end Snapshot Sync");
+                onSnapshotSyncComplete();
+                break;
+            default:
+                throw new IllegalStateException("Illegal replication type encountered " + currentReplicationType);
         }
 
         if (entriesProcessed) {
             try (TxnContext txnContext = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
                 List<UUID> noStreamTags = Collections.emptyList();
-                allEntries.forEach(q -> txnContext.logUpdateDelete(recvQ, q.getRecordId(), noStreamTags, corfuStore)
-                );
+                allEntries.forEach(q -> txnContext.logUpdateDelete(recvQ, q.getRecordId(), noStreamTags, corfuStore));
                 txnContext.commit();
             }
             log.debug("Deleted {} messages from {}", allEntries.size(), recvQ.getFullyQualifiedTableName());
         }
     }
+
     @Override
     public CorfuStoreMetadata.Timestamp performFullSync() {
-        CorfuStoreMetadata.Timestamp ts = null;
+        CorfuStoreMetadata.Timestamp ts;
         List<Table.CorfuQueueRecord> allMsgs;
+
         try (TxnContext txnContext = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             allMsgs = txnContext.entryList(recvQ);
             ts = txnContext.commit();
         }
 
         List<Queue.RoutingTableEntryMsg> batchOneOfAKind = new ArrayList<>();
-        // TODO: Fix the enum once the receiver sets the type for full sync as well.
-        Queue.ReplicationType currentType = Queue.ReplicationType.LAST_FULL_SYNC_ENTRY;
         int entriesProcessed = 0;
         for (Table.CorfuQueueRecord q : allMsgs) {
             Queue.RoutingTableEntryMsg msg = (Queue.RoutingTableEntryMsg) q.getEntry();
-            if (!msg.getReplicationType().equals(currentType)) {
-                if (currentType.equals(Queue.ReplicationType.LAST_FULL_SYNC_ENTRY)) {
-                    currentType = msg.getReplicationType();
-                    batchOneOfAKind.add(msg);
-                    continue;
-                }
-                if (currentType.equals(Queue.ReplicationType.LOG_ENTRY_SYNC)) {
-                    log.info("LiteRecvQ::performFullSync {} LOG_ENTRY messages", batchOneOfAKind.size());
-                    if (processUpdatesInLogEntrySync(batchOneOfAKind)) {
-                        entriesProcessed = entriesProcessed + batchOneOfAKind.size();
-                    }
-                } else {
-                    log.info("LiteRecvQ::performFullSync {} SNAPSHOT messages", batchOneOfAKind.size());
-                    if (processUpdatesInSnapshotSync(batchOneOfAKind)) {
-                        entriesProcessed = entriesProcessed + batchOneOfAKind.size();
-                    }
-                } // else we have encountered a change in type, reset our batch..
+
+            if (msg.getReplicationType() != currentReplicationType) {
+                entriesProcessed += processBatch(currentReplicationType, batchOneOfAKind);
+
+                // We have encountered a change in type, reset our batch..
                 batchOneOfAKind = new ArrayList<>();
-                currentType = msg.getReplicationType();
-            } // else batch up message of the same kind so we can deliver in a batch
-            batchOneOfAKind.add(msg);
-        }
-        if (!batchOneOfAKind.isEmpty()) {
-            if (currentType.equals(Queue.ReplicationType.LOG_ENTRY_SYNC)) {
-                log.info("LiteRecvQ::performFullSync {} LOG_ENTRY messages", batchOneOfAKind.size());
-                if (processUpdatesInLogEntrySync(batchOneOfAKind)) {
-                    entriesProcessed = entriesProcessed + batchOneOfAKind.size();
-                }
-            } else {
-                log.info("LiteRecvQ::performFullSync {} SNAPSHOT messages", batchOneOfAKind.size());
-                if (processUpdatesInSnapshotSync(batchOneOfAKind)) {
-                    entriesProcessed = entriesProcessed + batchOneOfAKind.size();
+                currentReplicationType = msg.getReplicationType();
+
+                // If the current message is of type LAST_SNAPSHOT_SYNC_ENTRY, invoke the completion callback
+                if (msg.getReplicationType() == LAST_SNAPSHOT_SYNC_ENTRY) {
+                    onSnapshotSyncComplete();
                 }
             }
+            // Batch up message of the same kind so we can deliver in a batch
+            batchOneOfAKind.add(msg);
         }
+
+        // Process any remaining entries
+        if (!batchOneOfAKind.isEmpty()) {
+            entriesProcessed += processBatch(currentReplicationType, batchOneOfAKind);
+        }
+
         if (entriesProcessed == allMsgs.size()) {
             log.info("LiteQRecv:performFullSync deleting {} messages", entriesProcessed);
             try (TxnContext txnContext = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
@@ -183,7 +179,35 @@ public abstract class LiteRoutingQueueListener extends StreamListenerResumeOrFul
         return ts;
     }
 
+    private int processBatch(ReplicationType currentReplicationType, List<Queue.RoutingTableEntryMsg> batch) {
+        int entriesProcessed = 0;
+        switch (currentReplicationType) {
+            case LOG_ENTRY_SYNC:
+                log.info("LiteRecvQ::performFullSync {} LOG_ENTRY messages", batch.size());
+                if (processUpdatesInLogEntrySync(batch)) {
+                    entriesProcessed = batch.size();
+                }
+                break;
+            case SNAPSHOT_SYNC:
+                log.info("LiteRecvQ::performFullSync {} SNAPSHOT messages", batch.size());
+                if (processUpdatesInSnapshotSync(batch)) {
+                    entriesProcessed = batch.size();
+                }
+                break;
+            case LAST_SNAPSHOT_SYNC_ENTRY:
+                // Just increment entriesProcessed.  onSnapshotSyncComplete() callback was already made
+                entriesProcessed++;
+                break;
+            default:
+                throw new IllegalStateException("Unexpected replication type encountered " +
+                    currentReplicationType);
+        }
+        return entriesProcessed;
+    }
+
     protected abstract boolean processUpdatesInSnapshotSync(List<Queue.RoutingTableEntryMsg> updates);
 
     protected abstract boolean processUpdatesInLogEntrySync(List<Queue.RoutingTableEntryMsg> updates);
+
+    protected abstract void onSnapshotSyncComplete();
 }

--- a/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationRoutingQueueIT.java
@@ -491,6 +491,11 @@ public class LogReplicationRoutingQueueIT extends CorfuReplicationMultiSourceSin
             });
             return true;
         }
+
+        @Override
+        protected void onSnapshotSyncComplete() {
+            log.info("Snapshot Sync Completed");
+        }
     }
 
     static class RoutingQSiteDiscoverer extends LRSiteDiscoveryListener {


### PR DESCRIPTION
LAST_SNAPSHOT_SYNC_ENTRY is not being used as intended.  Cleanup its usage in the listener and use it to indicate Snapshot Sync completion.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
