### PR TITLE
DiskBacked Snapshot Cache Cleanup Fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
@@ -126,6 +126,12 @@ public class MVOCache<S extends SnapshotGenerator<S>> {
                         .filter(voId -> objectId.equals(voId.getObjectId()))
                         .collect(Collectors.toList());
         objectCache.invalidateAll(voIdsToInvalidate);
+
+        // Force cleanup of invalidated and EXPIRED cache entries. Despite still being part of certain
+        // internal cache data structures, note that EXPIRED entries do not appear in the asMap() view.
+        // Moreover, unlike the invalidateAll() variant of this API, these EXPIRED entries are not
+        // removed when invalidateAll(Iterable<? extends Object> keys) is invoked.
+        objectCache.cleanUp();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
This patch addresses a bug for DiskBacked tables where, after a TrimmedException from the streaming layer, EXPIRED snapshots in the MVOCache are not removed as expected. When these EXPIRED snapshots linger in the cache, after the state of the object is reset from the TrimmedException, they can no longer be released without causing a core dump since the underlying RocksDB reference is no longer valid.

Why should this be merged:  Bug fix for DiskBacked Corfu.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
