### PR TITLE
Fix race condition while logging metrics 

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -181,7 +181,9 @@ public class MeterRegistryProvider {
     }
 
     public static void unregisterExternalSupplier(String identifier) {
-        externalMetricsSuppliers.remove(identifier);
+        synchronized (externalMetricsSuppliers) {
+            externalMetricsSuppliers.remove(identifier);
+        }
     }
 
     /**

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/LoggingMeterRegistryWithHistogramSupport.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/LoggingMeterRegistryWithHistogramSupport.java
@@ -198,9 +198,11 @@ public class LoggingMeterRegistryWithHistogramSupport extends StepMeterRegistry 
                             this::writeFunctionTimer,
                             this::writeMeter
                     )).forEach(loggingSink);
-            externalMetricsSuppliers.entrySet().stream()
-                    .map(entry -> entry.getValue().get().replaceAll("(?m)^", entry.getKey()))
-                    .forEach(loggingSink);
+            synchronized (externalMetricsSuppliers) {
+                externalMetricsSuppliers.entrySet().stream()
+                        .map(entry -> entry.getValue().get().replaceAll("(?m)^", entry.getKey()))
+                        .forEach(loggingSink);
+            }
         }
     }
 

--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -137,6 +137,8 @@ class CommandBuilder(object):
         cmd.append("-XX:+HeapDumpOnOutOfMemoryError")
         cmd.append("-XX:+CrashOnOutOfMemoryError")
         cmd.append("-XX:+AlwaysPreTouch")
+        if 'RootDir' in compactor_config['CorfuPaths']:
+            cmd.append("-XX:ErrorFile=" + compactor_config['CorfuPaths']['RootDir'] + "hs_err_pid%p.log")
         cmd.append("-Xms" + str(xmx) + "m")
         cmd.append("-Xmx" + str(xmx) + "m")
         cmd.append("-Djdk.nio.maxCachedBufferSize=1048576")


### PR DESCRIPTION
There's a race condition when two threads try to update and read the metrics suppliers map concurrently. To fix this issue make remove and reading from the map synchronous.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
