### PR TITLE
Jvm metrics: safepoint decommission

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
@@ -1,31 +1,16 @@
 package org.corfudb.common.metrics.micrometer;
 
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
-import lombok.Data;
-import lombok.Getter;
-import sun.management.HotspotRuntimeMBean;
-import sun.management.ManagementFactoryHelper;
 
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Provides JVM level metrics.
  */
 
 public final class JVMMetrics {
-
-    @Getter(lazy = true)
-    private final static HotspotRuntimeMBean runtimeMBean = ManagementFactoryHelper.getHotspotRuntimeMBean();
-
-    @Data
-    private static class SafePointStats {
-        long safepointTime;
-        long safepointCount;
-    }
 
     private static void subscribeThreadMetrics(MeterRegistry meterRegistry) {
         JvmThreadMetrics threadMetrics = new JvmThreadMetrics();
@@ -37,34 +22,12 @@ public final class JVMMetrics {
         memoryMetrics.bindTo(meterRegistry);
     }
 
-    private static void subscribeSafePointMetrics(MeterRegistry meterRegistry) {
-        SafePointStats safePointStats = new SafePointStats();
-        Gauge.builder("jvm.safe_point_time", safePointStats, data -> {
-            long current = getRuntimeMBean().getTotalSafepointTime();
-            long delta = current - data.safepointTime;
-            data.safepointTime = current;
-            return delta;
-        }).baseUnit(TimeUnit.MILLISECONDS.toString())
-                .strongReference(true)
-                .register(meterRegistry);
-
-        Gauge.builder("jvm.safe_point_count", safePointStats, data -> {
-            long current = getRuntimeMBean().getSafepointCount();
-            long delta = current - data.safepointCount;
-            data.safepointCount = current;
-            return delta;
-        }).baseUnit(TimeUnit.MILLISECONDS.toString())
-                .strongReference(true)
-                .register(meterRegistry);
-    }
-
     public static void register(Optional<MeterRegistry> metricsRegistry) {
 
         if (metricsRegistry.isPresent()) {
             final MeterRegistry meterRegistry = metricsRegistry.get();
             subscribeMemoryMetrics(meterRegistry);
             subscribeThreadMetrics(meterRegistry);
-            subscribeSafePointMetrics(meterRegistry);
         }
     }
 }


### PR DESCRIPTION
## Overview

Description:
JDK 11 strongly pushes towards not using sun* packages, so we need to to discontinue using it, so we need to get rid safepoints in jvm metrics. I believe not having safepoits is manageable for us. At least we can bring them back in the future if strongly needed.
And in the end, we will have JVM logs in the 'jvm' directory, so we are good anyway

Some info: https://blanco.io/blog/jvm-safepoint-pauses/ 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
