### PR TITLE
Print conflict table name on Transaction aborts

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.Utils;
 
@@ -70,7 +71,10 @@ public class TransactionAbortedException extends RuntimeException {
                 + " | Failed Transaction ID = " + txResolutionInfo.getTXid()
                 + " | Offending Address = " + offendingAddress
                 + " | Conflict Key = " + Utils.bytesToHex(conflictKey)
-                + " | Conflict Stream = " + conflictStream
+                + " | Conflict Stream = " + (TransactionalContext.getRootContext() != null &&
+                TransactionalContext.getRootContext().getTxnContext() != null ?
+                TransactionalContext.getRootContext().getTxnContext()
+                        .getTableNameFromUuid(conflictStream): conflictStream)
                 + " | Cause = " + abortCause
                 + " | Time = " + (context == null ? "Unknown" :
                 System.currentTimeMillis() -

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -255,6 +255,7 @@ public abstract class AbstractTransactionalContext implements
     public void abortTransaction(TransactionAbortedException ae) {
         AbstractTransactionalContext.log.debug("TXAbort[{}]", this);
         commitAddress = ABORTED_ADDRESS;
+        txnContext = null;
     }
 
     /**
@@ -412,5 +413,6 @@ public abstract class AbstractTransactionalContext implements
     public void close() {
         snapshotProxyMap.forEach((version, snapshot) -> snapshot.releaseView());
         snapshotProxyMap.clear();
+        txnContext = null;
     }
 }


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Printing table name when available on conflict aborts makes it easy to debug.
Message now looks like this:
org.corfudb.runtime.exceptions.TransactionAbortedException: TX ABORT  | Snapshot Time = Token(epoch=0, sequence=5) |
Failed Transaction ID = 700d3670-3143-9e3b-5742-55185334442f | Offending Address = 6 | Conflict Key = A20813379EBBB6B9 | Conflict Stream = `some-namespace$ManagedMetadata` | Cause = CONFLICT | Time = 7 ms

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
