### PR TITLE
Add ReloadableKeyManager for hot-swapping SSL cert support

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -331,6 +331,11 @@ public class LogReplicationClientRouter implements IClientRouter {
     }
 
     @Override
+    public void reconnect() {
+        // no-op
+    }
+
+    @Override
     public Integer getPort() {
         // For logging purposes return one port (as this abstraction does not make sense for a Log Replication
         // Client Router) as it is a router to an entire cluster/site.

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -1065,6 +1065,13 @@ public class CorfuRuntime {
     }
 
     /**
+     * Reestablish the netty connections to corfu servers
+     */
+    public void reconnect() {
+        nodeRouterPool.reconnect();
+    }
+
+    /**
      * Get a UUID for a named stream.
      *
      * @param string The name of the stream.

--- a/runtime/src/main/java/org/corfudb/runtime/NodeRouterPool.java
+++ b/runtime/src/main/java/org/corfudb/runtime/NodeRouterPool.java
@@ -56,4 +56,13 @@ public class NodeRouterPool {
             r.stop();
         }
     }
+
+    /**
+     * Reestablish all connections in the pool.
+     */
+    public void reconnect() {
+        for (IClientRouter r : nodeRouters.values()) {
+            r.reconnect();
+        }
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
@@ -93,6 +93,11 @@ public interface IClientRouter {
     void stop();
 
     /**
+     * Reestablish the connection.
+     */
+    void reconnect();
+
+    /**
      * The host that this router is routing requests for.
      */
     String getHost();

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -421,6 +421,15 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
     }
 
     /**
+     * Reestablish the netty connection.
+     */
+    @Override
+    public void reconnect() {
+        // Close the channel and auto-trigger the reconnection callback.
+        channel.close();
+    }
+
+    /**
      * Send a request message and get a completable future to be fulfilled by the reply.
      *
      * @param payload         Payload message of the pending request.

--- a/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManager.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManager.java
@@ -80,7 +80,7 @@ public class ReloadableKeyManager implements X509KeyManager {
             reloadKeyStore();
         } catch (SSLException e) {
             String message = "Unable to reload key store " + keyStoreConfig.getKeyStoreFile() + ".";
-            throw new RuntimeException(message, e);
+            throw new IllegalStateException(message, e);
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManager.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManager.java
@@ -1,0 +1,123 @@
+package org.corfudb.security.tls;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.X509KeyManager;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.X509Certificate;
+
+@Slf4j
+public class ReloadableKeyManager implements X509KeyManager {
+
+    private final TlsUtils.CertStoreConfig.KeyStoreConfig keyStoreConfig;
+
+    private X509KeyManager keyManager;
+
+    private long keysLastModifiedTime;
+
+    public ReloadableKeyManager(TlsUtils.CertStoreConfig.KeyStoreConfig keyStoreConfig) {
+        this.keyStoreConfig = keyStoreConfig;
+        this.keysLastModifiedTime = 0;
+        reloadKeyStoreWrapper();
+    }
+
+    @Override
+    public String[] getClientAliases(String keyType, Principal[] issuers) {
+        reloadKeyStoreWrapper();
+        return keyManager.getClientAliases(keyType, issuers);
+    }
+
+    @Override
+    public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+        reloadKeyStoreWrapper();
+        return keyManager.chooseClientAlias(keyType, issuers, socket);
+    }
+
+    @Override
+    public String[] getServerAliases(String keyType, Principal[] issuers) {
+        reloadKeyStoreWrapper();
+        return keyManager.getServerAliases(keyType, issuers);
+    }
+
+    @Override
+    public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+        reloadKeyStoreWrapper();
+        return keyManager.chooseServerAlias(keyType, issuers, socket);
+    }
+
+    @Override
+    public X509Certificate[] getCertificateChain(String alias) {
+        reloadKeyStoreWrapper();
+        return keyManager.getCertificateChain(alias);
+    }
+
+    @Override
+    public PrivateKey getPrivateKey(String alias) {
+        reloadKeyStoreWrapper();
+        return keyManager.getPrivateKey(alias);
+    }
+
+    private boolean hasKeysChanged() {
+        long lastModified = keyStoreConfig.getKeyStoreFile().toFile().lastModified();
+        if (lastModified != keysLastModifiedTime) {
+            keysLastModifiedTime = lastModified;
+            return true;
+        }
+        return false;
+    }
+
+    private void reloadKeyStoreWrapper() {
+        try {
+            reloadKeyStore();
+        } catch (SSLException e) {
+            String message = "Unable to reload key store " + keyStoreConfig.getKeyStoreFile() + ".";
+            throw new RuntimeException(message, e);
+        }
+    }
+
+    private void reloadKeyStore() throws SSLException {
+        if (!hasKeysChanged()) {
+            log.debug("Key store certs hasn't changed. Skip reloading.");
+            return;
+        }
+
+        log.info("Reloading key store from {}", keyStoreConfig.getKeyStoreFile());
+
+        KeyStore keyStore = TlsUtils.openCertStore(keyStoreConfig);
+        String keyStorePassword = TlsUtils.getKeyStorePassword(keyStoreConfig.getPasswordFile());
+
+        KeyManagerFactory kmf;
+        try {
+            kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(keyStore, keyStorePassword.toCharArray());
+        } catch (UnrecoverableKeyException e) {
+            String errorMessage = "Unrecoverable key in key store " + keyStoreConfig.getKeyStoreFile() + ".";
+            throw new SSLException(errorMessage, e);
+        } catch (NoSuchAlgorithmException e) {
+            String errorMessage = "Can not create key manager factory with default algorithm "
+                    + KeyManagerFactory.getDefaultAlgorithm() + ".";
+            throw new SSLException(errorMessage, e);
+        } catch (KeyStoreException e) {
+            String errorMessage = "Can not initialize key manager factory from " + keyStoreConfig.getKeyStoreFile() + ".";
+            throw new SSLException(errorMessage, e);
+        }
+
+        for (KeyManager km : kmf.getKeyManagers()) {
+            if (km instanceof X509KeyManager) {
+                keyManager = (X509KeyManager) km;
+                return;
+            }
+        }
+
+        throw new SSLException("No X509KeyManager in KeyManagerFactory.");
+    }
+}

--- a/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManagerFactory.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManagerFactory.java
@@ -1,0 +1,31 @@
+package org.corfudb.security.tls;
+
+import io.netty.handler.ssl.util.SimpleKeyManagerFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.ManagerFactoryParameters;
+import java.security.KeyStore;
+
+public class ReloadableKeyManagerFactory extends SimpleKeyManagerFactory {
+
+    private final ReloadableKeyManager reloadableKeyManager;
+
+    public ReloadableKeyManagerFactory(TlsUtils.CertStoreConfig.KeyStoreConfig keyStoreConfig) {
+        reloadableKeyManager = new ReloadableKeyManager(keyStoreConfig);
+    }
+
+    @Override
+    protected void engineInit(KeyStore keyStore, char[] var2) throws Exception {
+        //inherited, don't do anything
+    }
+
+    @Override
+    protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws Exception {
+        //inherited, don't do anything
+    }
+
+    @Override
+    protected KeyManager[] engineGetKeyManagers() {
+        return new KeyManager[] {reloadableKeyManager};
+    }
+}

--- a/runtime/src/main/java/org/corfudb/security/tls/SslContextConstructor.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/SslContextConstructor.java
@@ -34,7 +34,7 @@ public class SslContextConstructor {
         log.info("Trust store file path: {}.", trustStoreConfig.getTrustStoreFile());
         log.info("Trust store password file path: {}.", trustStoreConfig.getPasswordFile());
 
-        KeyManagerFactory kmf = TlsUtils.createKeyManagerFactory(keyStoreConfig);
+        KeyManagerFactory kmf = new ReloadableKeyManagerFactory(keyStoreConfig);
         ReloadableTrustManagerFactory tmf = new ReloadableTrustManagerFactory(trustStoreConfig);
 
         SslProvider provider = getSslProvider();

--- a/runtime/src/main/java/org/corfudb/security/tls/TlsUtils.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/TlsUtils.java
@@ -94,29 +94,6 @@ public class TlsUtils {
         return password;
     }
 
-    public static KeyManagerFactory createKeyManagerFactory(KeyStoreConfig cfg) throws SSLException {
-
-        KeyStore keyStore = TlsUtils.openCertStore(cfg);
-        String keyStorePassword = getKeyStorePassword(cfg.getPasswordFile());
-
-        KeyManagerFactory kmf;
-        try {
-            kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            kmf.init(keyStore, keyStorePassword.toCharArray());
-            return kmf;
-        } catch (UnrecoverableKeyException e) {
-            String errorMessage = "Unrecoverable key in key store " + cfg.getKeyStoreFile() + ".";
-            throw new SSLException(errorMessage, e);
-        } catch (NoSuchAlgorithmException e) {
-            String errorMessage = "Can not create key manager factory with default algorithm "
-                    + KeyManagerFactory.getDefaultAlgorithm() + ".";
-            throw new SSLException(errorMessage, e);
-        } catch (KeyStoreException e) {
-            String errorMessage = "Can not initialize key manager factory from " + cfg.getKeyStoreFile() + ".";
-            throw new SSLException(errorMessage, e);
-        }
-    }
-
     /**
      * Java key store configuration class
      * https://www.baeldung.com/java-keystore-truststore-difference

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -25,8 +25,12 @@ import javax.annotation.Nonnull;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -566,6 +570,141 @@ public class NettyCommTest extends AbstractCorfuTest {
     public void testTlsCipherRsaAndEcdsaKeyStoreEcdsaEcdsa() throws Exception {
         tlsCipherTestHelper(ConfigParamsHelper.getTlsCiphersCSV(), KeyStoreType.ECDSA_ECDSA,
                 true, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
+    }
+
+    @Test
+    public void testBasicReloadSslCerts() throws Exception {
+        int port = findRandomOpenPort();
+
+        Path certDir = Paths.get(PARAMETERS.TEST_TEMP_DIR);
+
+        // Start corfu server
+        CertificateManager serverCertManager = CertificateManager.buildSHA384withEcDsa(certDir);
+        NettyServerData serverData = new NettyServerData(buildServerContext(port, serverCertManager.certManagementConfig));
+        serverData.bootstrapServer();
+
+        // Happy path
+        CertificateManager clientCertManager = CertificateManager.buildSHA384withEcDsa(certDir);
+        clientCertManager.trustStoreManager.addCertificate(serverCertManager);
+        clientCertManager.trustStoreManager.save();
+        serverCertManager.trustStoreManager.addCertificate(clientCertManager);
+        serverCertManager.trustStoreManager.save();
+        NettyClientRouter clientRouter = new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                buildRuntimeParams(clientCertManager.certManagementConfig)
+        );
+        clientRouter.getConnectionFuture().join();
+        assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
+
+        // Reload ssl
+        clientRouter.reconnect();
+        TimeUnit.SECONDS.sleep(1);
+        assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
+
+        clientRouter.close();
+
+        serverData.shutdownServer();
+        serverData.serverContext.close();
+    }
+
+    @Test
+    public void testReloadSslCertsWithCorruptedKeyStore() throws Exception {
+        int port = findRandomOpenPort();
+
+        Path certDir = Paths.get(PARAMETERS.TEST_TEMP_DIR);
+
+        // Start corfu server
+        CertificateManager serverCertManager = CertificateManager.buildSHA384withEcDsa(certDir);
+        NettyServerData serverData = new NettyServerData(buildServerContext(port, serverCertManager.certManagementConfig));
+        serverData.bootstrapServer();
+
+        // Happy path with correct cert
+        CertificateManager clientCertManager = CertificateManager.buildSHA384withEcDsa(certDir);
+        clientCertManager.trustStoreManager.addCertificate(serverCertManager);
+        clientCertManager.trustStoreManager.save();
+        serverCertManager.trustStoreManager.addCertificate(clientCertManager);
+        serverCertManager.trustStoreManager.save();
+        NettyClientRouter clientRouter = new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                buildRuntimeParams(clientCertManager.certManagementConfig)
+        );
+        clientRouter.getConnectionFuture().join();
+        assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
+
+        // Corrupt client cert and reload ssl
+        Path keyStoreFilePath = clientCertManager.keyStoreConfig.getKeyStoreFile();
+        Path keyStoreFilePathCopy = keyStoreFilePath.resolveSibling(keyStoreFilePath.getFileName() + ".copy");
+        Files.move(keyStoreFilePath, keyStoreFilePathCopy, StandardCopyOption.ATOMIC_MOVE);
+
+        byte[] randomBytes = new byte[100];
+        Random random = new Random();
+        random.nextBytes(randomBytes);
+        Files.write(keyStoreFilePath, randomBytes, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+        clientRouter.reconnect();
+        TimeUnit.SECONDS.sleep(1);
+        assertThat(getBaseClient(clientRouter).pingSync()).isFalse();
+
+        // Restore the correct cert and reload ssl
+        Files.move(keyStoreFilePathCopy, keyStoreFilePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        clientRouter.reconnect();
+        TimeUnit.SECONDS.sleep(1);
+        assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
+
+        clientRouter.close();
+
+        serverData.shutdownServer();
+        serverData.serverContext.close();
+    }
+
+    @Test
+    public void testReloadSslCertsWithCorruptedTrustStore() throws Exception {
+        int port = findRandomOpenPort();
+
+        Path certDir = Paths.get(PARAMETERS.TEST_TEMP_DIR);
+
+        // Start corfu server
+        CertificateManager serverCertManager = CertificateManager.buildSHA384withEcDsa(certDir);
+        NettyServerData serverData = new NettyServerData(buildServerContext(port, serverCertManager.certManagementConfig));
+        serverData.bootstrapServer();
+
+        // Happy path with correct cert
+        CertificateManager clientCertManager = CertificateManager.buildSHA384withEcDsa(certDir);
+        clientCertManager.trustStoreManager.addCertificate(serverCertManager);
+        clientCertManager.trustStoreManager.save();
+        serverCertManager.trustStoreManager.addCertificate(clientCertManager);
+        serverCertManager.trustStoreManager.save();
+        NettyClientRouter clientRouter = new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                buildRuntimeParams(clientCertManager.certManagementConfig)
+        );
+        clientRouter.getConnectionFuture().join();
+        assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
+
+        // Corrupt client cert and reload ssl
+        Path trustStoreFilePath = clientCertManager.trustStoreManager.config.getTrustStoreFile();
+        Path trustStoreFilePathCopy = trustStoreFilePath.resolveSibling(trustStoreFilePath.getFileName() + ".copy");
+        Files.move(trustStoreFilePath, trustStoreFilePathCopy, StandardCopyOption.ATOMIC_MOVE);
+
+        byte[] randomBytes = new byte[100];
+        Random random = new Random();
+        random.nextBytes(randomBytes);
+        Files.write(trustStoreFilePath, randomBytes, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+        clientRouter.reconnect();
+        TimeUnit.SECONDS.sleep(1);
+        assertThat(getBaseClient(clientRouter).pingSync()).isFalse();
+
+        // Restore the correct cert and reload ssl
+        Files.move(trustStoreFilePathCopy, trustStoreFilePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        clientRouter.reconnect();
+        TimeUnit.SECONDS.sleep(1);
+        assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
+
+        clientRouter.close();
+
+        serverData.shutdownServer();
+        serverData.serverContext.close();
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -351,6 +351,11 @@ public class TestClientRouter implements IClientRouter {
         //TODO - pause pipeline
     }
 
+    @Override
+    public void reconnect() {
+        // no-op
+    }
+
     public RequestMsg simulateSerialization(RequestMsg message) throws IOException {
         // Simulate serialization/deserialization
         ByteBuf oBuf = Unpooled.buffer();


### PR DESCRIPTION
## Overview
Add ReloadableKeyManager and CorfuRuntime reconnect() API.

Description:
This PR uses ReloadableKeyManager in SSLContext to auto-reload the SSL certs upon new connections. It also adds reconnect() API in CorfuRuntime to support client triggered reconnections.

Why should this be merged: 
Support hot-swapping of SSL certs in Corfu runtime.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
