### PR TITLE
LR: fix event handling for eventTable

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -476,6 +476,8 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     public void processLockRelease() {
         log.debug("Lock released");
         sessionManager.getReplicationContext().setIsLeader(false);
+        logReplicationEventListener.stop();
+        sessionManager.stopClientConfigListener();
         sessionManager.notifyLeadershipChange();
         stopLogReplication(true);
         recordLockRelease();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -455,6 +455,10 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     private void stopLogReplication(boolean lockReleased) {
         if (lockReleased || sessionManager.getReplicationContext().getIsLeader().get()) {
             log.info("Stopping log replication.");
+            if(logReplicationEventListener != null) {
+                logReplicationEventListener.stop();
+            }
+            sessionManager.stopClientConfigListener();
             sessionManager.stopReplication();
         }
     }
@@ -476,10 +480,6 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     public void processLockRelease() {
         log.debug("Lock released");
         sessionManager.getReplicationContext().setIsLeader(false);
-        if(logReplicationEventListener != null) {
-            logReplicationEventListener.stop();
-        }
-        sessionManager.stopClientConfigListener();
         sessionManager.notifyLeadershipChange();
         stopLogReplication(true);
         recordLockRelease();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -476,7 +476,9 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     public void processLockRelease() {
         log.debug("Lock released");
         sessionManager.getReplicationContext().setIsLeader(false);
-        logReplicationEventListener.stop();
+        if(logReplicationEventListener != null) {
+            logReplicationEventListener.stop();
+        }
         sessionManager.stopClientConfigListener();
         sessionManager.notifyLeadershipChange();
         stopLogReplication(true);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -72,8 +72,9 @@ public final class LogReplicationEventListener implements StreamListener {
         // Generate a discovery event and put it into the discovery service event queue.
         for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {
             for (CorfuStreamEntry entry : entryList) {
-                if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
-                    log.warn("LREventListener ignoring a CLEAR operation");
+                if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR ||
+                        entry.getOperation() == CorfuStreamEntry.OperationType.DELETE) {
+                    log.warn("LREventListener ignoring a {} operation", entry.getOperation());
                     continue;
                 }
                 ReplicationEventInfoKey key = (ReplicationEventInfoKey) entry.getKey();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -72,25 +72,16 @@ public final class LogReplicationEventListener implements StreamListener {
             for (CorfuStreamEntry entry : entryList) {
                 if (entry.getOperation() == CorfuStreamEntry.OperationType.CLEAR ||
                         entry.getOperation() == CorfuStreamEntry.OperationType.DELETE) {
-                    log.warn("LREventListener ignoring a {} operation", entry.getOperation());
+                    log.warn("LR EventListener ignoring a {} operation", entry.getOperation());
                     continue;
                 }
                 ReplicationEventInfoKey key = (ReplicationEventInfoKey) entry.getKey();
                 ReplicationEvent event = (ReplicationEvent) entry.getPayload();
                 log.info("Received event :: id={}, type={}, session={}, ts={}", event.getEventId(), event.getType(),
                     key.getSession(), event.getEventTimestamp());
-                if (event.getType().equals(ReplicationEventType.FORCE_SNAPSHOT_SYNC)) {
-                    discoveryService.input(new DiscoveryServiceEvent(DiscoveryServiceEventType.ENFORCE_SNAPSHOT_SYNC,
-                        key.getSession(), event.getEventId()));
-                } else if (event.getType().equals(ReplicationEventType.UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC)) {
-                    // Note: This block will not get executed in the first version of LRv2 because in this version,
-                    // LR does not start until all nodes in the cluster are on the same version.  So the event to
-                    // trigger a forced snapshot sync will not be received as an update on the listener.
-                    // Instead, it will be read on startup in processPendingRequests().
-                    // In later versions of LRv2, the Log Replication process will run even when nodes are on
-                    // different versions.  At that time, this event will be processed as an update from this
-                    // block.
-                    triggerForcedSnapshotSyncForAllSessions(event);
+                if (event.getType().equals(ReplicationEventType.FORCE_SNAPSHOT_SYNC) ||
+                        event.getType().equals(ReplicationEventType.UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC)) {
+                    triggerForcedSnapshotSync(key, event);
                 } else {
                     log.warn("Received invalid event :: id={}, type={}, cluster_id={} ts={}", event.getEventId(),
                         event.getType(), event.getClusterId(), event.getEventTimestamp());
@@ -106,21 +97,22 @@ public final class LogReplicationEventListener implements StreamListener {
         List<CorfuStoreEntry<ReplicationEventInfoKey, ReplicationEvent, Message>> pendingEvents =
             discoveryService.getSessionManager().getMetadataManager().getReplicationEvents();
 
-        // TODO v2: Currently, this method runs on LR startup and processes events of type
-        //  UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC only.  If in future, there is a requirement to process all types of
-        //  events handled by onNext(), this logic can be abstracted out to a common method which can be shared with
-        //  onNext()
         for (CorfuStoreEntry event : pendingEvents) {
-            triggerForcedSnapshotSyncForAllSessions((ReplicationEvent)event.getPayload());
+            triggerForcedSnapshotSync((ReplicationEventInfoKey)event.getKey(), (ReplicationEvent)event.getPayload());
         }
     }
 
-    private void triggerForcedSnapshotSyncForAllSessions(ReplicationEvent event) {
-        for (LogReplicationSession session : discoveryService.getSessionManager().getSessions()) {
-            log.info("Adding event for forced snapshot sync request for session {}, sync_id={}",
-                    session, event.getEventId());
+    private void triggerForcedSnapshotSync(ReplicationEventInfoKey key, ReplicationEvent event) {
+        if (event.getType().equals(ReplicationEventType.UPGRADE_COMPLETION_FORCE_SNAPSHOT_SYNC)) {
+            for (LogReplicationSession session : discoveryService.getSessionManager().getSessions()) {
+                log.info("Adding event for forced snapshot sync request for session {}, sync_id={}",
+                        session, event.getEventId());
+                discoveryService.input(new DiscoveryServiceEvent(DiscoveryServiceEventType.ENFORCE_SNAPSHOT_SYNC,
+                        session, event.getEventId()));
+            }
+        } else {
             discoveryService.input(new DiscoveryServiceEvent(DiscoveryServiceEventType.ENFORCE_SNAPSHOT_SYNC,
-                    session, event.getEventId()));
+                    key.getSession(), event.getEventId()));
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -51,6 +51,7 @@ public final class LogReplicationEventListener implements StreamListener {
                                 LogReplicationMetadataManager.REPLICATION_EVENT_TABLE_NAME));
             } catch (Exception e) {
                 log.error("Failed to subscribe to the ReplicationEvent Table", e);
+                listenerStarted.set(false);
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -471,8 +471,6 @@ public class SessionManager {
      */
     public void stopReplication() {
         log.info("Stopping log replication.");
-        // Stop config listener if required
-        stopClientConfigListener();
         stopReplication(sessions);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -106,6 +106,7 @@ public class InSnapshotSyncState implements LogReplicationState {
                             .get(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
                     waitSnapshotApplyState.setTransitionSyncId(transitionSyncId);
                     waitSnapshotApplyState.setBaseSnapshotTimestamp(snapshotSender.getBaseSnapshotTimestamp());
+                    waitSnapshotApplyState.setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                     fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                     fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                     snapshotSyncAcksCounter.ifPresent(AtomicLong::getAndIncrement);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -119,10 +119,19 @@ public class InSnapshotSyncState implements LogReplicationState {
                 // If cancel was intended for current snapshot sync task, cancel and transition to new state
                 if (fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     cancelSnapshotSync("cancellation request.");
-                    log.debug("Starting new snapshot sync after cancellation. forced {} ID={}", event.getMetadata().isForcedSnapshotSync(), transitionSyncId);
+                    // Re-trigger SnapshotSync due to error.
+                    LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
+                    // If the cancelled sync is a force snapshot sync, retain the syncID. This is to track and clear
+                    // the snapshot sync requests in the eventTable
+                    UUID newSnapshotSyncId = event.getMetadata().isForcedSnapshotSync() ? event.getMetadata().getSyncId() : UUID.randomUUID();
+                    log.debug("Starting new snapshot sync after cancellation. forced {} ID={}", event.getMetadata().isForcedSnapshotSync(), newSnapshotSyncId);
+                    inSnapshotSyncState.setTransitionSyncId(newSnapshotSyncId);
+                    // If a force snapshot sync gets cancelled due to ACK timeout, a new snapshot sync is triggered.
+                    // Retain the 'forced' information in the subsequent snapshot syncs
+                    ((InSnapshotSyncState)inSnapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                     snapshotSender.reset();
                     fsm.getAckReader().markSnapshotSyncInfoOngoing(forcedSnapshotSync, transitionSyncId);
-                    return this;
+                    return inSnapshotSyncState;
                 }
 
                 log.warn("Ignoring Sync Cancel for eventId {}, while running snapshot sync for {}",

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -226,7 +226,7 @@ public class WaitSnapshotApplyState implements LogReplicationState {
                 log.info("Snapshot sync apply is complete appliedTs={}, baseTs={}", metadataResponse.getSnapshotApplied(),
                         baseSnapshotTimestamp);
                 fsm.input(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_APPLY_COMPLETE,
-                        new LogReplicationEventMetadata(transitionSyncId, baseSnapshotTimestamp, baseSnapshotTimestamp)));
+                        new LogReplicationEventMetadata(transitionSyncId, baseSnapshotTimestamp, baseSnapshotTimestamp, forcedSnapshotSync)));
             } else {
                 log.debug("Snapshot sync apply is still in progress, appliedTs={}, baseTs={}, sync_id={}", metadataResponse.getSnapshotApplied(),
                         baseSnapshotTimestamp, transitionSyncId);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -102,8 +102,7 @@ public class WaitSnapshotApplyState implements LogReplicationState {
                 if(fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     log.debug("Sync has been canceled while waiting for Snapshot Sync {} to complete apply. Restart.", transitionSyncId);
                     LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
-                    // new ID for new snapshot sync ID
-                    inSnapshotSyncState.setTransitionSyncId(UUID.randomUUID());
+                    inSnapshotSyncState.setTransitionSyncId(transitionSyncId);
                     ((InSnapshotSyncState) inSnapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                     return inSnapshotSyncState;
                 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -102,7 +102,9 @@ public class WaitSnapshotApplyState implements LogReplicationState {
                 if(fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     log.debug("Sync has been canceled while waiting for Snapshot Sync {} to complete apply. Restart.", transitionSyncId);
                     LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
-                    inSnapshotSyncState.setTransitionSyncId(transitionSyncId);
+                    // If the cancelled sync was a force sync, retain the syncID, else generate a new sync ID
+                    UUID newSnapshotSyncId = event.getMetadata().isForcedSnapshotSync() ? event.getMetadata().getSyncId() : UUID.randomUUID();
+                    inSnapshotSyncState.setTransitionSyncId(newSnapshotSyncId);
                     ((InSnapshotSyncState) inSnapshotSyncState).setForcedSnapshotSync(event.getMetadata().isForcedSnapshotSync());
                     return inSnapshotSyncState;
                 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -555,24 +555,19 @@ public class LogReplicationMetadataManager {
                                            CorfuStoreMetadata.Timestamp shadowStreamTs) {
         ReplicationMetadata metadata = queryReplicationMetadata(txn, session);
 
-
-        UUID currentSnapshotCycleId = new UUID(metadata.getCurrentSnapshotCycleId().getMsb(), metadata.getCurrentSnapshotCycleId().getLsb());
-
-        // Update if current Snapshot Sync differs from the persisted one, otherwise ignore.
-        // It could have already been updated in the case that leader changed in between a snapshot sync cycle
-        if (!Objects.equals(currentSnapshotCycleId, newSnapshotCycleId)) {
-            RpcCommon.UuidMsg uuidMsg = RpcCommon.UuidMsg.newBuilder()
+        RpcCommon.UuidMsg uuidMsg = RpcCommon.UuidMsg.newBuilder()
                 .setMsb(newSnapshotCycleId.getMostSignificantBits())
                 .setLsb(newSnapshotCycleId.getLeastSignificantBits())
                 .build();
 
-            ReplicationMetadata updatedMetadata = metadata.toBuilder()
+        ReplicationMetadata updatedMetadata = metadata.toBuilder()
                 .setCurrentCycleMinShadowStreamTs(shadowStreamTs.getSequence())
                 .setCurrentSnapshotCycleId(uuidMsg)
                 .build();
 
-            updateReplicationMetadata(txn, session, updatedMetadata);
-        }
+        updateReplicationMetadata(txn, session, updatedMetadata);
+
+        log.debug("Shadow stream for the current sync starts from {} (inclusive)", shadowStreamTs);
     }
 
     // =============================== Replication Event Table Methods ===================================
@@ -608,6 +603,38 @@ public class LogReplicationMetadataManager {
             log.error("Failed to get the replication events", e);
         }
         return events;
+    }
+
+    public CorfuStoreEntry<ReplicationEventInfoKey, ReplicationEvent, Message> getEventEnqueuedForSession(LogReplicationSession session) {
+        CorfuStoreEntry<ReplicationEventInfoKey, ReplicationEvent, Message> eventEnqueuedForSession = null;
+        ReplicationEventInfoKey key = ReplicationEventInfoKey.newBuilder().setSession(session).build();
+        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+            eventEnqueuedForSession = txn.getRecord(REPLICATION_EVENT_TABLE_NAME, key);
+            txn.commit();
+        } catch (Exception e) {
+            log.error("Failed to get the replication event for session {}", session, e);
+        }
+
+        return eventEnqueuedForSession;
+    }
+
+    public void deleteProcessedEvent(LogReplicationSession session) {
+        ReplicationEventInfoKey keyToDelete = ReplicationEventInfoKey.newBuilder().setSession(session).build();
+        try {
+            IRetry.build(IntervalRetry.class, () -> {
+                try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+                    txn.delete(REPLICATION_EVENT_TABLE_NAME, keyToDelete);
+                    txn.commit();
+                } catch (TransactionAbortedException tae) {
+                    log.error("Error while attempting to delete event for session {}", session, tae);
+                    throw new RetryNeededException();
+                }
+                return null;
+            }).run();
+        } catch (InterruptedException e) {
+            log.error("Unrecoverable exception when attempting to reset replication status", e);
+            throw new UnrecoverableCorfuInterruptedError(e);
+        }
     }
 
     // ================================= Replication Status Table Methods ===================================

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.send;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
@@ -33,6 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
 @ToString
 @Slf4j
 public class LogReplicationAckReader {
+    @Getter
     private final LogReplicationMetadataManager metadataManager;
     private final CorfuRuntime runtime;
     private final LogReplicationSession session;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
@@ -69,18 +69,6 @@ public class LogReplicationEventMetadata {
      * @param syncTimestamp last synced timestamp.
      * @param baseSnapshot last base snapshot
      */
-    public LogReplicationEventMetadata(UUID syncId, long syncTimestamp, long baseSnapshot) {
-        this(syncId, syncTimestamp);
-        this.lastTransferredBaseSnapshot = baseSnapshot;
-    }
-
-    /**
-     * Constructor
-     *
-     * @param syncId identifier of the request that preceded this event.
-     * @param syncTimestamp last synced timestamp.
-     * @param baseSnapshot last base snapshot
-     */
     public LogReplicationEventMetadata(UUID syncId, long syncTimestamp, long baseSnapshot, boolean forcedSnapshotSync) {
         this(syncId, syncTimestamp);
         this.lastTransferredBaseSnapshot = baseSnapshot;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
@@ -74,6 +74,19 @@ public class LogReplicationEventMetadata {
         this.lastTransferredBaseSnapshot = baseSnapshot;
     }
 
+    /**
+     * Constructor
+     *
+     * @param syncId identifier of the request that preceded this event.
+     * @param syncTimestamp last synced timestamp.
+     * @param baseSnapshot last base snapshot
+     */
+    public LogReplicationEventMetadata(UUID syncId, long syncTimestamp, long baseSnapshot, boolean forcedSnapshotSync) {
+        this(syncId, syncTimestamp);
+        this.lastTransferredBaseSnapshot = baseSnapshot;
+        this.forceSnapshotSync = forcedSnapshotSync;
+    }
+
     public UUID getSyncId() {
         return this.syncId;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -162,7 +162,7 @@ public class SnapshotSender {
                         // Snapshot Sync Transfer Completed
                         log.info("Snapshot sync transfer completed for {} on timestamp={}, ack={}", snapshotSyncEventId,
                                 baseSnapshotTimestamp, TextFormat.shortDebugString(ack.getMetadata()));
-                        snapshotSyncTransferComplete(snapshotSyncEventId);
+                        snapshotSyncTransferComplete(snapshotSyncEventId, forcedSnapshotSync);
                     } else {
                         log.warn("Expected ack for {}, but received for a different snapshot {}", baseSnapshotTimestamp,
                                 ack.getMetadata());
@@ -195,7 +195,7 @@ public class SnapshotSender {
                 dataSenderBufferManager.sendWithBuffering(getSnapshotSyncStartMarker(snapshotSyncEventId));
                 snapshotSyncAck = dataSenderBufferManager.sendWithBuffering(getSnapshotSyncEndMarker(snapshotSyncEventId));
                 snapshotSyncAck.get(DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                snapshotSyncTransferComplete(snapshotSyncEventId);
+                snapshotSyncTransferComplete(snapshotSyncEventId, forcedSnapshotSync);
             } catch (Exception e) {
                 log.warn("Caught exception while sending data to sink.", e);
                 snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.UNKNOWN, forcedSnapshotSync);
@@ -271,11 +271,11 @@ public class SnapshotSender {
      *
      * @param snapshotSyncEventId unique identifier for the completed snapshot sync.
      */
-    private void snapshotSyncTransferComplete(UUID snapshotSyncEventId) {
+    private void snapshotSyncTransferComplete(UUID snapshotSyncEventId, boolean forcedSnapshotSync) {
         // We need to bind the internal event (COMPLETE) to the snapshotSyncEventId that originated it, this way
         // the state machine can correlate to the corresponding state (in case of delayed events)
         fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE,
-                new LogReplicationEventMetadata(snapshotSyncEventId, baseSnapshotTimestamp, baseSnapshotTimestamp)));
+                new LogReplicationEventMetadata(snapshotSyncEventId, baseSnapshotTimestamp, baseSnapshotTimestamp, forcedSnapshotSync)));
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -260,7 +260,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
             fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                     new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE,
                             new LogReplicationEventMetadata(LogReplicationEventMetadata.getNIL_UUID(), negotiationResponse.getSnapshotStart(),
-                                    negotiationResponse.getSnapshotTransferred()))));
+                                    negotiationResponse.getSnapshotTransferred(), false))));
             return;
         }
 
@@ -290,7 +290,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                         new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST,
                                 new LogReplicationEventMetadata(LogReplicationEventMetadata.getNIL_UUID(), negotiationResponse.getLastLogEntryTimestamp(),
-                                        negotiationResponse.getSnapshotApplied()))));
+                                        negotiationResponse.getSnapshotApplied(), false))));
             } else {
                 // TODO: it is OK for a first phase, but this might not be efficient/accurate, as the next (+1)
                 //  might not really be the next entry (as that is a globalAddress and the +1 might not even belong to

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -156,8 +156,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     @Parameterized.Parameters
     public static List<ClusterUuidMsg> input() {
         return Arrays.asList(
-                TP_SINGLE_SOURCE_SINK
-//                TP_SINGLE_SOURCE_SINK_REV_CONNECTION
+                TP_SINGLE_SOURCE_SINK,
+                TP_SINGLE_SOURCE_SINK_REV_CONNECTION
         );
 
     }
@@ -2001,7 +2001,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(replicationStatus.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus())
                 .isEqualTo(SyncStatus.COMPLETED);
 
-//        assertThat(eventTable.count()).isZero();
+        assertThat(eventTable.count()).isZero();
 
         shutdownCorfuServer(sourceReplicationServer);
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -72,6 +72,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager.TP_SINGLE_SOURCE_SINK;
 import static org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager.TP_SINGLE_SOURCE_SINK_REV_CONNECTION;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.METADATA_TABLE_NAME;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_EVENT_TABLE_NAME;
+import static org.corfudb.integration.AbstractIT.shutdownCorfuServer;
+import static org.corfudb.integration.AbstractIT.shutdownCorfuServer;
 import static org.corfudb.runtime.LogReplicationUtils.LR_STATUS_STREAM_TAG;
 import static org.corfudb.runtime.LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
@@ -152,8 +156,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     @Parameterized.Parameters
     public static List<ClusterUuidMsg> input() {
         return Arrays.asList(
-                TP_SINGLE_SOURCE_SINK,
-                TP_SINGLE_SOURCE_SINK_REV_CONNECTION
+                TP_SINGLE_SOURCE_SINK
+//                TP_SINGLE_SOURCE_SINK_REV_CONNECTION
         );
 
     }
@@ -1811,7 +1815,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
-     * This test verifies enforceSnapshotSync API
+     * This test verifies enforceSnapshotSync API and the handling of the event.
      * <p>
      * 1. Init with corfu 9000 source and 9001 sink
      * 2. Write 10 entries to source map
@@ -1821,6 +1825,10 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      * 6. Write 5 more entries to source map and perform an enforced full snapshot sync
      * 7. Verify a full snapshot sync is triggered
      * 8. Verify a full snapshot sync is completed and data is correctly replicated.
+     * 9. Shutdown sink and write more data
+     * 10. Bring up the sink.
+     * 11. Verify that the data was replicated and also that there was no snapshot sync.. The data should be replicated via log_entry sync.
+     * To verify this, check that the "CurrentCycleMinShadowStreamTs" has not changed since the last snapshot sync.
      */
     @Test
     public void testEnforceSnapshotSync() throws Exception {
@@ -1926,12 +1934,28 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         }
         assertThat(mapSource.count()).isEqualTo(thirdBatch);
 
+        Table<LogReplicationMetadata.ReplicationEventInfoKey, LogReplicationMetadata.ReplicationEvent, Message> eventTable =
+                sourceCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
+                        REPLICATION_EVENT_TABLE_NAME,
+                        LogReplicationMetadata.ReplicationEventInfoKey.class,
+                        LogReplicationMetadata.ReplicationEvent.class,
+                        null,
+                        TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationEvent.class));
+
+        assertThat(eventTable.count()).isZero();
+
         // Perform an enforce full snapshot sync
         try (TxnContext txn = sourceCorfuStore.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
             txn.putRecord(configTable, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC,
                     DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC);
             txn.commit();
         }
+
+        while(eventTable.count() == 0) {
+            //wait
+        }
+        assertThat(eventTable.count()).isOne();
+
         TimeUnit.SECONDS.sleep(mediumInterval);
 
         // Sink map should have thirdBatch size, since topology config is resumed.
@@ -1943,6 +1967,21 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
             replicationStatus = (ReplicationStatus)txn.getRecord(REPLICATION_STATUS_TABLE, sessionKey).getPayload();
             txn.commit();
         }
+
+        Table<LogReplicationSession, LogReplicationMetadata.ReplicationMetadata, Message> metadataTable =
+                sinkCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
+                        METADATA_TABLE_NAME,
+                        LogReplicationSession.class,
+                        LogReplicationMetadata.ReplicationMetadata.class,
+                        null,
+                        TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationMetadata.class));
+
+        LogReplicationMetadata.ReplicationMetadata metadata = null;
+        try (TxnContext txn = sinkCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
+            metadata = (LogReplicationMetadata.ReplicationMetadata) txn.getRecord(METADATA_TABLE_NAME, sessionKey).getPayload();
+            txn.commit();
+        }
+        long shadowStreamTs = metadata.getCurrentCycleMinShadowStreamTs();
 
         log.info("ReplicationStatusVal: RemainingEntriesToSend: {}, SyncType: {}, Status: {}",
                 replicationStatus.getSourceStatus().getRemainingEntriesToSend(),
@@ -1961,6 +2000,42 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 .isEqualTo(SnapshotSyncInfo.SnapshotSyncType.FORCED);
         assertThat(replicationStatus.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus())
                 .isEqualTo(SyncStatus.COMPLETED);
+
+//        assertThat(eventTable.count()).isZero();
+
+        shutdownCorfuServer(sourceReplicationServer);
+
+        // Remove the force snapshot operation enqueued above from the test configTable.
+        try (TxnContext txn = sourceCorfuStore.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+            txn.delete(configTable, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC);
+            txn.commit();
+        }
+
+        // Append to mapSource
+        for (int i = thirdBatch; i < fourthBatch; i++) {
+            try (TxnContext txn = sourceCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapSource, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
+        }
+        assertThat(mapSource.count()).isEqualTo(fourthBatch);
+
+
+        sourceReplicationServer = runReplicationServer(sourceReplicationServerPort, sourceClusterCorfuPort,
+                pluginConfigPath, transportType);
+
+        // Sink map should have thirdBatch size, since topology config is resumed.
+        waitForReplication(size -> size == fourthBatch, mapSink, fourthBatch);
+        assertThat(mapSink.count()).isEqualTo(fourthBatch);
+
+        try (TxnContext txn = sinkCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
+            metadata = (LogReplicationMetadata.ReplicationMetadata) txn.getRecord(METADATA_TABLE_NAME, sessionKey).getPayload();
+            txn.commit();
+        }
+        long oldShadowTs = shadowStreamTs;
+        // If the force snapshot sync was processed again, the CurrentCycleMinShadowStreamTs would be updated. Verify this hasn't happened.
+        assertThat(oldShadowTs).isEqualTo(metadata.getCurrentCycleMinShadowStreamTs());
     }
 
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -1118,7 +1118,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         logReplicationSourceManager.getLogReplicationFSM().input(
                 new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST,
                         new LogReplicationEventMetadata(LogReplicationEventMetadata.getNIL_UUID(),
-                                negotiationResponse.getLastLogEntryTimestamp(), negotiationResponse.getSnapshotApplied())));
+                                negotiationResponse.getLastLogEntryTimestamp(), negotiationResponse.getSnapshotApplied(), false)));
         checkStateChange(logReplicationSourceManager.getLogReplicationFSM(),
                 LogReplicationStateType.IN_LOG_ENTRY_SYNC, true);
 
