### PR TITLE
Revert "Logs optimization (#3836)"

### DIFF
--- a/infrastructure/src/main/resources/compactor-logback.prod.xml
+++ b/infrastructure/src/main/resources/compactor-logback.prod.xml
@@ -47,7 +47,6 @@
         <queueSize>1024</queueSize>
         <maxFlushTime>5000</maxFlushTime>
     </appender>
-
     <root level="info">
         <appender-ref ref="async_file"/>
     </root>

--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -14,10 +14,10 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${LOG_DIRECTORY}/corfu.9000.%i.log.gz</fileNamePattern>
             <minIndex>1</minIndex>
-            <maxIndex>50</maxIndex>
+            <maxIndex>30</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>50MB</maxFileSize>
+            <maxFileSize>700MB</maxFileSize>
         </triggeringPolicy>
         <encoder>
             <pattern>
@@ -57,24 +57,6 @@
             </pattern>
         </encoder>
     </appender>
-
-    <appender name="log_unit_writes_file" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_DIRECTORY}/tx-log.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${LOG_DIRECTORY}/tx-log.%i.log.gz</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>100</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder>
-            <pattern>
-                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %11.11thread | %msg%n%xException
-            </pattern>
-        </encoder>
-    </appender>
-
     <!-- https://logback.qos.ch/manual/appenders.html#AsyncAppender -->
     <appender name="async_file" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="file" />
@@ -86,13 +68,6 @@
         <queueSize>1024</queueSize>
         <maxFlushTime>5000</maxFlushTime>
     </appender>
-
-    <appender name="async_log_unit_writes_file" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="log_unit_writes_file" />
-        <queueSize>1024</queueSize>
-        <maxFlushTime>1000</maxFlushTime>
-    </appender>
-
     <appender name="async_compactor_leader_file" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="compactor_leader_file" />
         <queueSize>1024</queueSize>
@@ -103,10 +78,6 @@
         <appender-ref ref="async_metrics_file"/>
     </logger>
     <logger name="org.corfudb.client.metricsdata" level="off" />
-
-    <logger name="org.corfudb.infrastructure.LogUnitServerWriter" level="debug">
-        <appender-ref ref="async_log_unit_writes_file"/>
-    </logger>
 
     <logger additivity="false" name="compactor-leader" level="debug">
 	    <appender-ref ref="async_compactor_leader_file"/>

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -1301,7 +1301,8 @@ public class CorfuRuntime {
                         MicroMeterUtils.time(fetchSample, "runtime.fetch_layout.timer");
                         return l;
                     } catch (InterruptedException ie) {
-                        throw new UnrecoverableCorfuInterruptedError("Interrupted during layout fetch", ie);
+                        throw new UnrecoverableCorfuInterruptedError(
+                                "Interrupted during layout fetch", ie);
                     } catch (WrongClusterException we) {
                         // It is futile trying to re-connect to the wrong cluster
                         log.warn("Giving up since cluster is incorrect or reconfigured!");


### PR DESCRIPTION
## Overview
This change is no longer needed.

This reverts commit 18a0f0d59dbe7230246ba5d6cebaa56e584c4742.

Why should this be merged:

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
