### PR TITLE
Avoid SIGSEGV on an invalid RocksDB instance

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/RocksDbStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/RocksDbStore.java
@@ -88,6 +88,8 @@ public class RocksDbStore<S extends SnapshotGenerator<S>> implements
             this.secondaryIndexColumnFamily = this.rocksDb.createColumnFamily(
                     new ColumnFamilyDescriptor("secondary-indexes".getBytes(), columnFamilyOptions));
         }
+
+        log.info("Opened RocksDB instance {} at {}.", rocksDb.getNativeHandle(), absolutePathString);
     }
 
     @Override
@@ -190,7 +192,7 @@ public class RocksDbStore<S extends SnapshotGenerator<S>> implements
     public void close() throws RocksDBException {
         rocksDb.close();
         RocksDB.destroyDB(absolutePathString, rocksDbOptions);
-        log.info("Cleared RocksDB data on {}", absolutePathString);
+        log.info("Closed RocksDB instance {} at {}.", rocksDb.getNativeHandle(), absolutePathString);
     }
 
     /**


### PR DESCRIPTION
Prevent the JVM from crashing in the event of an invalid RocksDB instance by performing validation beforehand.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
