### PR TITLE
Refactor FileWatcher code in CorfuRuntime

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -184,6 +184,12 @@
             <artifactId>vavr</artifactId>
             <version>0.9.2</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.classic.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -154,7 +154,7 @@ public class CorfuRuntime {
      * File watcher for SSL key store to support auto hot-swapping.
      */
     @Getter
-    private Optional<FileWatcher> sslCertWatcher = Optional.empty();
+    private volatile Optional<FileWatcher> sslCertWatcher = Optional.empty();
 
     /**
      * A completable future containing a layout, when completed.

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -1034,7 +1034,7 @@ public class CorfuRuntime {
      *
      * @return The Optional of FileWatcher on Keystore file. Empty if keystore is not set in runtime.
      */
-    private Optional<FileWatcher> getSslCertWatcher() {
+    private Optional<FileWatcher> initializeSslCertWatcher() {
         String keyStorePath = this.parameters.getKeyStore();
         if (keyStorePath == null || keyStorePath.isEmpty()) {
             return Optional.empty();
@@ -1343,7 +1343,7 @@ public class CorfuRuntime {
         // Start file watcher on Ssl certs
         if (!sslCertWatcher.isPresent()) {
             log.info("connect: Initializing sslCertWatcher.");
-            sslCertWatcher = getSslCertWatcher();
+            sslCertWatcher = initializeSslCertWatcher();
         }
 
         if (layout == null) {

--- a/runtime/src/main/java/org/corfudb/util/FileWatcher.java
+++ b/runtime/src/main/java/org/corfudb/util/FileWatcher.java
@@ -1,6 +1,7 @@
 package org.corfudb.util;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.Closeable;
@@ -29,8 +30,10 @@ public class FileWatcher implements Closeable {
 
     private final ExecutorService executorService = newExecutorService();
 
+    @Getter
     private final AtomicBoolean isStopped = new AtomicBoolean(false);
 
+    @Getter
     private final AtomicBoolean isRegistered = new AtomicBoolean(false);
 
 
@@ -90,7 +93,14 @@ public class FileWatcher implements Closeable {
             // reset key for continuous watching
             key.reset();
         } catch (Throwable t) {
-            log.error("FileWatcher failed to poll file {}", file.getAbsoluteFile(), t);
+            // Check if the FileWatcher is stopped and log accordingly
+            // to avoid throwing unintentional ERROR statements
+            if (isStopped.get()) {
+                log.info("FileWatcher failed to poll file {}, Exception: {}., isStopped: {}",
+                        file.getAbsoluteFile(), t, isStopped.get());
+            } else {
+                log.error("FileWatcher failed to poll file {}", file.getAbsoluteFile(), t);
+            }
             reloadNewWatchService();
         }
     }

--- a/runtime/src/test/java/org/corfudb/runtime/utils/FileWatcherTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/utils/FileWatcherTest.java
@@ -1,0 +1,150 @@
+package org.corfudb.runtime.utils;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.corfudb.util.FileWatcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test {@link FileWatcher}'s life cycle and functionality.
+ * Created by cgudisagar on 2/17/24.
+ */
+@Slf4j
+public class FileWatcherTest {
+
+    private static FileWatcher fileWatcher;
+    private static String PATH;
+    private Path filePath;
+    private ExecutorService executorService;
+    private static final int SLEEP_TIMER_1S = 1;
+    private static final int MAX_RETRY_LIMIT = 20;
+
+    @Before
+    public void setup() throws IOException {
+        PATH = com.google.common.io.Files.createTempDir().getAbsolutePath();
+        filePath = Paths.get(PATH , "keystore.jks");
+        Files.createFile(filePath);
+    }
+
+    @After
+    public void cleanup() throws IOException {
+        FileUtils.deleteDirectory(new File(PATH));
+        fileWatcher.close();
+        executorService.shutdownNow();
+    }
+
+    /**
+     * Test that executor service of the file watcher service
+     * is started and shutdown correctly
+     */
+    @Test
+    public void testFileWatcherExecutorService() {
+        executorService = mock(ExecutorService.class);
+        fileWatcher = spy(new FileWatcher(filePath.toFile().getAbsolutePath(), () -> {}, executorService));
+        verify(executorService, times(1)).submit(any(Runnable.class));
+        fileWatcher.close();
+        verify(fileWatcher, times(1)).close();
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    /**
+     * Test that {@link FileWatcher}'s OnChance is triggered correctly when the watched file
+     * contents are changed.
+     * Test that on close method closes the executor service correctly and sets the statuses of
+     * {@link FileWatcher#getIsRegistered()} and {@link FileWatcher#getIsStopped()}.
+     *
+     * @throws InterruptedException When a sleeping thread is interrupted.
+     * @throws IOException Any File IO Exception
+     */
+    @Test
+    public void testFileWatcherOnChangeAndClose() throws InterruptedException, IOException {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("FileWatcher")
+                .build();
+        executorService = Executors.newSingleThreadExecutor(threadFactory);
+        AtomicInteger onChangeCounter = new AtomicInteger(0);
+        Runnable onChange = () -> {
+            log.info("onChangeCounter - " + onChangeCounter.get() + " lastModified " +
+            filePath.toFile().lastModified() + " size " + filePath.toFile().length() );
+            onChangeCounter.incrementAndGet();
+            log.info("onChangeCounter - " + onChangeCounter.get());
+        };
+
+        fileWatcher = spy(new FileWatcher(filePath.toFile().getAbsolutePath(), onChange, executorService));
+
+        assertThat(onChangeCounter.get()).isZero();
+
+        for (int i = 0; i < MAX_RETRY_LIMIT; i+=1) {
+            log.info("iteration: " + i + " onChangeCounter: " + onChangeCounter.get() + " lastModified: " +
+                    filePath.toFile().lastModified() + " size: " + filePath.toFile().length());
+            if (fileWatcher.getIsRegistered().get()) {
+                log.info("fileWatcher.getIsRegistered: " + fileWatcher.getIsRegistered().get());
+                break;
+            }
+        }
+
+        long lastModifiedTime = filePath.toFile().lastModified();
+
+        Path keyStoreFilePathTemp = filePath.resolveSibling(filePath.getFileName() + ".temp");
+        byte[] randomBytes = new byte[100];
+        Random random = new Random();
+        random.nextBytes(randomBytes);
+
+        Files.write(keyStoreFilePathTemp, randomBytes, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        Files.move(keyStoreFilePathTemp, filePath, StandardCopyOption.ATOMIC_MOVE);
+
+        // Avoid same lastModifiedTime for the new file
+        if (filePath.toFile().lastModified() == lastModifiedTime) {
+            log.info("Writing to file again to avoid same lastModifiedTime. lastModifiedTime: {}", lastModifiedTime);
+            TimeUnit.SECONDS.sleep(SLEEP_TIMER_1S);
+            Files.write(keyStoreFilePathTemp, randomBytes, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+            Files.move(keyStoreFilePathTemp, filePath, StandardCopyOption.ATOMIC_MOVE);
+        }
+
+        for (int i = 0; i < MAX_RETRY_LIMIT; i+=1) {
+            log.info("iteration: " + i + " onChangeCounter: " + onChangeCounter.get() + " lastModified: " +
+                    filePath.toFile().lastModified() + " size: " + filePath.toFile().length());
+            if (onChangeCounter.get() == 1) {
+                break;
+            }
+            TimeUnit.SECONDS.sleep(SLEEP_TIMER_1S);
+        }
+        assertThat(onChangeCounter.get()).isEqualTo(1);
+
+        assertThat(executorService.isShutdown()).isFalse();
+        assertThat(fileWatcher.getIsStopped()).isFalse();
+        assertThat(fileWatcher.getIsRegistered()).isTrue();
+
+        fileWatcher.close();
+
+        verify(fileWatcher, times(1)).close();
+        assertThat(executorService.isShutdown()).isTrue();
+        assertThat(fileWatcher.getIsStopped()).isTrue();
+        assertThat(fileWatcher.getIsRegistered()).isFalse();
+    }
+}

--- a/runtime/src/test/resources/logback-test.xml
+++ b/runtime/src/test/resources/logback-test.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %-5level | %20.20thread{20} | %50.50(%logger.%M:%L) | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${user.home}/corfudb.log</file>
+        <encoder>
+            <pattern>
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %-5level | %20.20thread{20} | %50.50(%logger.%M:%L) | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+    <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/tmp/log/corfu-metrics.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/var/log/corfu-metrics.%i.log</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d %-5level - %msg%n %ex{short}</pattern>
+        </encoder>
+    </appender>
+
+    <property name="CORFU_METRICS_DIRECTORY" value="/tmp/corfu_metrics" />
+
+    <appender name="MetricsRollingFileCorfu" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${CORFU_METRICS_DIRECTORY}/corfu-metrics.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${CORFU_METRICS_DIRECTORY}/corfu-metrics.%i.log.gz</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>30</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>700MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder>
+            <pattern>
+                %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+
+    <appender name="AsyncMetricsRollingFileCorfu" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="MetricsRollingFileCorfu" />
+        <queueSize>1024</queueSize>
+    </appender>
+
+
+
+
+    <!-- Control logging levels for individual components here. -->
+    <logger name="org.corfudb.runtime.object" level="INFO"/>
+    <logger name="org.corfudb.runtime.clients" level="INFO"/>
+    <logger name="org.corfudb.infrastructure" level="INFO"/>
+    <logger name="io.netty.util" level="INFO"/>
+    <logger name="io.netty.util.internal" level="INFO"/>
+    <logger name="io.netty.buffer" level="INFO"/>
+    <!--<logger name="org.corfudb.client.metricsdata" level="DEBUG"/>-->
+
+    <logger name="org.corfudb.metricsdata" level="INFO">
+        <!--<appender-ref ref="MetricsRollingFile" />-->
+    </logger>
+
+    <logger name="org.corfudb.metricsdata1" level="DEBUG" additivity="false">
+        <appender-ref ref="AsyncMetricsRollingFileCorfu" />
+    </logger>
+
+
+    <root level="INFO">
+        <!--<appender-ref ref="FILE" />-->
+        <!--<appender-ref ref="STDOUT" />-->
+        <!--<appender-ref ref="MetricsRollingFile" />-->
+    </root>
+</configuration>

--- a/test/src/test/java/org/corfudb/integration/SecurityIT.java
+++ b/test/src/test/java/org/corfudb/integration/SecurityIT.java
@@ -9,6 +9,7 @@ import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters.CorfuRuntimeParam
 import org.corfudb.runtime.collections.PersistentCorfuTable;
 import org.corfudb.runtime.exceptions.UnreachableClusterException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.util.FileWatcher;
 import org.corfudb.util.NodeLocator;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.common.util.URLUtils.getVersionFormattedEndpointURL;
@@ -329,6 +331,54 @@ public class SecurityIT extends AbstractIT {
         corfuRuntime.shutdown();
     }
 
+    /**
+     * Test that FileWatcher is started in {@link CorfuRuntime#connect()} method and stopped  after
+     * it the runtime is shut down.
+     * @throws IOException when File IO Error occurs while loading certs
+     */
+    @Test
+    public void testFileWatcherLifeCycle() throws Exception {
+        // Run a corfu server
+        // Enable Tls Mutual Auth to trigger CheckClientTrusted() in ReloadableTrustManager
+        Process corfuServer = runSinglePersistentServerTls(true);
+
+        // Create Runtime parameters for enabling TLS, without calling connect() yet
+        final CorfuRuntimeParameters rtParams = CorfuRuntime.CorfuRuntimeParameters
+                .builder()
+                .tlsEnabled(tlsEnabled)
+                .keyStore(runtimePathToKeyStore)
+                .ksPasswordFile(runtimePathToKeyStorePassword)
+                .trustStore(runtimePathToTrustStore)
+                .tsPasswordFile(runtimePathToTrustStorePassword)
+                .systemDownHandler(getShutdownHandler())
+                .maxMvoCacheEntries(DEFAULT_MVO_CACHE_SIZE)
+                .cacheDisabled(true)
+                .build();
+
+        CorfuRuntime corfuRuntime = CorfuRuntime.fromParameters(rtParams)
+                    .parseConfigurationString(
+                            getVersionFormattedEndpointURL(corfuSingleNodeHost, corfuStringNodePort)
+                    );
+
+        // Before Runtime connects FileWatcher should not have been initialized
+        assertThat(corfuRuntime.getSslCertWatcher()).isEmpty();
+
+        corfuRuntime.connect();
+
+        // After Runtime connects FileWatcher should have been initialized
+        Optional<FileWatcher> sslCertWatcher = corfuRuntime.getSslCertWatcher();
+        assertThat(sslCertWatcher).isNotEmpty();
+        assertThat(sslCertWatcher.get().getIsStopped()).isFalse();
+        assertThat(sslCertWatcher.get().getIsRegistered()).isTrue();
+
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+        corfuRuntime.shutdown();
+
+        // After Runtime is shut down FileWatcher should have been stopped
+        assertThat(sslCertWatcher).isNotEmpty();
+        assertThat(sslCertWatcher.get().getIsStopped()).isTrue();
+        assertThat(sslCertWatcher.get().getIsRegistered()).isFalse();
+    }
 
     private Runnable getShutdownHandler() {
         return () -> {

--- a/test/src/test/java/org/corfudb/integration/SecurityIT.java
+++ b/test/src/test/java/org/corfudb/integration/SecurityIT.java
@@ -337,7 +337,7 @@ public class SecurityIT extends AbstractIT {
      * @throws IOException when File IO Error occurs while loading certs
      */
     @Test
-    public void testFileWatcherLifeCycle() throws Exception {
+    public void testRuntimeFileWatcherLifeCycleWithServer() throws Exception {
         // Run a corfu server
         // Enable Tls Mutual Auth to trigger CheckClientTrusted() in ReloadableTrustManager
         Process corfuServer = runSinglePersistentServerTls(true);


### PR DESCRIPTION
- Make FileWatcher start only in connect()
- Avoid restarting FileWatcher on reconnecting client routers.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
