### PR TITLE
Compactor CorfuRuntime Cleanup On Connection Failures

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -82,9 +82,11 @@ public class CompactorService implements ManagementService {
             //the following if condition can possibly invoked by all calls. It's ok to have multiple
             //calls to shutdown and start.
             synchronized (this) {
-                if (!corfuRuntimeOptional.isPresent() || runtime == corfuRuntimeOptional.get()) {
+                if (corfuRuntimeOptional.isPresent() && runtime == corfuRuntimeOptional.get()) {
                     shutdown();
                     start(this.triggerInterval);
+                } else {
+                    runtime.shutdown();
                 }
             }
             throw new UnreachableClusterException("CorfuRuntime for CompactorService stalled. Invoked systemDownHandler after "
@@ -105,7 +107,6 @@ public class CompactorService implements ManagementService {
         } catch (UnrecoverableCorfuError er) {
             log.error("Unable to connect to server due to UnrecoverableCorfuError: ", er);
             runtime.getParameters().getSystemDownHandler().run();
-            throw er;
         }
         log.info("getNewCorfuRuntime: Corfu Runtime connected successfully");
         return runtime;

--- a/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CompactorServiceIT.java
@@ -9,26 +9,31 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.exceptions.UnreachableClusterException;
 import org.corfudb.runtime.exceptions.WrongClusterException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.view.AddressSpaceView;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -140,9 +145,7 @@ public class CompactorServiceIT extends AbstractIT {
 
         verify(compactorServiceSpy, timeout(VERIFY_TIMEOUT.toMillis()).times(1)).getNewCorfuRuntime();
 
-        Runnable invokeConcurrentSystemDownHandler = () -> {
-            runtime.getParameters().getSystemDownHandler().run();
-        };
+        Runnable invokeConcurrentSystemDownHandler = () -> runtime.getParameters().getSystemDownHandler().run();
 
         Thread t1 = new Thread(invokeConcurrentSystemDownHandler);
         Thread t2 = new Thread(invokeConcurrentSystemDownHandler);
@@ -151,10 +154,56 @@ public class CompactorServiceIT extends AbstractIT {
         t1.join();
         t2.join();
 
-        final int invokeStartTimes = 3;
         verify(compactorServiceSpy, timeout(VERIFY_TIMEOUT.toMillis())).getCompactorLeaderServices();
         verify(compactorServiceSpy, times(2)).getSystemDownHandlerForCompactor(any());
-        verify(compactorServiceSpy, times(invokeStartTimes)).start(any());
-        verify(compactorServiceSpy, times(2)).shutdown();
+        verify(runtime, times(2)).shutdown();
+        verify(compactorServiceSpy, times(1)).shutdown();
+
+        // Note that start() was called once manually above.
+        verify(compactorServiceSpy, times(2)).start(any());
+    }
+
+    /**
+     * Test that the CompactorService runtime is shutdown when there is a
+     * failure (UnrecoverableCorfuError) on connect() to CorfuDB.
+     */
+    @Test
+    public void testConnectCleanup() throws Exception {
+        corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
+        final ServerContext scSpy = spy(new ServerContextBuilder()
+                .setSingle(true)
+                .setAddress(corfuSingleNodeHost)
+                .setPort(corfuStringNodePort)
+                .setLogPath(com.google.common.io.Files.createTempDir().getAbsolutePath())
+                .build());
+
+        // Populate the CorfuRuntimeParameters
+        CorfuRuntime.CorfuRuntimeParameters.CorfuRuntimeParametersBuilder paramsBuilder =
+                CorfuRuntime.CorfuRuntimeParameters.builder().checkpointTriggerFreqMillis(1);
+
+        doReturn(paramsBuilder.build()).when(scSpy).getManagementRuntimeParameters();
+
+        CompactorService compactorService = new CompactorService(scSpy, SCHEDULER_INTERVAL, invokeCheckpointing, new DynamicTriggerPolicy());
+
+        // Inject our CorfuRuntime into the test.
+        CorfuRuntime rt = spy(CorfuRuntime.fromParameters(paramsBuilder.build())
+                .parseConfigurationString(singleNodeEndpoint));
+
+        try (MockedStatic<CorfuRuntime> mockedStatic = mockStatic(CorfuRuntime.class)) {
+            doThrow(new UnrecoverableCorfuError("Fatal error connecting to Corfu server instance.")).when(rt).connect();
+            doNothing().when(rt).shutdown();
+
+            mockedStatic.when(() -> CorfuRuntime.fromParameters(any())).thenReturn(rt);
+
+            // Validate that the systemDownHandler was invoked.
+             try {
+                 compactorService.getNewCorfuRuntime();
+             } catch (Throwable th) {
+                 assertThat(th).isInstanceOf(UnreachableClusterException.class);
+             }
+
+             // Validate that shutdown was called exactly once.
+             verify(rt, times(1)).shutdown();
+        }
     }
 }


### PR DESCRIPTION
This patch addresses a bug where resources are leaked when the CompactorService is unable to connect to Corfu. By shutting down the CorfuRuntime on such failures, we prevent runtime threads and other resources from being leaked.

## Overview

Description:

Why should this be merged: Bug fix.

## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
