### PR TITLE
LR Changes to Support Uncompressed Max Write Size Change

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -298,6 +298,11 @@ public class ServerContext implements AutoCloseable {
         return val == null ? DEFAULT_MAX_CACHE_NUM_ENTRIES : Integer.parseInt(val);
     }
 
+    public int getMaxUncompressedTxSize() {
+        String val = getServerConfig(String.class, "--runtime-max-uncompressed-size");
+        return val == null ? CorfuRuntime.MAX_UNCOMPRESSED_WRITE_SIZE : Integer.parseInt(val);
+    }
+
     /**
      * Get the max write size of a transaction for LR's runtime.
      * @return max write size of a transaction

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
@@ -67,12 +67,12 @@ public abstract class LogReplicationConfig {
     /**
      * The max size of replicated data payload transferred at a time.
      */
-    private int maxTransferSize;
+    private long maxTransferSize;
 
     /**
      * The max size of data payload written in a single transaction during the Apply phase of Snapshot Sync
      */
-    private int maxApplySize;
+    private long maxApplySize;
 
     /**
      * Max number of entries to be applied during a snapshot sync.  For special tables only.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
@@ -97,13 +97,15 @@ public abstract class LogReplicationConfig {
             this.maxMsgSize = DEFAULT_MAX_DATA_MSG_SIZE;
             this.maxCacheSize = DEFAULT_MAX_CACHE_NUM_ENTRIES;
             this.maxSnapshotEntriesApplied = DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED;
+            this.maxTransferSize = Math.min(maxMsgSize,
+                CorfuRuntime.MAX_UNCOMPRESSED_WRITE_SIZE * DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100);
         } else {
             this.maxNumMsgPerBatch = serverContext.getLogReplicationMaxNumMsgPerBatch();
             this.maxMsgSize = serverContext.getLogReplicationMaxDataMessageSize();
             this.maxCacheSize = serverContext.getLogReplicationCacheMaxSize();
             this.maxSnapshotEntriesApplied = serverContext.getMaxSnapshotEntriesApplied();
-        }
-        this.maxTransferSize = Math.min(maxMsgSize,
+            this.maxTransferSize = Math.min(maxMsgSize,
                 serverContext.getMaxUncompressedTxSize() * DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100);
+        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
@@ -41,7 +41,7 @@ public abstract class LogReplicationConfig {
     public static final int DEFAULT_MAX_CACHE_NUM_ENTRIES = 200;
 
     // Percentage of log data per log replication message
-    public static final int DATA_FRACTION_PER_MSG = 90;
+    public static final int DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE = 85;
 
     public static final UUID REGISTRY_TABLE_ID = CorfuRuntime.getStreamID(
         TableRegistry.getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, TableRegistry.REGISTRY_TABLE_NAME));
@@ -67,9 +67,9 @@ public abstract class LogReplicationConfig {
     private int maxCacheSize;
 
     /**
-     * The max size of data payload for the log replication message.
+     * The max size of replicated data payload transferred at a time.
      */
