### PR TITLE
LR: non-leader nodes retrieve session info from system tables

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -80,7 +80,9 @@ public class LogReplicationMetadataManager {
     @Getter
     private final CorfuRuntime runtime;
 
+    @Getter
     private final Table<LogReplicationSession, ReplicationStatus, Message> statusTable;
+    @Getter
     private final Table<LogReplicationSession, ReplicationMetadata, Message> metadataTable;
     private final Table<ReplicationEventInfoKey, ReplicationEvent, Message> replicationEventTable;
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -177,7 +177,8 @@ public class LogReplicationMetadataManager {
      * of relying on the default value, as some clients of log replicator v1 consume the status table with hasField
      * check.
      */
-    private void initializeMetadata(TxnContext txn, LogReplicationSession session, boolean incomingSession,
+    @VisibleForTesting
+    public void initializeMetadata(TxnContext txn, LogReplicationSession session, boolean incomingSession,
                                     long topologyConfigId) {
         if (incomingSession) {
             // Add an entry for this session if it does not exist, otherwise, this is a resuming/ongoing session


### PR DESCRIPTION
the plugin callbacks fetch sessions..this is currently being fed from the in-memory structures. This is used by the plugin to enqueue certain events.
With the change of creating sessions only on the leader node, this needs to be changed to fetch the sessions from LR's internal tables on the non-leader nodes.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
