### PR TITLE
Allow lock acquisition if the Lock Table is empty.

### DIFF
--- a/test/src/test/java/org/corfudb/utils/LockStoreTest.java
+++ b/test/src/test/java/org/corfudb/utils/LockStoreTest.java
@@ -262,7 +262,7 @@ public class LockStoreTest extends AbstractViewTest {
             // Wait till the duration of the lock lease expiry + an
             // additional delay of 10ms.
             // LockStore detects a lock as expired if (the duration between
-            // the time it was first read - lease expiry time) is before the
+            // the time it was first read + lease expiry time) is before the
             // current system clock time.  So adding an arbitrary 10ms so
             // that the lock is detected as
             // expired.
@@ -289,11 +289,27 @@ public class LockStoreTest extends AbstractViewTest {
         }
     }
 
+    /**
+     * This test verifies the behavior of 2 operations when the lock table is empty.
+     * 1)lock renewal and
+     * 2)filtering of locks with expired lease
+     * This table can be empty if no node has acquired leadership or it has been manually deleted.  The expected
+     * behavior is for renewal to fail and filtering shows the requested lock as revocable so that the querying node
+     * can acquire leadership.
+     * @throws Exception
+     */
     @Test
-    public void testFilterExpiredLocksWithEmptyLockTable() throws Exception {
+    public void testEmptyLockTable() throws Exception {
         LockStore lockStore = new LockStore(runtime1, UUID.randomUUID());
+
+        // Renewal of a lock which has not yet been acquired is not valid
+        Assert.assertFalse(lockStore.renew(lockId));
+
+        // Get a list of locks with revocable lease.  As there is no lock currently acquired, the request lock can be
+        // revoked.
         List<LockDataTypes.LockId> revocableLocks =
             lockStore.filterLocksWithExpiredLeases(Collections.singletonList(lockId)).stream().collect(Collectors.toList());
-        Assert.assertTrue(Objects.equals(revocableLocks, Collections.singletonList(lockId)));
+        Assert.assertEquals(1, revocableLocks.size());
+        Assert.assertEquals(lockId, revocableLocks.get(0));
     }
 }

--- a/test/src/test/java/org/corfudb/utils/LockStoreTest.java
+++ b/test/src/test/java/org/corfudb/utils/LockStoreTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
@@ -286,5 +287,13 @@ public class LockStoreTest extends AbstractViewTest {
 
             cleanupAfterIteration();
         }
+    }
+
+    @Test
+    public void testFilterExpiredLocksWithEmptyLockTable() throws Exception {
+        LockStore lockStore = new LockStore(runtime1, UUID.randomUUID());
+        List<LockDataTypes.LockId> revocableLocks =
+            lockStore.filterLocksWithExpiredLeases(Collections.singletonList(lockId)).stream().collect(Collectors.toList());
+        Assert.assertTrue(Objects.equals(revocableLocks, Collections.singletonList(lockId)));
     }
 }

--- a/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
@@ -244,8 +244,8 @@ public class LockStore {
                                 Optional<LockData> lockDataOptional) {
 
         if (!lockDataOptional.isPresent()) {
-            // No lock in the database.  Return.
-            return false;
+            log.info("LockStore: lockId {} not present in store", lockId.getLockName());
+            return true;
         }
 
         ObservedLock observedLock = observedLocks.get(lockId);


### PR DESCRIPTION
## Overview
PR #3219 introduced a regression where no node can acquire a lock after the lock table gets cleared.

This is a rare scenario and can be addressed by restarting LR service on 1 or more nodes but good to fix as it's a regression.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
