### PR TITLE
Change EventLoop Selector

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerCmdLine.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerCmdLine.java
@@ -79,7 +79,7 @@ public class CorfuServerCmdLine {
                     + "              The version of the network interface, IPv4 or IPv6(default).\n"
                     + " -i <channel-implementation>, --implementation <channel-implementation>   "
                     + "              The type of channel to use (auto, nio, epoll, kqueue)"
-                    + "[default: nio].\n"
+                    + "[default: auto].\n"
                     + " -m, --memory                                                             "
                     + "              Run the unit in-memory (non-persistent).\n"
                     + "              Data will be lost when the server exits!\n"

--- a/runtime/src/main/java/org/corfudb/runtime/RuntimeParameters.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RuntimeParameters.java
@@ -113,7 +113,7 @@ public class RuntimeParameters {
          * The type of socket which {@link NettyClientRouter}s should use. By default,
          * an NIO based implementation is used.
          */
-        public ChannelImplementation socketType = ChannelImplementation.NIO;
+        public ChannelImplementation socketType = ChannelImplementation.AUTO;
 
         /**
          * The {@link EventLoopGroup} which {@link NettyClientRouter}s will use.

--- a/runtime/src/main/java/org/corfudb/runtime/RuntimeParametersBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RuntimeParametersBuilder.java
@@ -28,7 +28,7 @@ public class RuntimeParametersBuilder {
     protected Duration connectionTimeout = Duration.ofMillis(500);
     protected Duration connectionRetryRate = Duration.ofSeconds(1);
     protected UUID clientId = UUID.randomUUID();
-    protected ChannelImplementation socketType = ChannelImplementation.NIO;
+    protected ChannelImplementation socketType = ChannelImplementation.AUTO;
     protected EventLoopGroup nettyEventLoop;
     protected String nettyEventLoopThreadFormat = "netty-%d";
     protected int nettyEventLoopThreads = 0;


### PR DESCRIPTION
## Overview
The NioEventLoop selector has a workaround (i.e., rebuildSelector) a JDK edge condition that seems to cause some concurrency issues. This patch switches the selector to auto which will use netty's EPollSelectorImpl on linux. This implementation doesn't seem to have that issue and also produces less garbage.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
