### PR TITLE
Delay Execution for Repeat Empty Log Entry Reads

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -148,7 +148,7 @@ public class InLogEntrySyncState implements LogReplicationState {
                 fsm.getAckReader().markSnapshotSyncInfoCompleted();
             }
 
-            logEntrySender.send(transitionEventId);
+            logEntrySender.send(transitionEventId, from.getType() == this.getType());
 
         } catch (Throwable t) {
             log.error("Error on entry of InLogEntrySyncState", t);


### PR DESCRIPTION
## Overview

Description:

Refactor of PR #3838 to accommodate for the pending thread pool change in #3815.

Why should this be merged: 

Adds progressive delay to task that executes the read and send of next log entry message when the former had not found entires to send. This addresses a known CPU hotspot when log entries to send are sparse.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
