### PR TITLE
Nullify CorfuInterClusterReplicationServerNode after closing

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -228,6 +228,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
             if (interClusterServerNode != null) {
                 interClusterServerNode.close();
+                interClusterServerNode = null;
             }
         }
     }
@@ -408,6 +409,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
                 // There may be a topology change where the remote cluster that would connect to the local cluster was
                 // removed from the topology.
                 interClusterServerNode.close();
+                interClusterServerNode = null;
             }
             return;
         }
@@ -689,6 +691,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
         if (interClusterServerNode != null) {
             interClusterServerNode.close();
+            interClusterServerNode = null;
         }
 
         if (sessionManager != null) {


### PR DESCRIPTION
## Overview

Description:

The method `cleanupResources()` in CorfuInterClusterReplicationServerNode is not idempotent. When local cluster is no longer connection receiver and there are multiple topology changes coming in, it will try to invoke `cleanupResources()` multiple times that could cause `RejectedExecutionException` on an already shutdown executor, which is further exposed to LR discovery service to make it crash.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
