### PR TITLE
Fix: Ack for Async Leadership Loss on Non-connection Starter

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/msghandlers/LogReplicationServer.java
@@ -381,7 +381,7 @@ public class LogReplicationServer extends LogReplicationAbstractServer {
                 sessionToSinkManagerMap.remove(session);
             }
         } catch (NullPointerException npe) {
-            log.warn("SinkManger was either shutdown or wasnot created for session {}", session);
+            log.warn("SinkManger was either shutdown or was not created for session {}", session);
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
@@ -158,7 +158,7 @@ public class GRPCLogReplicationServerHandler extends LogReplicationGrpc.LogRepli
         LogReplicationSession session = msg.getHeader().getSession();
 
         // Case: message to send is an ACK (async observers)
-        if (msg.getPayload().getPayloadCase().equals(ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK) ||
+        if (msg.getPayload().getPayloadCase().equals(PayloadCase.LR_ENTRY_ACK) ||
                 msg.getPayload().getPayloadCase().equals(PayloadCase.LR_LEADERSHIP_LOSS)) {
             try {
                 if (!replicationStreamObserverMap.containsKey(Pair.of(session, requestId))) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
@@ -12,6 +12,7 @@ import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase;
 
 import java.util.Map;
 import java.util.Objects;
@@ -157,7 +158,8 @@ public class GRPCLogReplicationServerHandler extends LogReplicationGrpc.LogRepli
         LogReplicationSession session = msg.getHeader().getSession();
 
         // Case: message to send is an ACK (async observers)
-        if (msg.getPayload().getPayloadCase().equals(ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK)) {
+        if (msg.getPayload().getPayloadCase().equals(ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK) ||
+                msg.getPayload().getPayloadCase().equals(PayloadCase.LR_LEADERSHIP_LOSS)) {
             try {
                 if (!replicationStreamObserverMap.containsKey(Pair.of(session, requestId))) {
                     log.warn("Corfu Message {} has no pending observer. Message {} will not be sent.",

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -2218,7 +2218,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
     @Test
     public void testSinkLockRelease() throws Exception {
-        if (topologyType.equals(TP_SINGLE_SOURCE_SINK) || topologyType.equals(TP_LOCAL_CLUSTER_NOT_FOUND)) {
+        if (topologyType.equals(TP_LOCAL_CLUSTER_NOT_FOUND)) {
             return;
         }
         // Write 10 entries to source map
@@ -2294,9 +2294,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         clearLockTable(false);
         log.info("Sink's lock table cleared!");
 
-        // Wait till the lock release is asynchronously processed and the replication status on Source changes to
-        // STOPPED
-        countDownLatch.await();
+        // Allow for the sinks leadership loss to be processed
+        Thread.sleep(5000);
 
         // Write more data on the Source
         for (int i = secondBatch; i < thirdBatch; i++) {
@@ -2308,6 +2307,10 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         }
         assertThat(mapSource.count()).isEqualTo(thirdBatch);
         log.info("Source map has {} entries now!", thirdBatch);
+
+        // Wait till the lock release is asynchronously processed and the replication status on Source changes to
+        // STOPPED
+        countDownLatch.await();
 
         // Sink map should still have secondBatch size
         log.info("Sink map should still have {} size", secondBatch);

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -2295,7 +2295,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         log.info("Sink's lock table cleared!");
 
         // Allow for the sinks leadership loss to be processed
-        Thread.sleep(5000);
+        Thread.sleep(PARAMETERS.TIMEOUT_NORMAL.toMillis());
 
         // Write more data on the Source
         for (int i = secondBatch; i < thirdBatch; i++) {


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
