### PR TITLE
Restore FULL_TABLE's number to 0 for upgrade compatiblity

### DIFF
--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -57,11 +57,10 @@ enum LogReplicationEntryType {
 }
 
 enum ReplicationModel {
-  NONE = 0;
-  FULL_TABLE = 1;                 // Full table replication (Single Source to Single Sink = 1:1)
-  ROUTING_QUEUES = 2;             // Routing queue replication (used for entry-level replication) (1:1)
-  LOGICAL_GROUPS = 3;             // Table association to logical group (1:1)
-  MULTI_SOURCE_MERGE = 4;         // Same table replication from multiple sources to single sink (n:1)
+  FULL_TABLE = 0;                 // Full table replication (Single Source to Single Sink = 1:1)
+  ROUTING_QUEUES = 1;             // Routing queue replication (used for entry-level replication) (1:1)
+  LOGICAL_GROUPS = 2;             // Table association to logical group (1:1)
+  MULTI_SOURCE_MERGE = 3;         // Same table replication from multiple sources to single sink (n:1)
 }
 
 // Key for LogReplicationModelMetadataTable


### PR DESCRIPTION
## Overview

Description:
Released versions use 0 as the enum for FULL_TABLE, we should continue the same enum to not break upgrades

Why should this be merged: 

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
