### PR TITLE
FileWatcher watches all kinds of events

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -361,11 +361,6 @@ public class CorfuRuntime {
          */
         Duration runtimeGCPeriod = Duration.ofMinutes(20);
 
-        /**
-         * The period at which the file watcher will poll the file from disk
-         */
-        Duration fileWatcherPollPeriod = Duration.ofSeconds(10);
-
         /*
          * The {@link UUID} for the cluster this client is connecting to, or
          * {@code null} if the client should adopt the {@link UUID} of the first
@@ -470,7 +465,6 @@ public class CorfuRuntime {
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 1;
             private Duration runtimeGCPeriod = Duration.ofMinutes(20);
-            private Duration fileWatcherPollPeriod = Duration.ofSeconds(10);
             private UUID clusterId = null;
             private int systemDownHandlerTriggerLimit = 20;
             private List<NodeLocator> layoutServers = new ArrayList<>();
@@ -763,11 +757,6 @@ public class CorfuRuntime {
                 return this;
             }
 
-            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder fileWatcherPollPeriod(Duration fileWatcherPollPeriod) {
-                this.fileWatcherPollPeriod = fileWatcherPollPeriod;
-                return this;
-            }
-
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder clusterId(UUID clusterId) {
                 this.clusterId = clusterId;
                 return this;
@@ -853,7 +842,6 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);
                 corfuRuntimeParameters.setRuntimeGCPeriod(runtimeGCPeriod);
-                corfuRuntimeParameters.setFileWatcherPollPeriod(fileWatcherPollPeriod);
                 corfuRuntimeParameters.setClusterId(clusterId);
                 corfuRuntimeParameters.setSystemDownHandlerTriggerLimit(systemDownHandlerTriggerLimit);
                 corfuRuntimeParameters.setLayoutServers(layoutServers);
@@ -1054,7 +1042,7 @@ public class CorfuRuntime {
         if (keyStorePath == null || keyStorePath.isEmpty()) {
             return Optional.empty();
         }
-        FileWatcher sslWatcher = new FileWatcher(keyStorePath, this::reconnect, this.parameters.fileWatcherPollPeriod);
+        FileWatcher sslWatcher = new FileWatcher(keyStorePath, this::reconnect);
         return Optional.of(sslWatcher);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -364,7 +364,7 @@ public class CorfuRuntime {
         /**
          * The period at which the file watcher will poll the file from disk
          */
-        Duration fileWatcherPollPeriod = Duration.ofMinutes(1);
+        Duration fileWatcherPollPeriod = Duration.ofSeconds(10);
 
         /*
          * The {@link UUID} for the cluster this client is connecting to, or
@@ -470,7 +470,7 @@ public class CorfuRuntime {
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 1;
             private Duration runtimeGCPeriod = Duration.ofMinutes(20);
-            private Duration fileWatcherPollPeriod = Duration.ofMinutes(1);
+            private Duration fileWatcherPollPeriod = Duration.ofSeconds(10);
             private UUID clusterId = null;
             private int systemDownHandlerTriggerLimit = 20;
             private List<NodeLocator> layoutServers = new ArrayList<>();

--- a/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManager.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/ReloadableKeyManager.java
@@ -120,6 +120,7 @@ public class ReloadableKeyManager implements X509KeyManager {
             if (km instanceof X509KeyManager) {
                 keyManager = (X509KeyManager) km;
                 lastReloadSucceeded = true;
+                log.info("Successfully reloaded keystore.");
                 return;
             }
         }

--- a/runtime/src/main/java/org/corfudb/util/FileWatcher.java
+++ b/runtime/src/main/java/org/corfudb/util/FileWatcher.java
@@ -75,12 +75,14 @@ public class FileWatcher implements Closeable {
                 WatchEvent<Path> ev = (WatchEvent<Path>) event;
                 Path filename = ev.context();
 
-                log.info("FileWatcher: event kind: {}, filename: {}, watched file: {}",
+                log.info("FileWatcher: event kind: {}, event filename: {}, watched file: {}",
                         kind.toString(), filename.toString(), file.getName());
 
                 if (kind == StandardWatchEventKinds.OVERFLOW) {
                     log.warn("FileWatcher hit overflow and events might be lost!");
-                } else if ((kind == StandardWatchEventKinds.ENTRY_MODIFY || kind == StandardWatchEventKinds.ENTRY_CREATE)
+                } else if ((kind == StandardWatchEventKinds.ENTRY_MODIFY ||
+                        kind == StandardWatchEventKinds.ENTRY_CREATE ||
+                        kind == StandardWatchEventKinds.ENTRY_DELETE)
                         && filename.toString().equals(file.getName())) {
                     log.info("FileWatcher: file {} changed. Invoking handler...", filename);
                     onChange.run();
@@ -106,7 +108,8 @@ public class FileWatcher implements Closeable {
             }
             watchService = FileSystems.getDefault().newWatchService();
             Path path = file.toPath().getParent();
-            path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE);
+            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE,
+                    StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
             isRegistered.set(true);
             log.info("FileWatcher: parent dir {} for file {} registered.", path, file.getAbsoluteFile());
         } catch (IOException ioe) {

--- a/runtime/src/main/java/org/corfudb/util/FileWatcher.java
+++ b/runtime/src/main/java/org/corfudb/util/FileWatcher.java
@@ -71,9 +71,12 @@ public class FileWatcher implements Closeable {
                 WatchEvent<Path> ev = (WatchEvent<Path>) event;
                 Path filename = ev.context();
 
+                log.info("FileWatcher: event kind: {}, filename: {}, watched file: {}",
+                        kind.toString(), filename.toString(), file.getName());
+
                 if (kind == StandardWatchEventKinds.OVERFLOW) {
                     log.warn("FileWatcher hit overflow and events might be lost!");
-                } else if (kind == StandardWatchEventKinds.ENTRY_MODIFY
+                } else if ((kind == StandardWatchEventKinds.ENTRY_MODIFY || kind == StandardWatchEventKinds.ENTRY_CREATE)
                         && filename.toString().equals(file.getName())) {
                     log.info("FileWatcher: file {} changed. Invoking handler...", filename);
                     onChange.run();
@@ -94,7 +97,7 @@ public class FileWatcher implements Closeable {
             }
             watchService = FileSystems.getDefault().newWatchService();
             Path path = file.toPath().getParent();
-            path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+            path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE);
             isRegistered.set(true);
             log.info("FileWatcher: parent dir {} for file {} registered.", path, file.getAbsoluteFile());
         } catch (IOException ioe) {

--- a/runtime/src/main/java/org/corfudb/util/FileWatcher.java
+++ b/runtime/src/main/java/org/corfudb/util/FileWatcher.java
@@ -50,7 +50,6 @@ public class FileWatcher implements Closeable {
     }
 
     private void start() {
-        reloadNewWatchService();
         while (!isStopped.get()) {
             LambdaUtils.runSansThrow(this::poll);
         }
@@ -97,6 +96,7 @@ public class FileWatcher implements Closeable {
     }
 
     private void reloadNewWatchService() {
+        isRegistered.set(false);
         if (isStopped.get()) {
             log.info("Watch service is stopped. Skip reloading new watch service.");
             return;
@@ -113,7 +113,6 @@ public class FileWatcher implements Closeable {
             isRegistered.set(true);
             log.info("FileWatcher: parent dir {} for file {} registered.", path, file.getAbsoluteFile());
         } catch (IOException ioe) {
-            isRegistered.set(false);
             throw new IllegalStateException("Failed to start a new watch service!", ioe);
         }
     }

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -640,7 +640,7 @@ public class NettyCommTest extends AbstractCorfuTest {
 
         FileWatcher fileWatcher = new FileWatcher(
                 clientCertManager.keyStoreConfig.getKeyStoreFile().toString(),
-                clientRouter::reconnect, Duration.ofSeconds(1));
+                clientRouter::reconnect);
         TimeUnit.SECONDS.sleep(1);
 
         // Copy original keystore
@@ -658,11 +658,10 @@ public class NettyCommTest extends AbstractCorfuTest {
 
         // Verify ssl is auto-reloaded
         TimeUnit.SECONDS.sleep(2);
-        log.info("Testing connection after corrupting the keystore");
         assertThat(getBaseClient(clientRouter).pingSync()).isFalse();
 
         // Restore the correct cert
-        Files.copy(keyStoreFilePathCopy, keyStoreFilePath, StandardCopyOption.REPLACE_EXISTING);
+        Files.move(keyStoreFilePathCopy, keyStoreFilePath, StandardCopyOption.ATOMIC_MOVE);
 
         // Verify ssl is auto-reloaded
         TimeUnit.SECONDS.sleep(2);


### PR DESCRIPTION
## Overview

Description:
On Linux, Files.move(a,b) will trigger DELETE event on file a, and CREATE event on file b. Add CREATE event kind to the watch service to fix missing file change issue.

Why should this be merged: 
Fix missing file change notification issue.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
