### PR TITLE
LR: fix issues around leader changing

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
@@ -202,7 +202,6 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
             //  To resolve this, we need to have a long living RPC from the connectionInitiator cluster which will query
             //  for sessions from the other cluster
             if (sinkManager == null || sinkManager.isSinkManagerShutdown()) {
-                //TODO: this block probably can be removed now.
                 if(!allSessions.contains(session)) {
                     log.error("SessionManager does not know about incoming session {}, total={}, current sessions={}",
                             session, sessionToSinkManagerMap.size(), sessionToSinkManagerMap.keySet());
@@ -269,7 +268,6 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
             //  To resolve this, we need to have a long living RPC from the connectionInitiator cluster which will query
             //  for sessions from the other cluster
             if (sinkManager == null) {
-                //TODO: this block probably can be removed now.
                 if(!allSessions.contains(session)) {
                     log.error("SessionManager does not know about incoming session {}, total={}, current sessions={}",
                             session, sessionToSinkManagerMap.size(), sessionToSinkManagerMap.keySet());
@@ -311,15 +309,7 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
                                                      @Nonnull IClientServerRouter router) {
         log.debug("Log Replication Query Leadership Request received by Server.");
         HeaderMsg responseHeader = getHeaderMsg(request.getHeader());
-        ResponseMsg response;
-        // To ensure that SINK is ready to respond to a negotiation msg, we stall until the session manager is aware of
-        // the session. The node buys some time by replying "not-the-leader" even if it is the leader.
-        // This is needed in cases where the pluggable transport layer doesn't have a timeout mechanism for an rpc.
-        if (allSessions.contains(request.getPayload().getLrLeadershipQuery().getSession())) {
-            response = getLeadershipResponse(responseHeader, replicationContext.getIsLeader().get(), localNodeId);
-        } else {
-            response = getLeadershipResponse(responseHeader, false, localNodeId);
-        }
+        ResponseMsg response = getLeadershipResponse(responseHeader, replicationContext.getIsLeader().get(), localNodeId);
         router.sendResponse(response);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
@@ -98,7 +98,7 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
         this.executor = context.getExecutorService(1, EXECUTOR_NAME_PREFIX);
     }
 
-    public LogReplicationSinkManager createSinkManager(LogReplicationSession session) {
+    public synchronized LogReplicationSinkManager createSinkManager(LogReplicationSession session) {
         if(sessionToSinkManagerMap.containsKey(session)) {
             log.trace("Sink manager already exists for session {}", session);
             return sessionToSinkManagerMap.get(session);
@@ -202,6 +202,7 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
             //  To resolve this, we need to have a long living RPC from the connectionInitiator cluster which will query
             //  for sessions from the other cluster
             if (sinkManager == null || sinkManager.isSinkManagerShutdown()) {
+                //TODO: this block probably can be removed now.
                 if(!allSessions.contains(session)) {
                     log.error("SessionManager does not know about incoming session {}, total={}, current sessions={}",
                             session, sessionToSinkManagerMap.size(), sessionToSinkManagerMap.keySet());
@@ -268,6 +269,7 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
             //  To resolve this, we need to have a long living RPC from the connectionInitiator cluster which will query
             //  for sessions from the other cluster
             if (sinkManager == null) {
+                //TODO: this block probably can be removed now.
                 if(!allSessions.contains(session)) {
                     log.error("SessionManager does not know about incoming session {}, total={}, current sessions={}",
                             session, sessionToSinkManagerMap.size(), sessionToSinkManagerMap.keySet());
@@ -300,6 +302,7 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
      * Given a leadership request message, send back a
      * response indicating our current leadership status.
      *
+     *
      * @param request the leadership request message
      * @param router  router used for sending back the response
      */
@@ -308,7 +311,15 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
                                                      @Nonnull IClientServerRouter router) {
         log.debug("Log Replication Query Leadership Request received by Server.");
         HeaderMsg responseHeader = getHeaderMsg(request.getHeader());
-        ResponseMsg response = getLeadershipResponse(responseHeader, replicationContext.getIsLeader().get(), localNodeId);
+        ResponseMsg response;
+        // To ensure that SINK is ready to respond to a negotiation msg, we stall until the session manager is aware of
+        // the session. The node buys some time by replying "not-the-leader" even if it is the leader.
+        // This is needed in cases where the pluggable transport layer doesn't have a timeout mechanism for an rpc.
+        if (allSessions.contains(request.getPayload().getLrLeadershipQuery().getSession())) {
+            response = getLeadershipResponse(responseHeader, replicationContext.getIsLeader().get(), localNodeId);
+        } else {
+            response = getLeadershipResponse(responseHeader, false, localNodeId);
+        }
         router.sendResponse(response);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -295,6 +295,7 @@ public class CorfuLogReplicationRuntime {
     public synchronized void resetRemoteLeaderNodeId() {
         log.debug("Reset remote leader node id");
         leaderNodeId = Optional.empty();
+        router.resetRemoteLeader(session);
     }
 
     public synchronized Optional<String> getRemoteLeaderNodeId() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -763,6 +763,9 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     this.clientChannelAdapter.connectAsync(sessionToRemoteClusterDescriptor.get(session), nodeId, session);
+                } catch(NullPointerException npe) {
+                    log.info("The session is already stopped. Abort trying to reconnect {}", session);
+                    return null;
                 } catch (Exception e) {
                     log.error("Failed to connect to remote node {} for session {}. Retry after 1 second. Exception {}.",
                             nodeId, session, e);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientServerRouter.java
@@ -386,11 +386,12 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
             final CompletableFuture<T> cfTimeout =
                     CFUtils.within(cf, Duration.ofMillis(timeoutResponse));
             final long finalRequestId = requestId;
+            String finalNodeId = nodeId;
             cfTimeout.exceptionally(e -> {
                 if (e.getCause() instanceof TimeoutException) {
                     sessionToOutstandingRequests.get(session).remove(finalRequestId);
-                    log.debug("sendMessageAndGetCompletable: Remove request {} to {} due to timeout! Message:{}",
-                            finalRequestId, sessionToRemoteClusterDescriptor.get(session).getClusterId(), payload.getPayloadCase());
+                    log.debug("sendMessageAndGetCompletable: Remove request {} to {}/{} due to timeout! Message:{}",
+                            finalRequestId, sessionToRemoteClusterDescriptor.get(session).getClusterId(), finalNodeId, payload.getPayloadCase());
                 }
                 return null;
             });
@@ -415,8 +416,8 @@ public class LogReplicationClientServerRouter implements IClientServerRouter {
             removeSessionInfo(session);
         } catch (Exception e) {
             sessionToOutstandingRequests.get(session).remove(requestId);
-            log.error("sendMessageAndGetCompletable: Remove request {} to {} due to exception! Message:{}",
-                    requestId, sessionToRemoteClusterDescriptor.get(session).getClusterId(), payload.getPayloadCase(), e);
+            log.error("sendMessageAndGetCompletable: Remove request {} to {}/{} due to exception! Message:{}",
+                    requestId, sessionToRemoteClusterDescriptor.get(session).getClusterId(), nodeId, payload.getPayloadCase(), e);
             cf.completeExceptionally(e);
         }
         return cf;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
@@ -44,7 +44,8 @@ public class LogReplicationFsmUtil {
                 // Check Leadership
                 CorfuMessage.RequestPayloadMsg payload =
                         CorfuMessage.RequestPayloadMsg.newBuilder().setLrLeadershipQuery(
-                                LogReplication.LogReplicationLeadershipRequestMsg.newBuilder().build()
+                                LogReplication.LogReplicationLeadershipRequestMsg.newBuilder()
+                                        .setSession(session).build()
                         ).build();
                 CompletableFuture<LogReplication.LogReplicationLeadershipResponseMsg> leadershipRequestCf =
                         router.sendRequestAndGetCompletable(session, payload, nodeId);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/LogReplicationFsmUtil.java
@@ -44,7 +44,7 @@ public class LogReplicationFsmUtil {
                 // Check Leadership
                 CorfuMessage.RequestPayloadMsg payload =
                         CorfuMessage.RequestPayloadMsg.newBuilder().setLrLeadershipQuery(
-                                LogReplication.LogReplicationLeadershipRequestMsg.newBuilder().setSession(session).build()
+                                LogReplication.LogReplicationLeadershipRequestMsg.newBuilder().build()
                         ).build();
                 CompletableFuture<LogReplication.LogReplicationLeadershipResponseMsg> leadershipRequestCf =
                         router.sendRequestAndGetCompletable(session, payload, nodeId);
@@ -114,12 +114,6 @@ public class LogReplicationFsmUtil {
 
     private static <T> void enqueueLeaderNotFound(Object fsm, Class<T> clazz, String leader) throws NoSuchMethodException,
             InvocationTargetException, IllegalAccessException {
-        // wait for a while before enqueuing
-        try {
-            new CompletableFuture<>().get(CorfuLogReplicationRuntime.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            log.trace("Exception occurred while waiting to enqueue REMOTE_LEADER_NOT_FOUND");
-        }
 
         if (clazz.getName().equals(CorfuLogReplicationRuntime.class.getName())) {
             clazz.getMethod("input", LogReplicationRuntimeEvent.class).invoke(fsm,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
@@ -51,7 +51,7 @@ public abstract class IClientChannelAdapter {
     /**
      * If connection is lost to a specific endpoint, attempt to reconnect to the specific node.
      */
-    public abstract void connectAsync(ClusterDescriptor remoteCluster, String nodeId, LogReplicationSession sessionMsg);
+    public abstract void connectAsync(ClusterDescriptor remoteCluster, String nodeId, LogReplicationSession sessionMsg) throws Exception;
 
     /**
      * Stop communication across all remote clusters.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -145,7 +145,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
     }
 
     @Override
-    public void connectAsync(ClusterDescriptor remoteCluster, String nodeId, LogReplicationSession session) {
+    public void connectAsync(ClusterDescriptor remoteCluster, String nodeId, LogReplicationSession session) throws Exception {
         Optional<String> endpoint = remoteCluster.getNodeDescriptors()
                 .stream()
                 .filter(nodeDescriptor -> nodeDescriptor.getNodeId().toString().equals(nodeId))

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -118,7 +118,7 @@ public class LogReplicationServerTest {
     @Test
     public void testHandleLeadershipQuery() {
         final LogReplicationLeadershipRequestMsg leadershipQuery =
-            LogReplicationLeadershipRequestMsg.newBuilder().build();
+            LogReplicationLeadershipRequestMsg.newBuilder().setSession(session).build();
         final RequestMsg request =
             getRequestMsg(HeaderMsg.newBuilder().setClusterId(sourceClusterUuid).build(),
                 CorfuMessage.RequestPayloadMsg.newBuilder()

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -118,7 +118,7 @@ public class LogReplicationServerTest {
     @Test
     public void testHandleLeadershipQuery() {
         final LogReplicationLeadershipRequestMsg leadershipQuery =
-            LogReplicationLeadershipRequestMsg.newBuilder().setSession(session).build();
+            LogReplicationLeadershipRequestMsg.newBuilder().build();
         final RequestMsg request =
             getRequestMsg(HeaderMsg.newBuilder().setClusterId(sourceClusterUuid).build(),
                 CorfuMessage.RequestPayloadMsg.newBuilder()

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -39,6 +39,7 @@ message LogReplicationLeadershipLossMsg {
 }
 
 message LogReplicationLeadershipRequestMsg {
+  LogReplicationSession session = 1;
 }
 
 message LogReplicationLeadershipResponseMsg {

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -39,7 +39,6 @@ message LogReplicationLeadershipLossMsg {
 }
 
 message LogReplicationLeadershipRequestMsg {
-  LogReplicationSession session = 1;
 }
 
 message LogReplicationLeadershipResponseMsg {


### PR DESCRIPTION
## Overview
This PR contains the below fixes:
    1. add retry logic to connectAsync while connecting to a particular remote node
    2. Do not complete ack future on leadership loss. The prior logic was incorrect
    3. integrate remoteLeaderLoss with transport layer : Some of the constructs need to be refreshed.
    4. Do not try to connect to remote cluster when local node looses leadership. : We can get an onConnectionDown event, but if it is because the local node is no longer the leader,  we shouldn't try to reconnect.
    5. When SOURCE is on an older version, stall the source during the VERIFY_LEADERSHIP state by sending a negative response until the SINK creates the default FULL_TABLE session

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