@@ -1237,7 +1237,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         log.info("****** Start Log Entry Sync with src tail " + srcDataRuntime.getAddressSpaceView().getLogTail()
                 + " dst tail " + dstDataRuntime.getAddressSpaceView().getLogTail());
         logReplicationSourceManager.startReplication(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST,
-                new LogReplicationEventMetadata(UUID.randomUUID(), -1, -1)));
+                new LogReplicationEventMetadata(UUID.randomUUID(), -1, -1, false)));
 
         // Start TX's in parallel, while log entry sync is running
         if (injectTxData) {
@@ -1431,7 +1431,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         LogReplicationEntryMsg ack = sourceDataSender.getAckMessages().getDataMessage();
 
         logReplicationSourceManager.getLogReplicationFSM().input(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.REPLICATION_STOP,
-                new LogReplicationEventMetadata(getUUID(ack.getMetadata().getSyncRequestId()), ack.getMetadata().getTimestamp(), ack.getMetadata().getSnapshotTimestamp())));
+                new LogReplicationEventMetadata(getUUID(ack.getMetadata().getSyncRequestId()), ack.getMetadata().getTimestamp(), ack.getMetadata().getSnapshotTimestamp(), false)));
 
         blockUntilFSMTransition.countDown();
     }


### PR DESCRIPTION
This change includes the below 3 fixes:
 
1. Remove events after successfully processing them.
2. Do not try to subscribe to an already subscribed listener on topology/leadership acquire
3. On lock release, stop the listeners.
4. Take the syncID from the enqueued sync_cancel event when the cancelled sync is a force snapshot sync. This will help track if the force snapshot request was processed successfully or not and also help with keeping the metadata table clean

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
