### PR TITLE
Do not re-enter on a snapshot read lock

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CheckedRocksIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CheckedRocksIterator.java
@@ -25,6 +25,8 @@ public class CheckedRocksIterator implements RocksIteratorInterface, AutoCloseab
     private final AtomicBoolean isValid;
 
     public CheckedRocksIterator(RocksIterator rocksIterator, StampedLock lock, ReadOptions readOptions) {
+        // NOTE: Ensure that the read lock is acquired when called from DiskBackedSMRSnapshot.
+
         // {@link ReadOptions::isOwningHandle} is atomically set to false on
         // {@link ReadOptions::close}. Therefore, if we do not own the handle,
         // the existing snapshot is no longer valid.
@@ -36,7 +38,7 @@ public class CheckedRocksIterator implements RocksIteratorInterface, AutoCloseab
         this.rocksIterator = rocksIterator;
         this.lock = lock;
 
-        underReadLock(rocksIterator::seekToFirst);
+        this.rocksIterator.seekToFirst();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/RocksDbEntryIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/RocksDbEntryIterator.java
@@ -34,7 +34,7 @@ public class RocksDbEntryIterator<K, V> implements Iterator<Map.Entry<K, V>>, Au
     private final ISerializer serializer;
 
     /**
-     * place holder for the current value
+     * Placeholder for the current value
      */
     private Map.Entry<K, V> next;
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/DiskBackedSMRSnapshot.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/DiskBackedSMRSnapshot.java
@@ -122,7 +122,7 @@ public class DiskBackedSMRSnapshot<S extends SnapshotGenerator<S>> implements SM
     }
 
     public <K, V> RocksDbEntryIterator<K, V> newIterator(ISerializer serializer, Transaction transaction) {
-        // When newIterator is invoked, it's possible that this snapshot has since been invalidated.
+        // When getIterator is invoked, it's possible that this snapshot has since been invalidated.
         // Requesting an iterator from the RocksDB transaction with an invalid snapshot/readOptions causes
         // an internal assertion failure. Hence, CheckedRocksIterator performs necessary validation before
         // creating the new iterator.

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -48,12 +48,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -349,11 +353,12 @@ public class CorfuStoreIT extends AbstractIT {
         CorfuRuntime runtime = createRuntime(singleNodeEndpoint);
         CorfuStore store = new CorfuStore(runtime);
 
-        String tempDiskPath = com.google.common.io.Files.createTempDir()
-                .getAbsolutePath();
+        Path tempDiskPath = Files.createTempDirectory(tableName);
+        final CorfuOptions.PersistenceOptions persistenceOptions = CorfuOptions.PersistenceOptions.newBuilder()
+                .setDataPath(tempDiskPath.toAbsolutePath().toString()).build();
         final Table<Uuid, Uuid, ManagedResources> table = store.openTable(namespace, tableName,
                 Uuid.class, Uuid.class, ManagedResources.class,
-                TableOptions.builder().persistentDataPath(Paths.get(tempDiskPath)).build());
+                TableOptions.builder().persistenceOptions(persistenceOptions).build());
 
         final long aLong = 1L;
         Uuid uuidVal = Uuid.newBuilder().setMsb(aLong).setLsb(aLong).build();
@@ -378,7 +383,7 @@ public class CorfuStoreIT extends AbstractIT {
         CorfuRuntime runtimeC = new CorfuRuntime(singleNodeEndpoint)
                 .setCacheDisabled(true)
                 .connect();
-        checkpointAndTrimCorfuStore(runtimeC, false, tempDiskPath);
+        checkpointAndTrimCorfuStore(runtimeC, false, tempDiskPath.toAbsolutePath().toString());
         runtimeC.shutdown();
 
         runtime = createRuntime(singleNodeEndpoint);
@@ -391,6 +396,53 @@ public class CorfuStoreIT extends AbstractIT {
         assertThat(table2.count()).isEqualTo(numRecords);
 
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+
+    /**
+     * Verify concurrent execution on the same snapshot for
+     * disk-backed Corfu. This test is probabilistic in nature.
+     *
+     * @throws IOException during Corfu Server startup or Table open
+     */
+    @Test
+    public void concurrentExecuteQueryDiskBacked() throws Exception {
+        final String namespace = "test-namespace";
+        final String tableName = "test-table";
+        final int numRecords = PARAMETERS.NUM_ITERATIONS_MODERATE;
+
+        final Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
+
+        CorfuRuntime runtime = createRuntime(singleNodeEndpoint);
+        CorfuStore store = new CorfuStore(runtime);
+
+        Path tempDiskPath = Files.createTempDirectory(tableName);
+        final Table<Uuid, Uuid, ManagedResources> diskBackedTable2 = store.openTable(
+                namespace, tableName,
+                Uuid.class, Uuid.class, ManagedResources.class,
+                TableOptions.builder().persistenceOptions(CorfuOptions.PersistenceOptions.newBuilder()
+                                .setDataPath(tempDiskPath.toAbsolutePath().toString())
+                                .setConsistencyModel(CorfuOptions.ConsistencyModel.READ_YOUR_WRITES).build())
+                        .build());
+
+        List<Uuid> records = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            records.add(Uuid.newBuilder().setMsb(i).build());
+        }
+
+        records.forEach(entry -> {
+            try (TxnContext tx = store.txn(namespace)) {
+                tx.putRecord(diskBackedTable2, entry, entry, null);
+                tx.commit();
+            }
+        });
+
+        records.parallelStream().forEach(record -> {
+            try (TxnContext tx = store.txn(namespace)) {
+                assertThat(tx.executeQuery(diskBackedTable2, entry -> entry.getPayload().equals(record)).size())
+                        .isEqualTo(1);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
While technically re-entrant, read locks will deadlock in case of a concurrent write lock acquisition. In order to prevent any future deadlocks, do not re-enter on both the write and the read lock.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