-    private int maxDataSizePerMsg;
+    private int maxTransferSize;
 
     /**
      * Max number of entries to be applied during a snapshot sync.  For special tables only.
@@ -103,6 +103,7 @@ public abstract class LogReplicationConfig {
             this.maxCacheSize = serverContext.getLogReplicationCacheMaxSize();
             this.maxSnapshotEntriesApplied = serverContext.getMaxSnapshotEntriesApplied();
         }
-        this.maxDataSizePerMsg = maxMsgSize * DATA_FRACTION_PER_MSG / 100;
+        this.maxTransferSize = Math.min(maxMsgSize,
+                serverContext.getMaxUncompressedTxSize() * DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/config/LogReplicationConfig.java
@@ -30,8 +30,8 @@ public abstract class LogReplicationConfig {
     // Default value for the max number of entries applied in a single transaction on Sink during snapshot sync
     public static final int DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED = 50;
 
-    // Max message size supported by protocol buffers is 64MB. Log Replication uses this limit as the default message
-    // size to batch and send data across over to the other side.
+    // The recommended max message size of a protobuf message is 64MB. Log Replication uses this limit as the default
+    // message size to batch and send data across over to the other side.
     public static final int DEFAULT_MAX_DATA_MSG_SIZE = 64 << 20;
 
     // Log Replication default max cache number of entries
@@ -40,7 +40,8 @@ public abstract class LogReplicationConfig {
     // This value is exposed as a configuration parameter for LR.
     public static final int DEFAULT_MAX_CACHE_NUM_ENTRIES = 200;
 
-    // Percentage of log data per log replication message
+    // Corfu runtime's max uncompressed write size is used to calculate the payload transfer and apply sizes in
+    // LR.  To account for extra bytes added in logData.serialize(), consider a fraction of this max write size.
     public static final int DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE = 85;
 
     public static final UUID REGISTRY_TABLE_ID = CorfuRuntime.getStreamID(
@@ -60,9 +61,6 @@ public abstract class LogReplicationConfig {
     // Snapshot Sync Batch Size(number of messages)
     private int maxNumMsgPerBatch;
 
-    // Max Size of Log Replication Data Message
-    private int maxMsgSize;
-
     // Max Cache number of entries
     private int maxCacheSize;
 
@@ -70,6 +68,11 @@ public abstract class LogReplicationConfig {
      * The max size of replicated data payload transferred at a time.
      */
     private int maxTransferSize;
