### PR TITLE
Start FileWatcher after enableTls() as well

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -976,6 +976,7 @@ public class CorfuRuntime {
         nodeRouterPool = new NodeRouterPool(getRouterFunction);
 
         // Start file watcher on Ssl certs
+        log.info("CorfuRuntime: Initializing sslCertWatcher.");
         sslCertWatcher = getSslCertWatcher();
 
         if (parameters.metricsEnabled) {
@@ -1102,6 +1103,7 @@ public class CorfuRuntime {
         nodeRouterPool.shutdown();
 
         if (!shutdown) {
+            log.info("stop: Re-Initializing sslCertWatcher.");
             sslCertWatcher = getSslCertWatcher();
             nodeRouterPool = new NodeRouterPool(getRouterFunction);
         }
@@ -1420,6 +1422,13 @@ public class CorfuRuntime {
         parameters.trustStore = trustStore;
         parameters.tsPasswordFile = tsPasswordFile;
         parameters.tlsEnabled = true;
+
+        // Start file watcher on Ssl certs if it is not initialized
+        if(!sslCertWatcher.isPresent()){
+            log.info("enableTls: Initializing sslCertWatcher.");
+            sslCertWatcher = getSslCertWatcher();
+        }
+
         return this;
     }
 


### PR DESCRIPTION
In some instances, CorfuRuntime is not
started from the main constructor.
In such cases, start the FileWatcher after
 the TLS parameters are configured.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
