### PR TITLE
Graceful shutdown of corfu runtimes in checkpointer and modify compactor memory config

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorCheckpointer.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorCheckpointer.java
@@ -17,19 +17,38 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 public class CompactorCheckpointer {
-    private final DistributedCheckpointerHelper distributedCheckpointerHelper;
-    private final DistributedCheckpointer distributedCheckpointer;
+    private CompactorBaseConfig config;
+    private DistributedCheckpointerHelper distributedCheckpointerHelper;
+    private DistributedCheckpointer distributedCheckpointer;
+    private CorfuRuntime cpRuntime;
+    private CorfuRuntime corfuRuntime;
     public static final int RETRY_CHECKPOINTING = 5;
     private static final int RETRY_CHECKPOINTING_SLEEP_SECOND = 10;
 
-    public CompactorCheckpointer(String[] args) throws Exception {
-        CompactorBaseConfig config = new CompactorBaseConfig(args, "", "");
-
+    public CompactorCheckpointer(String[] args) {
+        config = new CompactorBaseConfig(args, "", "");
         Thread.currentThread().setName("Cmpt-chkpter-" + config.getNodeLocator().getPort());
-        CorfuRuntime cpRuntime = (CorfuRuntime.fromParameters(
-                config.getParams())).parseConfigurationString(config.getNodeLocator().toEndpointUrl()).connect();
-        CorfuRuntime corfuRuntime = (CorfuRuntime.fromParameters(
-                config.getParams())).parseConfigurationString(config.getNodeLocator().toEndpointUrl()).connect();
+    }
+
+    public CompactorCheckpointer(CorfuRuntime cpRuntime,
+                                 CorfuRuntime corfuRuntime,
+                                 DistributedCheckpointerHelper distributedCheckpointerHelper,
+                                 DistributedCheckpointer distributedCheckpointer) {
+        this.cpRuntime = cpRuntime;
+        this.corfuRuntime = corfuRuntime;
+        this.distributedCheckpointerHelper = distributedCheckpointerHelper;
+        this.distributedCheckpointer = distributedCheckpointer;
+    }
+
+    public void initCheckpointer() throws Exception {
+        cpRuntime = (CorfuRuntime.fromParameters(
+                this.config.getParams())).parseConfigurationString(config.getNodeLocator().toEndpointUrl());
+        cpRuntime.connect();
+
+        corfuRuntime = (CorfuRuntime.fromParameters(
+                config.getParams())).parseConfigurationString(config.getNodeLocator().toEndpointUrl());
+        corfuRuntime.connect();
+
         CorfuStore corfuStore = new CorfuStore(corfuRuntime);
 
         this.distributedCheckpointerHelper = new DistributedCheckpointerHelper(corfuStore);
@@ -41,24 +60,21 @@ public class CompactorCheckpointer {
                 .build(), corfuStore, distributedCheckpointerHelper.getCompactorMetadataTables());
     }
 
-    public CompactorCheckpointer(DistributedCheckpointerHelper distributedCheckpointerHelper,
-                                 DistributedCheckpointer distributedCheckpointer) {
-        this.distributedCheckpointerHelper = distributedCheckpointerHelper;
-        this.distributedCheckpointer = distributedCheckpointer;
-    }
-
     /**
      * Entry point to invoke checkpointing by the client jvm
      *
      * @param args command line argument strings
      */
     public static void main(String[] args) {
+        CompactorCheckpointer corfuCompactorMain = new CompactorCheckpointer(args);
         try {
-            CompactorCheckpointer corfuCompactorMain = new CompactorCheckpointer(args);
+            corfuCompactorMain.initCheckpointer();
             corfuCompactorMain.startCheckpointing();
         } catch (Exception e) {
             log.error("CorfuStoreCompactorMain crashed with error: {}, Exception: ",
                     CompactorBaseConfig.CORFU_LOG_CHECKPOINT_ERROR, e);
+        } finally {
+            corfuCompactorMain.shutdown();
         }
         log.info("Exiting CorfuStoreCompactor");
     }
@@ -77,8 +93,16 @@ public class CompactorCheckpointer {
             log.error("Sleep interrupted with exception: ", ie);
         } catch (Exception e) {
             log.error("Exception during checkpointing: {}, StackTrace: {}", e.getMessage(), e.getStackTrace());
-        } finally {
-            distributedCheckpointer.shutdown();
         }
+    }
+
+    public void shutdown() {
+        if (cpRuntime != null) {
+            cpRuntime.shutdown();
+        }
+        if (corfuRuntime != null) {
+            corfuRuntime.shutdown();
+        }
+        distributedCheckpointer.shutdown();
     }
 }

--- a/infrastructure/src/main/resources/corfu-compactor-config.yml
+++ b/infrastructure/src/main/resources/corfu-compactor-config.yml
@@ -18,6 +18,10 @@ CorfuPaths:
   CorfuMemLogPrefix: /dev/shm/corfu.jvm.gc.
   CorfuDiskLogDir: /var/log/corfu/jvm
 
+MemoryOptions:
+  DiskBacked: yes
+  DiskPath: /config/corfu-compactor/
+
 Security:
   Keystore: /certs/keystore.jks
   KsPassword: /password/password


### PR DESCRIPTION
1. Fix corfu runtime leak in the checkpointer jvm
2. Modify checkpointer jvm's memory allocation options

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