+
+    /**
+     * The max size of data payload written in a single transaction during the Apply phase of Snapshot Sync
+     */
+    private int maxApplySize;
 
     /**
      * Max number of entries to be applied during a snapshot sync.  For special tables only.
@@ -94,18 +97,15 @@ public abstract class LogReplicationConfig {
 
         if (serverContext == null) {
             this.maxNumMsgPerBatch = DEFAULT_MAX_NUM_MSG_PER_BATCH;
-            this.maxMsgSize = DEFAULT_MAX_DATA_MSG_SIZE;
             this.maxCacheSize = DEFAULT_MAX_CACHE_NUM_ENTRIES;
             this.maxSnapshotEntriesApplied = DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED;
-            this.maxTransferSize = Math.min(maxMsgSize,
-                CorfuRuntime.MAX_UNCOMPRESSED_WRITE_SIZE * DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100);
+            this.maxApplySize = CorfuRuntime.MAX_UNCOMPRESSED_WRITE_SIZE * DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100;
         } else {
             this.maxNumMsgPerBatch = serverContext.getLogReplicationMaxNumMsgPerBatch();
-            this.maxMsgSize = serverContext.getLogReplicationMaxDataMessageSize();
             this.maxCacheSize = serverContext.getLogReplicationCacheMaxSize();
             this.maxSnapshotEntriesApplied = serverContext.getMaxSnapshotEntriesApplied();
-            this.maxTransferSize = Math.min(maxMsgSize,
-                serverContext.getMaxUncompressedTxSize() * DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100);
+            this.maxApplySize = serverContext.getMaxUncompressedTxSize() * DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100;
         }
+        this.maxTransferSize = Math.min(DEFAULT_MAX_DATA_MSG_SIZE, maxApplySize);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -81,7 +81,8 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                     + "[-H <seconds>] [-I <cluster-id>] [-x <ciphers>] [-z <tls-protocols>]] "
                     + "[--disable-cert-expiry-check-file=<file_path>]"
                     + "[--metrics] [--corfu-port-for-lr=<corfu-port-for-lr>]"
-                    + "[-P <prefix>] [-R <retention>] <port>\n"
+                    + "[-P <prefix>] [-R <retention>] [--runtime-max-uncompressed-size=<runtime-max-uncompressed-size>]"
+                    + "<port>\n"
                     + "\n"
                     + "Options:\n"
                     + " -l <path>, --log-path=<path>                                             "
@@ -210,6 +211,8 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                     + " --max-snapshot-entries-applied=<max-snapshot-entries-applied>            "
                     + "              Max number of entries applied in a snapshot transaction.  50 by default."
                     + "              For special tables only\n.                                  "
+                    + " --runtime-max-uncompressed-size=<runtime-max-uncompressed-size>          "
+                    + "              Max uncompressed size of a transaction written by LR's runtime\n. "
                     + " -h, --help                                                               "
                     + "              Show this screen\n"
                     + " --version                                                                "
@@ -368,7 +371,6 @@ public class CorfuInterClusterReplicationServer implements Runnable {
         String localCorfuEndpoint = CorfuSaasEndpointProvider.getCorfuSaasEndpoint()
                 .orElseGet(() ->getCorfuEndpoint(getHostFromEndpointURL(serverContext.getLocalEndpoint()),
             serverContext.getCorfuServerConnectionPort()));
-
         return CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder()
             .trustStore((String) serverContext.getServerConfig().get(ConfigParamNames.TRUST_STORE))
             .tsPasswordFile((String) serverContext.getServerConfig().get(ConfigParamNames.TRUST_STORE_PASS_FILE))
@@ -377,7 +379,7 @@ public class CorfuInterClusterReplicationServer implements Runnable {
             .tlsEnabled((Boolean) serverContext.getServerConfig().get("--enable-tls"))
             .systemDownHandler(() -> System.exit(SYSTEM_EXIT_ERROR_CODE))
             .maxCacheEntries(serverContext.getLogReplicationCacheMaxSize()/2)
-            .maxWriteSize(serverContext.getMaxWriteSize())
+            .maxUncompressedWriteSize(serverContext.getMaxUncompressedTxSize())
             .build())
             .parseConfigurationString(localCorfuEndpoint).connect();
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -157,7 +157,12 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
         try (TxnContext txn = metadataManager.getTxnContext()) {
             updateLog(txn, smrEntries, shadowStreamUuid);
-            metadataManager.updateReplicationMetadataField(txn, session, ReplicationMetadata.LASTSNAPSHOTTRANSFERREDSEQNUMBER_FIELD_NUMBER, currentSeqNum);
+            ReplicationMetadata metadata = metadataManager.queryReplicationMetadata(txn, session);
+            ReplicationMetadata updatedMetadata = metadata.toBuilder().setLastSnapshotStarted(srcGlobalSnapshot)
+                    .setLastSnapshotTransferredSeqNumber(currentSeqNum)
+                    .build();
+
+            metadataManager.updateReplicationMetadata(txn, session, updatedMetadata);
             timestamp = txn.commit();
         }
 
@@ -190,10 +195,6 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
                     srcGlobalSnapshot, recvSeq, persistedTopologyConfigId, persistedSnapshotStart, persistedSequenceNum);
             return;
         }
-
-        metadataManager.updateReplicationMetadataField(txnContext, session, ReplicationMetadata.TOPOLOGYCONFIGID_FIELD_NUMBER, topologyConfigId);
-        metadataManager.updateReplicationMetadataField(txnContext, session, ReplicationMetadata.LASTSNAPSHOTSTARTED_FIELD_NUMBER, srcGlobalSnapshot);
-
         for (SMREntry smrEntry : smrEntries) {
             txnContext.logUpdate(streamId, smrEntry, replicationContext.getConfig(session).getDataStreamToTagsMap().get(streamId));
         }
@@ -246,7 +247,6 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
         // Collect the streams that have evidenced data from source.
         replicatedStreamIds.add(regularStreamId);
-
         processUpdatesShadowStream(opaqueEntry.getEntries().get(regularStreamId),
             message.getMetadata().getSnapshotSyncSeqNum(),
             getShadowStreamId(regularStreamId),
@@ -348,8 +348,9 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
             // OOM on applications running with a small memory footprint.  So for such tables, introduce an
             // additional limit of max number of entries(50 by default) applied in a single transaction.  This
             // algorithm is in line with the limits imposed in Compaction and Restore workflows.
-            if (bufferSize + smrEntry.getSerializedSize() > metadataManager.getRuntime().getParameters()
-                    .getMaxWriteSize() || maxEntriesLimitReached(streamId, buffer)) {
+            if (bufferSize + smrEntry.getSerializedSize() > replicationContext.getConfig(session).getMaxTransferSize()
+                    || maxEntriesLimitReached(streamId,
+                buffer)) {
                 try (TxnContext txnContext = metadataManager.getTxnContext()) {
                     updateLog(txnContext, buffer, streamId);
                     CorfuStoreMetadata.Timestamp ts = txnContext.commit();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -340,15 +340,17 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         int numBatches = 1;
 
         for (SMREntry smrEntry : smrEntries) {
-            // Apply all SMR entries in a single transaction as long as it does not exceed the max write size(25MB).
+            // Apply all SMR entries in a single transaction as long as it does not exceed maxApplySize(a fraction of
+            // the runtime's max uncompressed write size(100 MB by default).  The fraction is added as a buffer to
+            // account for extra bytes added during LogData.serialize()).
             // It was observed that special streams(ProtobufDescriptor table), can get a lot of updates, especially
             // due to schema updates during an upgrade.  If the table was not checkpointed and trimmed on the Source,
             // no de-duplication on these updates will occur.  As a result, the transaction size can be large.
-            // Although it is within the maxWriteSize limit, deserializing these entries to read the table can cause an
+            // Although it is within the maxApplySize limit, deserializing these entries to read the table can cause an
             // OOM on applications running with a small memory footprint.  So for such tables, introduce an
             // additional limit of max number of entries(50 by default) applied in a single transaction.  This
             // algorithm is in line with the limits imposed in Compaction and Restore workflows.
-            if (bufferSize + smrEntry.getSerializedSize() > replicationContext.getConfig(session).getMaxTransferSize()
+            if (bufferSize + smrEntry.getSerializedSize() > replicationContext.getConfig(session).getMaxApplySize()
                     || maxEntriesLimitReached(streamId,
                 buffer)) {
                 try (TxnContext txnContext = metadataManager.getTxnContext()) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
@@ -56,7 +56,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
     // the sequence number of the message based on the globalBaseSnapshot
     private long sequence;
 
-    private final int maxDataSizePerMsg;
+    private final int maxTransferSize;
 
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
     private final Optional<Counter> deltaCounter;
@@ -77,7 +77,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
     public BaseLogEntryReader(CorfuRuntime runtime, LogReplication.LogReplicationSession replicationSession,
                               LogReplicationContext replicationContext) {
         runtime.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
-        this.maxDataSizePerMsg = replicationContext.getConfig(replicationSession).getMaxTransferSize();
+        this.maxTransferSize = replicationContext.getConfig(replicationSession).getMaxTransferSize();
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         this.deltaCounter = configureDeltaCounter();
@@ -180,7 +180,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
         int currentMsgSize = 0;
 
         try {
-            while (currentMsgSize < maxDataSizePerMsg) {
+            while (currentMsgSize < maxTransferSize) {
                 if (lastOpaqueEntry != null) {
 
                     if (lastOpaqueEntryValid) {
@@ -190,13 +190,13 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
 
                         // If a message cannot be sent due to its size exceeding the maximum boundary,
                         // throw an exception and the replication will be stopped.
-                        if (currentEntrySize > maxDataSizePerMsg) {
+                        if (currentEntrySize > maxTransferSize) {
                             throw new MessageSizeExceededException();
                         }
 
                         // If it cannot fit into this message, skip appending this entry and it will
                         // be processed with the next message.
-                        if (currentEntrySize + currentMsgSize > maxDataSizePerMsg) {
+                        if (currentEntrySize + currentMsgSize > maxTransferSize) {
                             break;
                         }
 
@@ -221,8 +221,8 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
                         lastOpaqueEntryValid);
             }
 
-            log.trace("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
-                currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
+            log.trace("Generate LogEntryDataMessage size {} with {} entries for maxTransferSize {}. lastEntry size {}",
+                currentMsgSize, opaqueEntryList.size(), maxTransferSize, lastOpaqueEntry == null ? 0 : currentEntrySize);
             final double currentMsgSizeSnapshot = currentMsgSize;
 
             messageSizeDistributionSummary.ifPresent(distribution -> distribution.record(currentMsgSizeSnapshot));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
@@ -77,7 +77,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
     public BaseLogEntryReader(CorfuRuntime runtime, LogReplication.LogReplicationSession replicationSession,
                               LogReplicationContext replicationContext) {
         runtime.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
-        this.maxDataSizePerMsg = replicationContext.getConfig(replicationSession).getMaxDataSizePerMsg();
+        this.maxDataSizePerMsg = replicationContext.getConfig(replicationSession).getMaxTransferSize();
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         this.deltaCounter = configureDeltaCounter();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseLogEntryReader.java
@@ -56,7 +56,7 @@ public abstract class BaseLogEntryReader extends LogEntryReader {
     // the sequence number of the message based on the globalBaseSnapshot
     private long sequence;
 
-    private final int maxTransferSize;
+    private final long maxTransferSize;
 
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
     private final Optional<Counter> deltaCounter;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -151,6 +151,13 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
                                 currentEntrySize, DEFAULT_MAX_DATA_MSG_SIZE);
                             throw new IllegalSnapshotEntrySizeException(" The snapshot entry is bigger than the system supported");
                         } else if (currentEntrySize > maxTransferSize) {
+                            // TODO: As of now, there is no plan to allow applications to change the max uncompressed
+                            //  tx size. (CorfuRuntime.MAX_UNCOMPRESSED_WRITE_SIZE).  So the transfer size(85 MB)
+                            //  will be higher than DEFAULT_MAX_DATA_MSG_SIZE(64 MB).
+                            // However, if this behavior changes in future, it is possible that
+                            // currentEntrySize <= DEFAULT_MAX_DATA_MSG_SIZE but currentEntrySize > maxTransferSize.
+                            // In that case, split the transaction (right now currentEntrySize contains the size of all
+                            // SMR entries in the transaction).
                             observeBiggerMsg.setValue(observeBiggerMsg.getValue()+1);
                             log.warn("The current entry size {} is bigger than the configured transfer size {}",
                                 currentEntrySize, maxTransferSize);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -44,7 +44,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
     /**
      * The max size of data for SMR entries in a replication message.
      */
