### PR TITLE
Code clean-up: remove redundant suppression's

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
@@ -83,7 +83,6 @@ public class RequestHandlerMethods {
      * @param ctx       The channel handler context.
      * @param r         The server router.
      */
-    @SuppressWarnings("unchecked")
     public void handle(RequestMsg req, ChannelHandlerContext ctx, IServerRouter r) {
         final HandlerMethod handler = getHandler(req);
         try {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/ReplicationHandlerMethods.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/ReplicationHandlerMethods.java
@@ -83,7 +83,6 @@ public class ReplicationHandlerMethods {
      * @param req       The request message to handle.
      * @param r         The server router.
      */
-    @SuppressWarnings("unchecked")
     public void handle(CorfuMessage.RequestMsg req, CorfuMessage.ResponseMsg res, IClientServerRouter r) {
         final HandlerMethod handler = req != null ? getRequestHandler(req) : getResponseHandler(res);
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -73,7 +73,6 @@ public interface IMetadata {
         getMetadataMap().put(LogUnitMetadataType.CLIENT_ID, clientId);
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
     default UUID getClientId() {
         return (UUID) getMetadataMap().getOrDefault(LogUnitMetadataType.CLIENT_ID, null);
@@ -83,7 +82,6 @@ public interface IMetadata {
         getMetadataMap().put(LogUnitMetadataType.THREAD_ID, threadId);
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
     default Long getThreadId() {
         return (Long) getMetadataMap().getOrDefault(LogUnitMetadataType.THREAD_ID, null);
@@ -94,7 +92,6 @@ public interface IMetadata {
      *
      * @return global address
      */
-    @SuppressWarnings("unchecked")
     default Long getGlobalAddress() {
         return Optional.ofNullable((Long) getMetadataMap()
                 .get(LogUnitMetadataType.GLOBAL_ADDRESS)).orElse(Address.NON_ADDRESS);

--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -23,7 +23,6 @@ public class MultiCheckpointWriter<T extends ICorfuTable<?, ?>> {
     private List<ICorfuSMR> tables = new ArrayList<>();
 
     /** Add a table to the list of tables to be checkpointed by this class. */
-    @SuppressWarnings("unchecked")
     public void addMap(T table) {
         this.tables.add((ICorfuSMR) table);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -136,7 +136,6 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
      *
      * @param tc The transaction to merge.
      */
-    @SuppressWarnings("unchecked")
     public void addTransaction(AbstractTransactionalContext tc) {
         log.trace("Merge[{}] adding {}", this, tc);
         // merge the conflict maps
@@ -157,7 +156,6 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
      * @throws TransactionAbortedException  If the transaction was aborted.
      */
     @Override
-    @SuppressWarnings("unchecked")
     public long commitTransaction() throws TransactionAbortedException {
         log.trace("TX[{}] request optimistic commit", this);
         return getConflictSetAndCommit(getReadSetInfo());

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -71,7 +71,6 @@ public class LayoutView extends AbstractView {
      * @throws OutrankedException outranked exception, i.e., higher rank.
      * @throws WrongEpochException wrong epoch number.
      */
-    @SuppressWarnings("unchecked")
     public void updateLayout(Layout layout, long rank)
             throws QuorumUnreachableException, OutrankedException, WrongEpochException {
         // Note this step is done because we have added the layout to the Epoch.

--- a/runtime/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
@@ -54,7 +54,6 @@ public class PrimitiveSerializer implements ISerializer {
                 .forEach(i -> applyFunc.apply(b, (R) i));
     }
 
-    @SuppressWarnings("unchecked")
     static <T, R> T[] readArray(ByteBuf b, Function<ByteBuf, T> applyFunc,
                                 Function<Integer, T[]> arrayGen) {
         int length = b.readInt();
@@ -85,7 +84,6 @@ public class PrimitiveSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    @SuppressWarnings("unchecked")
     public Object deserialize(ByteBuf b, CorfuRuntime rt) {
         byte type = b.readByte();
         DeserializerFunction d = DeserializerMap.get(type);

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -61,7 +61,6 @@ public class CorfuQueueTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void basicQueueOrder() {
         CorfuRuntime runtime = createDefaultRuntime();
         CorfuQueue corfuQueue = new CorfuQueue(runtime, "test");

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -85,7 +85,6 @@ public class CorfuTableTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadFromEachIndex() {
         PersistentCorfuTable<String, String>
                 corfuTable = getDefaultRuntime().getObjectsView().build()
@@ -141,7 +140,6 @@ public class CorfuTableTest extends AbstractViewTest {
      * when the index has never been specified for this CorfuTable.
      */
     @Test (expected = IllegalArgumentException.class)
-    @SuppressWarnings("unchecked")
     public void cannotLookupByIndexWhenIndexNotSpecified() {
         PersistentCorfuTable<String, String>
                 corfuTable = getDefaultRuntime().getObjectsView().build()
@@ -160,7 +158,6 @@ public class CorfuTableTest extends AbstractViewTest {
      * Can create create multiple index for the same value
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadFromMultipleIndices() {
         PersistentCorfuTable<String, String> corfuTable = getDefaultRuntime()
                 .getObjectsView()
@@ -180,7 +177,6 @@ public class CorfuTableTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void emptyIndexesReturnEmptyValues() {
         PersistentCorfuTable<String, String>
                 corfuTable = getDefaultRuntime().getObjectsView().build()
@@ -202,7 +198,6 @@ public class CorfuTableTest extends AbstractViewTest {
      * percolated all the way to the client.
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void problematicIndexFunction() {
         PersistentCorfuTable<String, String>
                 corfuTable = getDefaultRuntime().getObjectsView().build()
@@ -223,7 +218,6 @@ public class CorfuTableTest extends AbstractViewTest {
      * percolated all the way to the client (TX flavour).
      */
     @Test
-    @SuppressWarnings("unchecked")
     @Ignore // TODO: Exception thrown from different location
     public void problematicIndexFunctionTx() {
         PersistentCorfuTable<String, String>
@@ -244,7 +238,6 @@ public class CorfuTableTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWithoutIndexes() {
         PersistentCorfuTable<String, String>
                 corfuTable = getDefaultRuntime().getObjectsView().build()
@@ -305,7 +298,7 @@ public class CorfuTableTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked", "checkstyle:magicnumber"})
+    @SuppressWarnings({"checkstyle:magicnumber"})
     public void canHandleHoleInTail() {
         UUID streamID = UUID.randomUUID();
 

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -39,7 +39,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteToSingle() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime()
                 .getObjectsView()
@@ -57,7 +56,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteToSinglePrimitive() throws Exception {
         getRuntime().setCacheDisabled(true);
         PersistentCorfuTable<Long, Double> testTable = getRuntime()
@@ -82,7 +80,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canGetID() throws Exception {
         UUID id = UUID.randomUUID();
         ICorfuSMR testTable = getRuntime().getObjectsView()
@@ -95,7 +92,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void loadsFollowedByGets() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                 .build()
@@ -115,7 +111,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canContainOtherCorfuObjects() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                 .build()
@@ -228,8 +223,7 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
    @Test
-    @SuppressWarnings("unchecked")
-    public void canUpdateSingleObjectTransactionally() throws Exception {
+   public void canUpdateSingleObjectTransactionally() throws Exception {
        PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                .build()
                .setStreamName("test")
@@ -250,7 +244,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void multipleTXesAreApplied() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                 .build()
@@ -277,7 +270,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void multipleTXesAreAppliedWOAccessors() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                 .build()
@@ -301,7 +293,6 @@ public class SMRMapTest extends AbstractViewTest {
 
 
     @Test
-    @SuppressWarnings("unchecked")
     public void mutatorFollowedByATransaction() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                 .build()
@@ -322,7 +313,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void objectViewCorrectlyReportsInsideTX() throws Exception {
         assertThat(getRuntime().getObjectsView().TXActive()).isFalse();
         getRuntime().getObjectsView().TXBegin();
@@ -332,7 +322,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canUpdateSingleObjectTransactionallyWhenCached() throws Exception {
         r.setCacheDisabled(false);
 
@@ -355,7 +344,6 @@ public class SMRMapTest extends AbstractViewTest {
 
 
     @Test
-    @SuppressWarnings("unchecked")
     public void abortedTransactionsCannotBeReadOnSingleObject() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                 .build()
@@ -380,7 +368,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void modificationDuringTransactionCausesAbort() throws Exception {
         PersistentCorfuTable<String, String> testTable = getRuntime().getObjectsView()
                 .build()
@@ -415,7 +402,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void smrMapCanContainCustomObjects() throws Exception {
         PersistentCorfuTable<String, TestObject> testTable = getRuntime().getObjectsView()
                 .build()
@@ -429,7 +415,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void smrMapCanContainCustomObjectsInsideTXes() throws Exception {
         PersistentCorfuTable<String, TestObject> testTable = getRuntime().getObjectsView()
                 .build()
@@ -504,7 +489,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void concurrentAbortMultiViewInterleaved() throws Exception {
         final int numThreads = PARAMETERS.CONCURRENCY_SOME;
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
@@ -522,7 +506,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void concurrentAbortMultiViewThreaded() throws Exception {
         final int numThreads = PARAMETERS.CONCURRENCY_SOME;
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
@@ -540,7 +523,6 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void bulkReads() throws Exception {
         UUID stream = UUID.randomUUID();
         PersistentCorfuTable<String, String> testTable = getRuntime()

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -40,7 +40,6 @@ public class CorfuSMRObjectProxyTest extends AbstractObjectTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canUseCustomSerializer() throws Exception {
         //Register a custom serializer and use it with an SMR object
         ISerializer customSerializer = new CustomSerializer((byte) (Serializers.SYSTEM_SERIALIZERS_COUNT + 1));

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -114,7 +114,6 @@ public class AddressSpaceViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void ensureStripingWorks() throws Exception {
         setupNodes();
         CorfuRuntime rt = getRuntime().connect();
@@ -197,7 +196,6 @@ public class AddressSpaceViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void ensureStripingReadAllWorks() throws Exception {
         setupNodes();
         CorfuRuntime rt = getRuntime().connect();

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -20,7 +20,6 @@ public class ChainReplicationViewTest extends AbstractViewTest {
 
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteToSingle()
             throws Exception {
         CorfuRuntime r = getDefaultRuntime();
@@ -40,7 +39,6 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteToSingleConcurrent()
             throws Exception {
         CorfuRuntime r = getDefaultRuntime();
@@ -70,7 +68,6 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteToMultiple()
             throws Exception {
 
@@ -112,7 +109,6 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void ensureAllUnitsContainData()
             throws Exception {
 

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class ObjectsViewTest extends AbstractViewTest {
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canAbortNoTransaction()
             throws Exception {
         //begin tests
@@ -35,7 +34,6 @@ public class ObjectsViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void abortedTransactionDoesNotConflict()
             throws Exception {
         final String mapA = "map a";
@@ -135,7 +133,6 @@ public class ObjectsViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void unrelatedStreamDoesNotConflict()
             throws Exception {
         //begin tests
@@ -162,7 +159,6 @@ public class ObjectsViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void unrelatedTransactionDoesNotConflict()
             throws Exception {
         //begin tests

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -104,7 +104,6 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteFromStream()
             throws Exception {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
@@ -169,7 +168,6 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteFromStreamConcurrent()
             throws Exception {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
@@ -191,7 +189,6 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteFromCachedStream()
             throws Exception {
         CorfuRuntime r = getDefaultRuntime().connect()
@@ -282,7 +279,6 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void streamCanSurviveOverwriteException()
             throws Exception {
         UUID streamA = CorfuRuntime.getStreamID("stream A");
@@ -304,7 +300,6 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void streamWillHoleFill()
             throws Exception {
         //begin tests
@@ -327,7 +322,6 @@ public class StreamViewTest extends AbstractViewTest {
 
 
     @Test
-    @SuppressWarnings("unchecked")
     public void streamWithHoleFill()
             throws Exception {
         UUID streamA = CorfuRuntime.getStreamID("stream A");
@@ -365,7 +359,6 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void prefixTrimThrowsException()
             throws Exception {
         //begin tests

--- a/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
@@ -41,7 +41,6 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
      * that was written.
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void canWriteRead()
             throws Exception {
         setupNodes();
@@ -67,7 +66,6 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
      * the case of an unwritten address.
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void readOnlyCommitted()
             throws Exception {
         setupNodes();
@@ -93,7 +91,6 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
      * written entry results in an OverwriteException.
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void overwriteThrowsException()
             throws Exception {
         setupNodes();


### PR DESCRIPTION
## Overview

Description:
Code clean-up: remove redundant suppression's

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
