### PR TITLE
LR: fix getSession() when source is on older version

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/SessionManager.java
@@ -112,9 +112,7 @@ public class SessionManager {
         this.replicationManager = new CorfuReplicationManager(topology, metadataManager, runtime,
                 replicationContext);
 
-        this.incomingMsgHandler = new LogReplicationServer(serverContext, sessions, metadataManager,
-                topology.getLocalNodeDescriptor().getNodeId(), topology.getLocalNodeDescriptor().getClusterId(),
-                replicationContext);
+        this.incomingMsgHandler = new LogReplicationServer(serverContext, sessions, topology, metadataManager, replicationContext);
 
         this.router = new LogReplicationClientServerRouter(replicationManager,
                 topology.getLocalNodeDescriptor().getClusterId(), topology.getLocalNodeDescriptor().getNodeId(),

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
@@ -142,7 +142,8 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
         LogReplicationSession session = null;
 
         if(!request.getHeader().hasSession()) {
-            // Backward compatibility where 'session' field is not present.
+            // Backward compatibility where 'session' field is not present. Here, we are running with the assumption that
+            // the sink will be upgraded before the source.
             // The clusterId was added to the request msg only in LR V2. So to be backward compatible, we navigate the
             // topology to find the source cluster which supports FULL_TABLE model which was the only supported model in LR V1.
             // (Currently, we expect only 1 source cluster to support FULL_TABLE model.)
@@ -325,6 +326,8 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
         // SOURCE until the leader on the SINK knows about the FULL_TABLE session.
         LogReplicationSession session = getSession(request);
         if (session == null || !allSessions.contains(session)) {
+            log.error("The session {} was not found, hence will be returning not a leader while leadership value is {}. Current sessions are {}",
+                    session, replicationContext.getIsLeader().get(), sessionToSinkManagerMap.keySet());
             response = getLeadershipResponse(responseHeader, false, localNodeId);
         } else {
             response = getLeadershipResponse(responseHeader, replicationContext.getIsLeader().get(), localNodeId);

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -3,7 +3,10 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.msghandlers.LogReplicationServer;
 import org.corfudb.infrastructure.logreplication.infrastructure.SessionManager;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
@@ -12,6 +15,7 @@ import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicat
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationSinkManager;
 import org.corfudb.infrastructure.logreplication.transport.IClientServerRouter;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationLeadershipResponseMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
@@ -27,11 +31,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
+import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -41,6 +51,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link LogReplicationServer} message handing.
@@ -60,6 +71,9 @@ public class LogReplicationServerTest {
     ChannelHandlerContext mockHandlerContext;
     IClientServerRouter mockServerRouter;
     AtomicBoolean isLeader = new AtomicBoolean(true);
+    TopologyDescriptor topology;
+    LogReplicationContext replicationContext;
+    Set<LogReplicationSession> sessionSet;
 
     UuidMsg sourceClusterUuid = UuidMsg.newBuilder().setLsb(5).setMsb(5).build();
     String sourceClusterId = getUUID(sourceClusterUuid).toString();
@@ -78,11 +92,22 @@ public class LogReplicationServerTest {
         metadataManager = mock(LogReplicationMetadataManager.class);
         sessionManager = mock(SessionManager.class);
         sinkManager = mock(LogReplicationSinkManager.class);
-        Set<LogReplicationSession> sessionSet = new HashSet<>();
+
+        topology = mock(TopologyDescriptor.class);
+        NodeDescriptor sinkNodeDescriptor = new NodeDescriptor("host", "port",sourceClusterId, "", SINK_NODE_ID);
+        ClusterDescriptor sourceCluster = new ClusterDescriptor(sourceClusterId, 9000, Collections.singletonList(sinkNodeDescriptor));
+        ClusterDescriptor sinkCluster = new ClusterDescriptor(SINK_CLUSTER_ID, 9000, Collections.singletonList(sinkNodeDescriptor));
+        when(topology.getLocalNodeDescriptor()).thenReturn(sinkNodeDescriptor);
+        Map<ClusterDescriptor, Set<LogReplication.ReplicationModel>> remoteSourceToReplicationModel = new HashMap();
+        remoteSourceToReplicationModel.put(sourceCluster, Collections.singleton(LogReplication.ReplicationModel.FULL_TABLE));
+        when(topology.getRemoteSourceClusterToReplicationModels()).thenReturn(remoteSourceToReplicationModel);
+        when(topology.getLocalClusterDescriptor()).thenReturn(sinkCluster);
+
+        sessionSet = new HashSet<>();
         sessionSet.add(session);
-        LogReplicationContext replicationContext = new LogReplicationContext(mock(LogReplicationConfigManager.class),
+        replicationContext = new LogReplicationContext(mock(LogReplicationConfigManager.class),
                 0L, SAMPLE_HOSTNAME, true, mock(LogReplicationPluginConfig.class));
-        lrServer = spy(new LogReplicationServer(context, sessionSet, metadataManager, SINK_NODE_ID, SINK_CLUSTER_ID,
+        lrServer = spy(new LogReplicationServer(context, sessionSet, topology, metadataManager,
                 replicationContext));
         lrServer.getSessionToSinkManagerMap().put(session, sinkManager);
         mockHandlerContext = mock(ChannelHandlerContext.class);
@@ -103,11 +128,10 @@ public class LogReplicationServerTest {
                 .setLrMetadataRequest(metadataRequest).build());
 
         doReturn(LogReplicationMetadata.ReplicationMetadata.getDefaultInstance()).when(metadataManager)
-            .getReplicationMetadata(session);
+                .getReplicationMetadata(session);
         doReturn(metadataManager).when(sessionManager).getMetadataManager();
 
         lrServer.getHandlerMethods().handle(request, null, mockServerRouter);
-
         verify(metadataManager).getReplicationMetadata(session);
     }
 
@@ -126,19 +150,63 @@ public class LogReplicationServerTest {
 
         doReturn(SAMPLE_HOSTNAME).when(context).getLocalEndpoint();
 
-        // verify the response when not the leader
-        lrServer.getHandlerMethods().handle(request, null,
-            mockServerRouter);
+        //verify the response when leader and sessionManager knows about the session
+        lrServer.getHandlerMethods().handle(request, null, mockServerRouter);
         ArgumentCaptor<ResponseMsg> argument = ArgumentCaptor.forClass(ResponseMsg.class);
-        verify(mockServerRouter).sendResponse(argument.capture());
-
-        lrServer.getHandlerMethods().handle(request, null,
-            mockServerRouter);
-        argument = ArgumentCaptor.forClass(ResponseMsg.class);
-        verify(mockServerRouter, atMost(2))
+        verify(mockServerRouter, atMost(1))
             .sendResponse(argument.capture());
+        Assertions.assertThat(argument.getValue().getPayload().getLrLeadershipResponse().getIsLeader()).isTrue();
+
+        // verify the response when leader but sessionManager does not know about the session
+        replicationContext = new LogReplicationContext(mock(LogReplicationConfigManager.class),
+                0L, SAMPLE_HOSTNAME, false, mock(LogReplicationPluginConfig.class));
+        lrServer = spy(new LogReplicationServer(context, new HashSet<>(), topology, metadataManager,
+                replicationContext));
+        lrServer.getHandlerMethods().handle(request, null, mockServerRouter);
+        argument = ArgumentCaptor.forClass(ResponseMsg.class);
+        verify(mockServerRouter, atMost(2)).sendResponse(argument.capture());
+        Assertions.assertThat(argument.getValue().getPayload().getLrLeadershipResponse().getIsLeader()).isFalse();
+
+        // verify the response when not the leader
+        replicationContext = new LogReplicationContext(mock(LogReplicationConfigManager.class),
+                0L, SAMPLE_HOSTNAME, false, mock(LogReplicationPluginConfig.class));
+        lrServer = spy(new LogReplicationServer(context, new HashSet<>(), topology, metadataManager,
+                replicationContext));
+        lrServer.getHandlerMethods().handle(request, null, mockServerRouter);
+        argument = ArgumentCaptor.forClass(ResponseMsg.class);
+        verify(mockServerRouter, atMost(3)).sendResponse(argument.capture());
+        Assertions.assertThat(argument.getValue().getPayload().getLrLeadershipResponse().getIsLeader()).isFalse();
+    }
+
+    @Test
+    public void testHandleLeadershipQueryOnMixedVersion() {
+        final LogReplicationLeadershipRequestMsg leadershipQuery =
+                LogReplicationLeadershipRequestMsg.newBuilder().build();
+        final RequestMsg request =
+                getRequestMsg(HeaderMsg.newBuilder()
+                        .setVersion(getDefaultProtocolVersionMsg())
+                        .setIgnoreClusterId(true)
+                        .setIgnoreEpoch(true)
+                        .setClientId(getUuidMsg(UUID.randomUUID()))
+                                .build(),
+                        CorfuMessage.RequestPayloadMsg.newBuilder()
+                                .setLrLeadershipQuery(leadershipQuery).build());
+
+        doReturn(SAMPLE_HOSTNAME).when(context).getLocalEndpoint();
+
+        // when node is the leader and when sessionManger knows about the session
+        lrServer.getHandlerMethods().handle(request, null, mockServerRouter);
+        ArgumentCaptor<ResponseMsg> argument = ArgumentCaptor.forClass(ResponseMsg.class);
+        verify(mockServerRouter, atMost(1)).sendResponse(argument.capture());
         Assertions.assertThat(argument.getValue().getPayload()
-            .getLrLeadershipResponse().getIsLeader()).isTrue();
+                .getLrLeadershipResponse().getIsLeader()).isTrue();
+
+        //when node is the leader and sessionManager does not know about the session
+        lrServer = spy(new LogReplicationServer(context, new HashSet<>(), topology, metadataManager, replicationContext));
+        lrServer.getHandlerMethods().handle(request, null, mockServerRouter);
+        argument = ArgumentCaptor.forClass(ResponseMsg.class);
+        verify(mockServerRouter, atMost(2)).sendResponse(argument.capture());
+        Assertions.assertThat(argument.getValue().getPayload().getLrLeadershipResponse().getIsLeader()).isFalse();
     }
 
     /**


### PR DESCRIPTION
## Overview
When the sink on the new version receives a request from source on older version, the sink creates a session object.
An assumption here was that the source embeds the clusterId in the header of the request, which is not true.

So, instead of relying on the incoming request, we can rely on the topology to be backward compatible. This is safe to do as the older versions of LR only supports the FULL_TABLE model. 


Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
