### PR TITLE
Fix Deadlock Scenario Between Seal Protocol And Log Metadata Persistence

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -661,11 +661,11 @@ public class ServerContext implements AutoCloseable {
         return resetEpoch == null ? Layout.INVALID_EPOCH : resetEpoch;
     }
 
-    public synchronized void setLogUnitMetadata(Map<UUID, String> streamAddressSpace) {
+    public void setLogUnitMetadata(Map<UUID, String> streamAddressSpace) {
         dataStore.put(LOG_UNIT_METADATA_RECORD, streamAddressSpace);
     }
 
-    public synchronized Map<UUID, String> getLogUnitMetadata() {
+    public Map<UUID, String> getLogUnitMetadata() {
         return (Map<UUID, String>)dataStore.get(LOG_UNIT_METADATA_RECORD);
     }
 


### PR DESCRIPTION
This patch fixes a race between the BatchProcessor and BaseServer threads that induces a deadlock. The BatchProcessor thread persists log metadata via the synchronized ServerContext::setLogUnitMetadata method. However, if the seal protocol is in progress and the BaseServer thread calls the synchronized ServerContext::setServerEpoch method first, it will become blocked indefinitely waiting for a BatchProcessor future to complete.

Why should this be merged: Bug fix.

Related issue(s) (if applicable): #3862 

## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