-    private final int maxTransferSize;
+    private final long maxTransferSize;
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
     private final CorfuRuntime rt;
     private long snapshotTimestamp;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -71,7 +71,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
         this.session = session;
         this.replicationContext = replicationContext;
         this.rt.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
-        this.maxDataSizePerMsg = replicationContext.getConfig(session).getMaxDataSizePerMsg();
+        this.maxDataSizePerMsg = replicationContext.getConfig(session).getMaxTransferSize();
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         refreshStreamsToReplicateSet();
         log.info("Total of {} streams to replicate at initialization. Streams to replicate={}, Session={}",
@@ -146,7 +146,6 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
                     List<SMREntry> smrEntries = lastEntry.getEntries().get(stream.uuid);
                     if (smrEntries != null) {
                         int currentEntrySize = ReaderUtility.calculateSize(smrEntries);
-
                         if (currentEntrySize > DEFAULT_MAX_DATA_MSG_SIZE) {
                             log.error("The current entry size {} is bigger than the maxDataSizePerMsg {} supported",
                                 currentEntrySize, DEFAULT_MAX_DATA_MSG_SIZE);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/BaseSnapshotReader.java
@@ -42,9 +42,9 @@ import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLrEnt
 @Slf4j
 public abstract class BaseSnapshotReader extends SnapshotReader {
     /**
-     * The max size of data for SMR entries in data message.
+     * The max size of data for SMR entries in a replication message.
      */
-    private final int maxDataSizePerMsg;
+    private final int maxTransferSize;
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
     private final CorfuRuntime rt;
     private long snapshotTimestamp;
@@ -71,7 +71,7 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
         this.session = session;
         this.replicationContext = replicationContext;
         this.rt.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
-        this.maxDataSizePerMsg = replicationContext.getConfig(session).getMaxTransferSize();
+        this.maxTransferSize = replicationContext.getConfig(session).getMaxTransferSize();
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         refreshStreamsToReplicateSet();
         log.info("Total of {} streams to replicate at initialization. Streams to replicate={}, Session={}",
@@ -141,23 +141,23 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
         int currentMsgSize = 0;
 
         try {
-            while (currentMsgSize < maxDataSizePerMsg) {
+            while (currentMsgSize < maxTransferSize) {
                 if (lastEntry != null) {
                     List<SMREntry> smrEntries = lastEntry.getEntries().get(stream.uuid);
                     if (smrEntries != null) {
                         int currentEntrySize = ReaderUtility.calculateSize(smrEntries);
                         if (currentEntrySize > DEFAULT_MAX_DATA_MSG_SIZE) {
-                            log.error("The current entry size {} is bigger than the maxDataSizePerMsg {} supported",
+                            log.error("The current entry size {} is bigger than the max size {} supported",
                                 currentEntrySize, DEFAULT_MAX_DATA_MSG_SIZE);
                             throw new IllegalSnapshotEntrySizeException(" The snapshot entry is bigger than the system supported");
-                        } else if (currentEntrySize > maxDataSizePerMsg) {
+                        } else if (currentEntrySize > maxTransferSize) {
                             observeBiggerMsg.setValue(observeBiggerMsg.getValue()+1);
-                            log.warn("The current entry size {} is bigger than the configured maxDataSizePerMsg {}",
-                                currentEntrySize, maxDataSizePerMsg);
+                            log.warn("The current entry size {} is bigger than the configured transfer size {}",
+                                currentEntrySize, maxTransferSize);
                         }
 
                         // Skip append this entry in this message. Will process it first at the next round.
-                        if (currentEntrySize + currentMsgSize > maxDataSizePerMsg && currentMsgSize != 0) {
+                        if (currentEntrySize + currentMsgSize > maxTransferSize && currentMsgSize != 0) {
                             break;
                         }
 
@@ -181,8 +181,9 @@ public abstract class BaseSnapshotReader extends SnapshotReader {
             throw e;
         }
 
-        log.trace("CurrentMsgSize {} lastEntrySize {}  maxDataSizePerMsg {}",
-            currentMsgSize, lastEntry == null ? 0 : ReaderUtility.calculateSize(lastEntry.getEntries().get(stream.uuid)), maxDataSizePerMsg);
+        log.trace("CurrentMsgSize {} lastEntrySize {}  maxTransferSize {}",
+            currentMsgSize, lastEntry == null ? 0 : ReaderUtility.calculateSize(lastEntry.getEntries().get(stream.uuid)),
+                    maxTransferSize);
         return new SMREntryList(currentMsgSize, smrList);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -173,6 +173,8 @@ public class CorfuRuntime {
 
     public static final Marker LOG_NOT_IMPORTANT = MarkerFactory.getMarker("NOT_IMPORTANT");
 
+    public static final int MAX_UNCOMPRESSED_WRITE_SIZE = 100 << 20;
+
 
     /**
      * This thread is used by fetchLayout to find a new layout in the system
@@ -193,6 +195,8 @@ public class CorfuRuntime {
     @Getter
     private final Serializers serializers = new Serializers();
 
+
+
     /**
      * A class which holds parameters and settings for the {@link CorfuRuntime}.
      */
@@ -203,7 +207,7 @@ public class CorfuRuntime {
         /*
          * Max uncompressed size for a write request.
          */
-        int maxUncompressedWriteSize = 100 << 20;
+        int maxUncompressedWriteSize = MAX_UNCOMPRESSED_WRITE_SIZE;
 
         /*
          * Max compressed size for a write request.
@@ -430,7 +434,7 @@ public class CorfuRuntime {
         public static class CorfuRuntimeParametersBuilder extends RuntimeParametersBuilder {
 
             //Max uncompressed size for a write request.
-            private int maxUncompressedWriteSize = 100 << 20;
+            private int maxUncompressedWriteSize = MAX_UNCOMPRESSED_WRITE_SIZE;
             //Max compressed size for a write request
             private int maxWriteSize = 25 << 20;
             private int bulkReadSize = 10;

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -413,8 +413,8 @@ public class AbstractIT extends AbstractCorfuTest {
                 .runServer();
     }
 
-    public Process runReplicationServerCustomMaxWriteSize(int port, int corfuServerPort,
-                                                          String pluginConfigFilePath, int maxWriteSize,
+    public Process runReplicationServerWithCustomMaxTxSize(int port, int corfuServerPort,
+                                                          String pluginConfigFilePath, int maxUncompressedTxSize,
                                                           int maxEntriesApplied, String transportType) throws IOException {
         return new CorfuReplicationServerRunner()
                 .setHost(DEFAULT_HOST)
@@ -422,7 +422,7 @@ public class AbstractIT extends AbstractCorfuTest {
                 .setCorfuServerConnectionPort(corfuServerPort)
                 .setPluginConfigFilePath(pluginConfigFilePath)
                 .setMsg_size(MSG_SIZE)
-                .setMaxWriteSize(maxWriteSize)
+                .setMaxUncompressedTxSize(maxUncompressedTxSize)
                 .setMaxSnapshotEntriesApplied(maxEntriesApplied)
                 .setTransportType(transportType)
                 .runServer();
@@ -720,7 +720,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private String logPath = null;
         private int msg_size = 0;
         private Integer lockLeaseDuration;
-        private int maxWriteSize = 0;
+        private int maxUncompressedTxSize = 0;
         private int maxSnapshotEntriesApplied;
         private int corfuServerConnectionPort = 0;
 
@@ -782,8 +782,8 @@ public class AbstractIT extends AbstractCorfuTest {
                 command.append(" --lock-lease=").append(lockLeaseDuration);
             }
 
-            if (maxWriteSize != 0) {
-                command.append(" --max-replication-write-size=").append(maxWriteSize);
+            if (maxUncompressedTxSize != 0) {
+                command.append(" --runtime-max-uncompressed-size=").append(maxUncompressedTxSize);
             }
 
             if (maxSnapshotEntriesApplied != 0) {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
@@ -51,16 +51,21 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
 
     private static final int NUM_ENTRIES_PER_TABLE = 20;
 
-    // Max transaction size(in bytes) for applying snapshot sync updates
-    private static final int MAX_WRITE_SIZE_BYTES = 9000;
+    // Max uncompressed transaction size(in bytes) for applying snapshot sync updates
+    // It was observed that a single transaction on the Protobuf descriptor table was >9k bytes.  The Snapshot reader
+    // currently does not have the ability to split a single transaction before sending it.  So the max write size
+    // must be able to accommodate this much data as it will not be split when writing to the shadow stream on the
+    // Sink also.
+    private static final int MAX_WRITE_SIZE_BYTES = 10000;
 
     // Max number of entries applied in a single transaction during snapshot sync
     private static final int MAX_SNAPSHOT_ENTRIES_APPLIED = 1;
 
     /**
-     * MAX_WRITE_SIZE_BYTES is the maximum number of bytes which can be written in a single transaction during
-     * snapshot sync apply on the Sink.  It was empirically determined that NUM_ENTRIES_PER_TABLE had a serialized
-     * size of 8.5k bytes approx.  Hence, a snapshot sync with this much data will be applied in a single transaction.
+     * In LR Snapshot sync, the max payload size transferred is 85% of MAX_WRITE_SIZE_BYTES, i.e., 8500 bytes.
+     * The Sink cluster also applies the same number of bytes in a single transaction during the apply phase.
+     * It was empirically determined that NUM_ENTRIES_PER_TABLE had a serialized size of 5.5k bytes approx.  Hence, a
+     * snapshot sync with this much data will be applied in a single transaction on the Sink
      * @throws Exception
      */
     @Test
@@ -69,10 +74,10 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
     }
 
     /**
-     * MAX_WRITE_SIZE_BYTES is the maximum number of bytes which can be written in a single transaction during
-     * snapshot sync apply on the Sink.  It was empirically determined that NUM_ENTRIES_PER_TABLE had a serialized
-     * size of 8.5k bytes approx.  Hence, a snapshot sync with twice the data(2*NUM_ENTRIES_PER_TABLE) will be
-     * applied in 2 transactions.
+     * In LR Snapshot sync, the max payload size transferred is 85% of MAX_WRITE_SIZE_BYTES, i.e., 8500 bytes.
+     * The Sink cluster also applies the same number of bytes in a single transaction during the apply phase.
+     * It was empirically determined that NUM_ENTRIES_PER_TABLE had a serialized size of 5.5k bytes approx.  Hence, a
+     * snapshot sync with twice this much data will be applied in 2 transactions on the Sink.
      * @throws Exception
      */
     @Test
@@ -139,7 +144,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
         corfuStoreSink.subscribeListener(streamingUpdateListener, NAMESPACE, TAG_ONE);
 
         // Start LR on both clusters with custom write sizes.
-        startLogReplicatorServersWithCustomMaxWriteSize();
+        startLogReplicatorServersWithCustomMaxTxSize();
 
         log.debug("Wait for snapshot sync to finish");
         statusUpdateLatch.await();
@@ -274,14 +279,14 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
         }
     }
 
-    private void startLogReplicatorServersWithCustomMaxWriteSize() throws Exception {
+    private void startLogReplicatorServersWithCustomMaxTxSize() throws Exception {
         sourceReplicationServer =
-            runReplicationServerCustomMaxWriteSize(sourceReplicationServerPort, sourceSiteCorfuPort,
+            runReplicationServerWithCustomMaxTxSize(sourceReplicationServerPort, sourceSiteCorfuPort,
                 pluginConfigFilePath, MAX_WRITE_SIZE_BYTES, MAX_SNAPSHOT_ENTRIES_APPLIED, transportType);
 
         // Start Log Replication Server on Sink Site
         sinkReplicationServer =
-            runReplicationServerCustomMaxWriteSize(sinkReplicationServerPort, sinkSiteCorfuPort,
+            runReplicationServerWithCustomMaxTxSize(sinkReplicationServerPort, sinkSiteCorfuPort,
                 pluginConfigFilePath, MAX_WRITE_SIZE_BYTES, MAX_SNAPSHOT_ENTRIES_APPLIED, transportType);
     }
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1276,7 +1276,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // values are not used
         context.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);
         context.getConfig(session).setMaxMsgSize(SMALL_MSG_SIZE);
-        context.getConfig(session).setMaxDataSizePerMsg(SMALL_MSG_SIZE * LogReplicationConfig.DATA_FRACTION_PER_MSG / 100);
+        context.getConfig(session).setMaxTransferSize(SMALL_MSG_SIZE * LogReplicationConfig.DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100);
 
         // Data Sender
         sourceDataSender = new SourceForwardingDataSender(DESTINATION_ENDPOINT, testConfig, metadataManager,

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1275,7 +1275,6 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // This IT requires custom values to be set for the replication config.  Set these values so that the default
         // values are not used
         context.getConfig(session).setMaxNumMsgPerBatch(BATCH_SIZE);
-        context.getConfig(session).setMaxMsgSize(SMALL_MSG_SIZE);
         context.getConfig(session).setMaxTransferSize(SMALL_MSG_SIZE * LogReplicationConfig.DATA_FRACTION_OF_UNCOMPRESSED_WRITE_SIZE / 100);
 
         // Data Sender


### PR DESCRIPTION
Description:
PR [3828](https://github.com/CorfuDB/CorfuDB/pull/3828) introduces a limit of 100MB on the max uncompressed write size for a transaction.  Currently, Log Replicator receiver applies every batch of incoming Snapshot Sync data in a single transaction in the transfer phase.

Currently, LR's batch size for transfer is limited to 64MB which is well within the 100MB limit.  But it is customizable, so the limit of (100MB + some buffer for LR metadata and serialization) must be enforced to allow the replicated data to be applied atomically on the receiver.  This uncompressed transaction size must also be used when chunking the aggregated data in the apply phase.

Why should this be merged:  Enforces Corfu Runtime's max write size in LR

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
