### PR TITLE
Fix: Keep PartitionAgent Updater Thread Alive + Test

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -272,12 +272,12 @@ public class BatchProcessor implements AutoCloseable {
         private final AtomicReference<BatchProcessorStatus> status = new AtomicReference<>(BatchProcessorStatus.BP_STATUS_OK);
 
         @VisibleForTesting
-        void setErrorStatus() {
+        public void setErrorStatus() {
             status.set(BatchProcessorStatus.BP_STATUS_ERROR);
         }
 
         @VisibleForTesting
-        void setOkStatus() {
+        public void setOkStatus() {
             status.set(BatchProcessorStatus.BP_STATUS_OK);
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
@@ -49,8 +49,6 @@ public final class FileSystemAgent {
 
     private final ResourceQuota logSizeQuota;
 
-    private final PartitionAttribute partitionAttribute;
-
     private final ScheduledExecutorService scheduler;
 
     private final Optional<PartitionAgent> maybePartitionAgent;
@@ -65,17 +63,12 @@ public final class FileSystemAgent {
             logSizeLimit = Long.MAX_VALUE;
 
             maybePartitionAgent = Optional.empty();
-            partitionAttribute = new PartitionAttribute(
-                    false, Long.MAX_VALUE, Long.MAX_VALUE, batchProcessorContext.getStatus()
-            );
         } else {
             initialLogSize = estimateSize();
             logSizeLimit = getLogSizeLimit();
 
             PartitionAgent partitionAgent = new PartitionAgent(config, batchProcessorContext);
             maybePartitionAgent = Optional.of(partitionAgent);
-            partitionAttribute = partitionAgent.getPartitionAttribute();
-            partitionAgent.shutdown();
         }
 
         logSizeQuota = new ResourceQuota("LogSizeQuota", logSizeLimit);
@@ -128,7 +121,7 @@ public final class FileSystemAgent {
 
     public static PartitionAttribute getPartitionAttribute() {
         Supplier<IllegalStateException> err = () -> new IllegalStateException(NOT_CONFIGURED_ERR_MSG);
-        return instance.orElseThrow(err).partitionAttribute;
+        return instance.orElseThrow(err).maybePartitionAgent.orElseThrow(err).getPartitionAttribute();
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -23,6 +23,8 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig.UPDATE_INTERVAL_SECONDS;
+
 /**
  * This class implements the StreamLog interface using a Java hash map.
  * The stream log is only stored in-memory and not persisted.
@@ -57,7 +59,8 @@ public class InMemoryStreamLog implements StreamLog {
         Path dummyLogDir = new File(".").toPath().toAbsolutePath();
         double unlimited = 100;
         long reservedSpace = 0;
-        FileSystemConfig config = new FileSystemConfig(dummyLogDir, unlimited, reservedSpace, PersistenceMode.MEMORY);
+        FileSystemConfig config = new FileSystemConfig(dummyLogDir, unlimited, reservedSpace,
+                PersistenceMode.MEMORY, UPDATE_INTERVAL_SECONDS);
         fsAgent = FileSystemAgent.init(config, batchProcessorContext);
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/log/FileSystemAgentTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/FileSystemAgentTest.java
@@ -1,0 +1,40 @@
+package org.corfudb.infrastructure.log;
+
+import org.corfudb.infrastructure.BatchProcessor.BatchProcessorContext;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.infrastructure.ServerContextBuilder;
+import org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig;
+import org.corfudb.runtime.proto.FileSystemStats.BatchProcessorStatus;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileSystemAgentTest {
+
+    @Test
+    public void testFileSystemAgentUpdateBatchProcessorStatus() throws Exception {
+        // Init the FileSystemAgent
+        String logDir = com.google.common.io.Files.createTempDir().getAbsolutePath();
+        ServerContext context = new ServerContextBuilder()
+                .setLogPath(logDir)
+                .setMemory(false)
+                .build();
+        FileSystemConfig config = new FileSystemConfig(context);
+        BatchProcessorContext batchProcessorContext = new BatchProcessorContext();
+        FileSystemAgent.init(config, batchProcessorContext);
+
+        // Check  PartitionAttribute's BatchProcessor status is initialized to OK
+        assertThat(FileSystemAgent.getPartitionAttribute().getBatchProcessorStatus()
+                .equals(BatchProcessorStatus.BP_STATUS_OK)).isTrue();
+
+        // Set Batch Processor Error Status
+        batchProcessorContext.setErrorStatus();
+
+        // Allow time for PartitionAttribute's scheduled updater thread to run
+        Thread.sleep(10000);
+
+        // Check that the updated value is reflected
+        assertThat(FileSystemAgent.getPartitionAttribute().getBatchProcessorStatus()
+                .equals(BatchProcessorStatus.BP_STATUS_ERROR)).isTrue();
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig.UPDATE_INTERVAL_SECONDS;
 import static org.corfudb.infrastructure.log.Segment.METADATA_SIZE;
 import static org.corfudb.infrastructure.log.Segment.VERSION;
 import static org.corfudb.infrastructure.log.SegmentUtils.getByteBufferWithMetaData;
@@ -740,10 +741,10 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
 
         final double limit = 100.0;
         final PersistenceMode mode = PersistenceMode.DISK;
-        FileSystemAgent.init(new FileSystemConfig(parentDir.toPath(), limit, 0, mode), new BatchProcessorContext());
+        FileSystemAgent.init(new FileSystemConfig(parentDir.toPath(), limit, 0, mode, UPDATE_INTERVAL_SECONDS), new BatchProcessorContext());
         long parentSize = FileSystemAgent.getResourceQuota().getUsed().get();
 
-        FileSystemAgent.init(new FileSystemConfig(childDir.toPath(), limit, 0, mode), new BatchProcessorContext());
+        FileSystemAgent.init(new FileSystemConfig(childDir.toPath(), limit, 0, mode, UPDATE_INTERVAL_SECONDS), new BatchProcessorContext());
         long childDirSize = FileSystemAgent.getResourceQuota().getUsed().get();
 
         assertThat(parentSize).isEqualTo(parentDirFilePayloadSize + childDirFilePayloadSize);


### PR DESCRIPTION
## Overview

Description:

Prior to this change the thread executor responsible for updating the PartitionAttribute values of the PartitionAgent was being shutdown immediately after initialization. This would allow the PartitionAttribute's BatchProcessorStatus to remain stale and cause the failure detector to miss the updates of the BatchProcessorStatus from the BatchProcessor.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
