### PR TITLE
@rocksdb: Bound the size of LOG files (#3823)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <repositories>
         <repository>
             <id>clojars.org</id>
-            <url>http://clojars.org/repo</url>
+            <url>https://clojars.org/repo</url>
         </repository>
 
         <repository>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -59,8 +59,14 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
      */
     public static Options getPersistedStreamingMapOptions() {
         final int maxSizeAmplificationPercent = 50;
+        final long num_log_files = 2;
+        final long log_file_size = 1024 * 1024 * 5; // 5MB.
         final Options options = new Options();
 
+        // For long-running processes, limit the amount of space
+        // that the log files can occupy.
+        options.setKeepLogFileNum(num_log_files);
+        options.setMaxLogFileSize(log_file_size);
         options.setCreateIfMissing(true);
         options.setCompressionType(CompressionType.LZ4_COMPRESSION);
 


### PR DESCRIPTION
By default, there is no limit on how much space LOG files can occupy. Bound the maximum number of LOG files that can be created and the maximum size of any LOG file.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
