### PR TITLE
Print Error Information for Invalid Inputs to Corfu Editor.

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -331,14 +331,14 @@ public class DynamicProtobufSerializer implements ISerializer {
             builder = DynamicMessage.parseFrom(descriptor,
                 anyMsg.getValue()).toBuilder();
         } catch (InvalidProtocolBufferException e) {
-            log.warn("Unable to Parse Key {}", anyMsg.getValue());
+            log.error("Unable to Parse Key {} due to an invalid input", anyMsg.getValue(), e);
             return null;
         }
 
         try {
             JsonFormat.parser().merge(jsonString, builder);
         } catch(InvalidProtocolBufferException e) {
-            log.warn("Unable to Parse String {}", jsonString);
+            log.error("Unable to Parse String {} due to an invalid input", jsonString, e);
             return null;
         }
         return builder.build();


### PR DESCRIPTION
Description:
If a json string with incorrect data type or out-of-range values for a protobuf field is input to the Corfu Editor, parsing it into a protobuf object fails.  Currently, no error information is shown to the user, making it difficult to find the issue.

Making this error explicit will ease in debugging by showing the error:
```
2024-03-06T20:15:30.522Z | ERROR |                           main | .u.s.DynamicProtobufSerializer | Unable to Parse String {"lockId": {"lockGroup": "Log_Replication_Group","lockName": "Log_Replication_Lock"},"leaseOwnerId": {"msb": "2574355181226772460","lsb": "-4699585018479296088"},"leaseRenewalNumber": 1000} due to an invalid input
com.google.protobuf.InvalidProtocolBufferException: Out of range uint64 value: "-4699585018479296088"
	at com.google.protobuf.util.JsonFormat$ParserImpl.parseUint64(JsonFormat.java:1814)
        .........
```
        
Why should this be merged: Debuggability improvement

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
