### PR TITLE
Migrate NettyCommTestUtil to bouncycastle

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -22,6 +22,8 @@ jobs:
           java-version: '11'
           check-latest: true
 
+      - uses: docker/setup-buildx-action@v2
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:

--- a/common/src/main/java/org/corfudb/common/config/ConfigParamsHelper.java
+++ b/common/src/main/java/org/corfudb/common/config/ConfigParamsHelper.java
@@ -3,7 +3,7 @@ package org.corfudb.common.config;
 import java.util.Arrays;
 
 public final class ConfigParamsHelper {
-    public static enum TlsCiphers {
+    public enum TlsCiphers {
         TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
     }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <netty.tcnative.version>2.0.56.Final</netty.tcnative.version>
         <protobuf.version>3.21.7</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <guava.version>32.1.2-jre</guava.version>
         <junit.jupiter.version>5.10.1</junit.jupiter.version>
         <mockito.version>4.11.0</mockito.version>
@@ -347,11 +347,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
-                    <compilerVersion>1.8</compilerVersion>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>false</showDeprecation>
                     <compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>11</release>
+                    <compilerVersion>1.8</compilerVersion>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>false</showDeprecation>
                     <compilerArgs>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,6 +42,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.77</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
             <version>1.14</version>

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTestUtil.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTestUtil.java
@@ -73,7 +73,7 @@ public interface NettyCommTestUtil {
         public static CertificateManager buildSHA384withEcDsa(Path certDir, String alias, Duration validity,
                                                               Date firstDate) throws Exception {
 
-            final String keyType = "EC";
+            final KeyType keyType = KeyType.EC;
             final String sigAlg = "SHA384withECDSA";
             return build(keyType, sigAlg, PASSWORD, certDir, alias, validity, firstDate);
         }
@@ -90,12 +90,12 @@ public interface NettyCommTestUtil {
         }
 
         public static CertificateManager build(
-                String keyType, String sigAlg, String password, Path certDir, String alias,
+                KeyType keyType, String sigAlg, String password, Path certDir, String alias,
                 Duration validity, Date firstDate) throws Exception {
 
             Security.addProvider(new BouncyCastleProvider());
             X500Principal signedByPrincipal = new X500Principal("CN=ROOT");
-            KeyPair signedByKeyPair = generateKeyPair(keyType);
+            KeyPair signedByKeyPair = generateKeyPair(keyType.keyType);
 
             X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
                     signedByPrincipal,
@@ -218,6 +218,16 @@ public interface NettyCommTestUtil {
             try (OutputStream truststoreFile = Files.newOutputStream(truststorePath)) {
                 trustStore.store(truststoreFile, password.toCharArray());
             }
+        }
+    }
+
+    enum KeyType {
+        EC("EC"), RSA("RSA");
+
+        private final String keyType;
+
+        KeyType(String keyType) {
+            this.keyType = keyType;
         }
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTestUtil.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTestUtil.java
@@ -84,8 +84,8 @@ public interface NettyCommTestUtil {
                 KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(keyType);
                 keyPairGenerator.initialize(keyBits, new SecureRandom());
                 return keyPairGenerator.generateKeyPair();
-            } catch (GeneralSecurityException var2) {
-                throw new AssertionError(var2);
+            } catch (GeneralSecurityException ex) {
+                throw new IllegalStateException(ex);
             }
         }
 


### PR DESCRIPTION
## Overview

Description:
To prevent being locked by java 8 (cause sun.* packages) we need to migrate our cert tests to bouncy castle

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
