### PR TITLE
Sequencer bootstrap optimization

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorService.java
@@ -145,22 +145,12 @@ public class FailureDetectorService {
     private static class SequencerNotReadyCounter {
         private final long epoch;
         private int counter;
-
-        public void increment() {
-            counter += 1;
-        }
     }
 
     @Builder
     public static class SequencerBootstrapper {
         private static final CompletableFuture<DetectorTask> DETECTOR_TASK_SKIPPED
                 = CompletableFuture.completedFuture(DetectorTask.SKIPPED);
-
-        /**
-         * The management agent attempts to bootstrap a NOT_READY sequencer if the
-         * sequencerNotReadyCounter counter exceeds this value.
-         */
-        private final int sequencerNotReadyThreshold = 3;
 
         @NonNull
         private final ClusterStateContext clusterContext;
@@ -194,14 +184,6 @@ public class FailureDetectorService {
                 // If the epoch is different from the poll epoch, we reset the timeout state.
                 log.trace("Current epoch is different to layout epoch. Update current epoch to: {}", layout.getEpoch());
                 sequencerNotReadyCounter = new SequencerNotReadyCounter(layout.getEpoch(), 1);
-                return DETECTOR_TASK_SKIPPED;
-            }
-
-            // If the epoch is same as the epoch being tracked in the tuple, we need to
-            // increment the count and attempt to bootstrap the sequencer if the count has
-            // crossed the threshold.
-            sequencerNotReadyCounter.increment();
-            if (sequencerNotReadyCounter.getCounter() < sequencerNotReadyThreshold) {
                 return DETECTOR_TASK_SKIPPED;
             }
 


### PR DESCRIPTION
Sequencer bootstrap optimization: don't skip FD iterations of handling sequencer bootstrap. 
Currently, to bootstrap a new sequencer a node has to skip 3 iterations of failure detection, which is just waste of cycles and bring a lot of latency

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
