### PR TITLE
LogUnit Cache improvements: make LogUnitServerCache more flexible and testable

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -1,10 +1,13 @@
 package org.corfudb.protocols.wireprotocol;
 
+import org.corfudb.common.util.Memory;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 
 import java.util.Optional;
 import java.util.UUID;
+
+import static java.lang.Math.toIntExact;
 
 /**
  * An interface to log data entries.
@@ -135,6 +138,11 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * @return An estimate on the size of this object, in bytes.
      */
     int getSizeEstimate();
+
+    default int getTotalSize() {
+        int metaDadaSize = toIntExact(Memory.sizeOf.deepSizeOf(getMetadataMap()));
+        return Math.addExact(getSizeEstimate(), metaDadaSize);
+    }
 
     /**
      * Assign a given token to this log data.


### PR DESCRIPTION
## Overview

Description:
I have extracted caffeines' LoadingCache into a separate class, which makes it flexible and the cache can be tested in many ways (I have JMH benchmarks already, but not for this PR, it(benchmarks) requires more experiments to get in). 
When review, please thing about the changes as it is a refactoring and first step for better control of the cache.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
