### PR TITLE
Avoid using Table object in logUpdateEnqueue

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RoutingQueueSenderClient.java
@@ -273,7 +273,7 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
             @Override
             public void transmit(RoutingTableEntryMsg message, int progress) throws CancellationException {
                 log.trace("Enqueuing message to snapshot sync queue, message: {}", message);
-                getTxn().logUpdateEnqueue(snapSyncQ, message, message.getDestinationsList().stream()
+                getTxn().logUpdateEnqueue(snapSyncQ.getStreamUUID(), message, message.getDestinationsList().stream()
                         .map(destination -> TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
                                 SNAPSHOT_SYNC_QUEUE_TAG_SENDER_PREFIX + destination + "_" + clientName))
                         .collect(Collectors.toList()), corfuStore);
@@ -375,7 +375,7 @@ public class RoutingQueueSenderClient extends LogReplicationClient implements Lo
     @Override
     public void transmitDeltaMessage(TxnContext txn, RoutingTableEntryMsg message, CorfuStore corfuStore) throws Exception {
         log.trace("Enqueuing message to delta queue, message: {}", message);
-        txn.logUpdateEnqueue(logEntryQ, message, message.getDestinationsList().stream()
+        txn.logUpdateEnqueue(logEntryQ.getStreamUUID(), message, message.getDestinationsList().stream()
                 .map(destination -> {
                     UUID streamIdForTag = TableRegistry.getStreamIdForStreamTag(CORFU_SYSTEM_NAMESPACE,
                             LOG_ENTRY_SYNC_QUEUE_TAG_SENDER_PREFIX + destination + "_" + clientName);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -62,9 +62,11 @@ public class CorfuStore {
 
     private final CorfuStoreMetrics corfuStoreMetrics;
 
-    @Getter
-    @Setter
-    private volatile CorfuGuidGenerator corfuGuidGenerator;
+    /** Until the first request to access this guid generator is made,
+     *  Do not attempt to instantiate the guid generator.
+     */
+    @Getter(lazy = true)
+    private final CorfuGuidGenerator corfuGuidGenerator = new CorfuGuidGenerator(runtime);
 
     /**
      * Creates a new CorfuStore.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Iterables;
 import com.google.protobuf.Message;
 import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.google.protobuf.Message;
 import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
@@ -20,6 +21,7 @@ import org.corfudb.runtime.LogReplicationUtils;
 import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.Utils;
@@ -59,6 +61,10 @@ public class CorfuStore {
     private final CorfuRuntime runtime;
 
     private final CorfuStoreMetrics corfuStoreMetrics;
+
+    @Getter
+    @Setter
+    private volatile CorfuGuidGenerator corfuGuidGenerator;
 
     /**
      * Creates a new CorfuStore.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -14,7 +14,6 @@ import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.object.PersistenceOptions;
 import org.corfudb.runtime.object.PersistenceOptions.PersistenceOptionsBuilder;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
-import org.corfudb.runtime.view.CorfuGuid;
 import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.runtime.view.ObjectsView.ObjectID;
 import org.corfudb.runtime.view.SMRObject;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -14,6 +14,7 @@ import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.object.PersistenceOptions;
 import org.corfudb.runtime.object.PersistenceOptions.PersistenceOptionsBuilder;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.corfudb.runtime.view.CorfuGuid;
 import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.runtime.view.ObjectsView.ObjectID;
 import org.corfudb.runtime.view.SMRObject;
@@ -288,7 +289,7 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     public K enqueue(V e) {
         // Obtain a cluster-wide unique 64-bit id to identify this entry in the queue.
         // long entryId = guidGenerator.nextLong();
-        long entryId = guidGenerator.nextLong(TransactionalContext.getRootContext().getTxnContext(), this);
+        long entryId = guidGenerator.nextLong(TransactionalContext.getRootContext().getTxnContext());
         // Embed this key into a protobuf.
         K keyOfQueueEntry = (K) Queue.CorfuGuidMsg.newBuilder().setInstanceId(entryId).build();
 
@@ -302,31 +303,33 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     /**
      * Appends the specified element to the end of this unbounded queue, without materializing the queue in memory.
      *
+     * @param streamUUID - Queue's underlying stream UUID
      * @param e the element to add
      * @param streamTags  - stream tags associated to the given stream id
      * @param corfuStore CorfuStore that gets the runtime for the serializer.
      * @throws IllegalArgumentException if some property of the specified
      *                                  element prevents it from being added to the queue.
      */
-    public K logUpdateEnqueue(V e, List<UUID> streamTags, CorfuStore corfuStore) {
+    public static <K extends Message, V extends Message>
+    K logUpdateEnqueue(UUID streamUUID, V e, List<UUID> streamTags, CorfuStore corfuStore) {
         /**
          * This is a callback that is placed into the root transaction's context on
          * the thread local stack which will be invoked right after this transaction
          * is deemed successful and has obtained a final sequence number to write.
          */
         // Obtain a cluster-wide unique 64-bit id to identify this entry in the queue.
-        long entryId = guidGenerator.nextLong(TransactionalContext.getRootContext().getTxnContext(), this);
+        long entryId = corfuStore.getCorfuGuidGenerator().nextLong(TransactionalContext.getRootContext().getTxnContext());
         // Embed this key into a protobuf.
         K keyOfQueueEntry = (K) Queue.CorfuGuidMsg.newBuilder().setInstanceId(entryId).build();
 
         // Prepare a partial record with the queue's payload and temporary metadata that will be overwritten
         // by the QueueEntryAddressGetter callback above when the transaction finally commits.
-        CorfuRecord<V, M> queueEntry = new CorfuRecord<>(e, (M) null);
+        CorfuRecord<V, Message> queueEntry = new CorfuRecord<>(e, null);
 
         Object[] smrArgs = new Object[2];
         smrArgs[0] = keyOfQueueEntry;
         smrArgs[1] = queueEntry;
-        TransactionalContext.getCurrentContext().logUpdate(this.getStreamUUID(), new SMREntry("put", smrArgs,
+        TransactionalContext.getCurrentContext().logUpdate(streamUUID, new SMREntry("put", smrArgs,
                 corfuStore.getRuntime().getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE)),
                 streamTags);
         return keyOfQueueEntry;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -318,7 +318,8 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
          * is deemed successful and has obtained a final sequence number to write.
          */
         // Obtain a cluster-wide unique 64-bit id to identify this entry in the queue.
-        long entryId = corfuStore.getCorfuGuidGenerator().nextLong(TransactionalContext.getRootContext().getTxnContext());
+        long entryId = corfuStore.getCorfuGuidGenerator()
+                .nextLong(TransactionalContext.getRootContext().getTxnContext());
         // Embed this key into a protobuf.
         K keyOfQueueEntry = (K) Queue.CorfuGuidMsg.newBuilder().setInstanceId(entryId).build();
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
@@ -313,14 +313,16 @@ public class TransactionCrud<T extends StoreTransaction<T>>
      */
     @Nonnull
     public <K extends Message, V extends Message, M extends Message>
-    K logUpdateEnqueue(@Nonnull Table<K, V, M> table,
+    K logUpdateEnqueue(@Nonnull UUID queueUUID,
                        @Nonnull final V value, List<UUID> streamTags, CorfuStore corfuStore) {
 
         if (TransactionalContext.getRootContext().getPreCommitListeners().isEmpty()) {
             TransactionalContext.getCurrentContext().addPreCommitListener(new QueueEntryAddressGetter());
+            if (corfuStore.getCorfuGuidGenerator() == null) {
+                corfuStore.setCorfuGuidGenerator(corfuStore.getRuntime().getTableRegistry().getCorfuGuidGenerator());
+            }
         }
-        K ret = table.logUpdateEnqueue(value, streamTags, corfuStore);
-        tablesUpdated.putIfAbsent(table.getStreamUUID(), table);
+        K ret = Table.logUpdateEnqueue(queueUUID, value, streamTags, corfuStore);
         return ret;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
@@ -9,7 +9,6 @@ import org.corfudb.runtime.object.transactions.TransactionalContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionCrud.java
@@ -317,13 +317,9 @@ public class TransactionCrud<T extends StoreTransaction<T>>
                        @Nonnull final V value, List<UUID> streamTags, CorfuStore corfuStore) {
 
         if (TransactionalContext.getRootContext().getPreCommitListeners().isEmpty()) {
-            TransactionalContext.getCurrentContext().addPreCommitListener(new QueueEntryAddressGetter());
-            if (corfuStore.getCorfuGuidGenerator() == null) {
-                corfuStore.setCorfuGuidGenerator(corfuStore.getRuntime().getTableRegistry().getCorfuGuidGenerator());
-            }
+            TransactionalContext.getCurrentContext().addPreCommitListener(new QueueEntryAddressGetter<>());
         }
-        K ret = Table.logUpdateEnqueue(queueUUID, value, streamTags, corfuStore);
-        return ret;
+        return Table.logUpdateEnqueue(queueUUID, value, streamTags, corfuStore);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -459,6 +459,8 @@ public class TxnContext
         MultiObjectSMREntry writeSet = rootContext.getWriteSetInfo().getWriteSet();
         final Map<String, List<CorfuStreamEntry>> mutations = new HashMap<>(crud.tablesUpdated.size());
         crud.tablesUpdated.forEach((uuid, table) -> {
+            // logUpdateEnqueue method doesn't need a table instance and hence 'table' can be null. The API is used only by
+            // LR for the ROUTING_QUEUE model.
             if (table == null) {
                 return;
             }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -257,8 +257,8 @@ public class TxnContext
     /**
      * This API is used to add an entry to the CorfuQueue without materializing the queue in memory.
      *
-     * @param table  Table object to operate on the queue.
-     * @param record Record to be added.
+     * @param queueUUID  Corfu Stream ID of the Queue
+     * @param value Record to be added.
      * @param streamTags  - stream tags associated to the given stream id
      * @param corfuStore CorfuStore that gets the runtime for the serializer.
      * @param <K>    Type of Key.
@@ -268,9 +268,9 @@ public class TxnContext
      */
     @Nonnull
     public <K extends Message, V extends Message, M extends Message>
-    K logUpdateEnqueue(@Nonnull Table<K, V, M> table,
+    K logUpdateEnqueue(@Nonnull UUID queueUUID,
                        @Nonnull final V value, List<UUID> streamTags, CorfuStore corfuStore) {
-        return crud.logUpdateEnqueue(table, value, streamTags, corfuStore);
+        return crud.logUpdateEnqueue(queueUUID, value, streamTags, corfuStore);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -459,6 +459,9 @@ public class TxnContext
         MultiObjectSMREntry writeSet = rootContext.getWriteSetInfo().getWriteSet();
         final Map<String, List<CorfuStreamEntry>> mutations = new HashMap<>(crud.tablesUpdated.size());
         crud.tablesUpdated.forEach((uuid, table) -> {
+            if (table == null) {
+                return;
+            }
             List<CorfuStreamEntry> writesInTable = writeSet.getSMRUpdates(uuid).stream()
                     .map(CorfuStreamEntry::fromSMREntry).collect(Collectors.toList());
             mutations.put(table.getFullyQualifiedTableName(), writesInTable);

--- a/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
@@ -209,14 +209,12 @@ public class CorfuGuidGenerator implements OrderedGuidGenerator {
         return getCorrectedTimestamp().getLong();
     }
 
-    public long nextLong(TxnContext txnContext, Table queue) {
+    public long nextLong(TxnContext txnContext) {
         long txnIdForQueue = txnContext.getTxnIdForQueues();
         if (txnContext.getTxnIdForQueues() == 0) {
             txnIdForQueue = generateIdOncePerTxn(getInstanceId());
-            log.trace("Generating new txn id for queue {}: {}", queue.getFullyQualifiedTableName(), txnIdForQueue);
         } else {
             txnIdForQueue = generateNextIdInTxn(txnIdForQueue);
-            log.trace("Generating incremental id for queue {}: {}", queue.getFullyQualifiedTableName(), txnIdForQueue);
         }
         txnContext.setTxnIdForQueues(txnIdForQueue);
         return txnIdForQueue;

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/RoutingQueuesSnapshotReaderTest.java
@@ -106,7 +106,8 @@ public class RoutingQueuesSnapshotReaderTest extends AbstractViewTest {
                     .build();
 
             try (TxnContext txnContext = corfuStore.txn(namespace)) {
-                txnContext.logUpdateEnqueue(q, val, Arrays.asList(CorfuRuntime.getStreamID(streamTagFollowed)),
+                txnContext.logUpdateEnqueue(q.getStreamUUID(),
+                        val, Arrays.asList(CorfuRuntime.getStreamID(streamTagFollowed)),
                     corfuStore);
                 writeMarker(true, snapshotReqTimestamp, txnContext);
                 txnContext.commit();

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -300,7 +300,7 @@ public class CorfuQueueTest extends AbstractViewTest {
                 RoutingTableEntryMsg.newBuilder().setOpaquePayload(ByteString.copyFrom(payload)).build()));
         List<UUID> tags = new ArrayList<>();
         tags.add(CorfuRuntime.getStreamID(LR_STATUS_STREAM_TAG));
-        executeTxn(corfuStore, namespace, (TxnContext tx) -> tx.logUpdateEnqueue(finalQ,
+        executeTxn(corfuStore, namespace, (TxnContext tx) -> tx.logUpdateEnqueue(finalQ.getStreamUUID(),
                 RoutingTableEntryMsg.newBuilder().setOpaquePayload(ByteString.copyFrom(payload)).build(),
                 tags, corfuStore));
 


### PR DESCRIPTION

## Overview

Description:

Why should this be merged: 
While simply opening the Queue does not materialize the contents in-memory or on disk, we can avoid the possbility all together by only relying on the Queue's stream id.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
