### PR TITLE
LR: upgrade:add Data migration check

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -165,6 +165,11 @@ public class LogReplicationMetadataManager {
                 .addTypeToClassMap(LogReplicationMetadata.ReplicationEventKey.getDefaultInstance());
     }
 
+    public static boolean isMigrationComplete(TxnContext txnContext) {
+        Table<?,?,?> table = txnContext.getTable(LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME);
+        return table.getKeyClass().getSimpleName().equals(LogReplicationSession.class.getSimpleName());
+    }
+
     public static void migrateData(TxnContext txnContext) {
         txnContext.clear(txnContext.getTable(LogReplicationUtils.REPLICATION_STATUS_TABLE_NAME));
         txnContext.clear(txnContext.getTable(REPLICATION_EVENT_TABLE_NAME));
@@ -962,6 +967,7 @@ public class LogReplicationMetadataManager {
         if(replicationContext.getIsLeader().get()) {
             txn.delete(statusTable, session);
             txn.delete(metadataTable, session);
+            log.debug("Removed session {}", session);
         }
     }
 


### PR DESCRIPTION
## Overview

Description:
Added a check to verify if the data migration has been previously completed. Without this check, the data migration is open to be executed multiple times after all the nodes in a cluster are upgraded. 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
