### PR TITLE
Disable configure-corfu job as it's not required for 4.1.1 branch

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -58,20 +58,3 @@ jobs:
           
           sleep 120
           
-          if kubectl wait --for=condition=complete --timeout=180s job/configure-corfu | grep "job.batch/configure-corfu condition met"; then
-            echo "Successfull deployment!"
-            exit 0
-          else
-            echo "Failed deployment!"
-            
-            echo pods:
-            kubectl get pods
-          
-            echo corfu job:
-            kubectl describe job/configure-corfu
-            
-            echo corfu pod:
-            kubectl describe pod corfu-0
-          
-            exit 1
-          fi


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
