### PR TITLE
Do not restore some metadata tables to keep compactor disabled during restore

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/BackupRestoreIT.java
+++ b/test/src/test/java/org/corfudb/runtime/BackupRestoreIT.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime;
 
+import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -11,9 +12,12 @@ import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.CorfuCompactorManagement.CheckpointingStatus;
+import org.corfudb.runtime.CorfuCompactorManagement.StringKey;
 import org.corfudb.runtime.exceptions.BackupRestoreException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.test.SampleSchema;
 import org.corfudb.test.SampleSchema.Uuid;
@@ -30,6 +34,9 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.CompactorMetadataTables.COMPACTION_CONTROLS_TABLE;
+import static org.corfudb.runtime.CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
@@ -804,6 +811,94 @@ public class BackupRestoreIT extends AbstractIT {
 
         assertThat(allTablesBeforeBackup).containsAll(allTablesAfterRestore);
         assertThat(allTablesAfterRestore).containsAll(allTablesBeforeBackup);
+
+        Table<StringKey, CheckpointingStatus, Message> compactionManagerTable = destDataCorfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
+                COMPACTION_MANAGER_TABLE_NAME,
+                StringKey.class,
+                CheckpointingStatus.class,
+                null,
+                TableOptions.fromProtoSchema(CheckpointingStatus.class));
+
+        Table<StringKey, RpcCommon.TokenMsg, Message> compactionControlsTable = destDataCorfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
+                COMPACTION_CONTROLS_TABLE,
+                StringKey.class,
+                RpcCommon.TokenMsg.class,
+                null,
+                TableOptions.fromProtoSchema(RpcCommon.TokenMsg.class));
+
+        try (TxnContext txn = destDataCorfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+            CheckpointingStatus managerStatus = txn.getRecord(compactionManagerTable,
+                    CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
+            assertThat(managerStatus).isNull();
+            assertThat(txn.getRecord(compactionControlsTable,
+                    CompactorMetadataTables.DISABLE_COMPACTION).getPayload()).isNull();
+            txn.commit();
+        }
+
+        // Close servers and runtime before exiting
+        cleanEnv();
+    }
+
+    /**
+     * Tests if compaction is disabled till end of restore()
+     *
+     * @throws Exception
+     */
+    @Test
+    public void backupRestoreDisableCompactionTest() throws Exception {
+        // Set up the test environment
+        setupEnv();
+
+        // Create Corfu Store to add entries into server
+        CorfuStore srcDataCorfuStore = new CorfuStore(srcDataRuntime);
+        CorfuStore destDataCorfuStore = new CorfuStore(destDataRuntime);
+
+        List<String> tableNames = getTableNames(numTables);
+
+        // Generate random entries and save into sourceServer
+        // Set half of the tables with backup tag, and the other half without backup tag
+        int i = 0;
+        for (String tableName : tableNames) {
+            if (i++ % 2 == 0) {
+                // set requires_backup_support
+                generateData(srcDataCorfuStore, NAMESPACE, tableName, true);
+            } else {
+                generateData(srcDataCorfuStore, NAMESPACE, tableName, false);
+            }
+        }
+
+        // Backup all tables
+        Backup backup = new Backup(BACKUP_TAR_FILE_PATH, backupRuntime, false, null);
+        backup.start();
+
+        // Verify that backup tar file exists
+        File backupTarFile = new File(BACKUP_TAR_FILE_PATH);
+        assertThat(backupTarFile).exists();
+
+        // Generate pre-existing data and save into destServer
+        for (String tableName : tableNames) {
+            generateData(destDataCorfuStore, NAMESPACE, tableName, true);
+        }
+
+        // Restore using backup files
+        Restore restore = new Restore(BACKUP_TAR_FILE_PATH, restoreRuntime, Restore.RestoreMode.FULL, null);
+        restore.disableCompaction();
+        restore.openTarFile();
+        restore.restore();
+
+        //Do not call enableCompaction() here as we want to test if compaction is disabled after restore()
+        Table<StringKey, RpcCommon.TokenMsg, Message> compactionControlsTable = destDataCorfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
+                COMPACTION_CONTROLS_TABLE,
+                StringKey.class,
+                RpcCommon.TokenMsg.class,
+                null,
+                TableOptions.fromProtoSchema(RpcCommon.TokenMsg.class));
+
+        try (TxnContext txn = destDataCorfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+            assertThat(txn.getRecord(compactionControlsTable,
+                    CompactorMetadataTables.DISABLE_COMPACTION).getPayload()).isNotNull();
+            txn.commit();
+        }
 
         // Close servers and runtime before exiting
         cleanEnv();


### PR DESCRIPTION
## Overview

Description:

When Restore is invoked with mode as FULL, compactor should be disabled before starting restore and also during restore.

Restore corfu tables happens the following way -
1. Disable compactor
2. Clear all tables - in a single txn
3. Restore tables one by one as found in the backup tar file passed - Non-transactionally
4. Enable compactor

There are 2 issues here - 
1. It is possible that between steps 2 & 3, the compactor orchestrator tries to trigger a compaction cycle. 
2. When the compaction metadata tables are restored in step c, it's possible that the status of CompactionManagerTable is STARTED leading to restore and checkpointing happening in parallel

This PR fixes this issue by not clearing/restoring compactor metadata tables ensuring that compactor is disabled before and during restore workflow.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
