### PR TITLE
Avoid reflection getting process pid

### DIFF
--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -330,16 +330,12 @@ public class AbstractIT extends AbstractCorfuTest {
 
     public static long getPid(Process p) {
         long pid = -1;
-
         try {
-            if (p.getClass().getName().equals("java.lang.UNIXProcess") || p.getClass().getName().equals("java.lang.ProcessImpl")) {
-                Field f = p.getClass().getDeclaredField("pid");
-                f.setAccessible(true);
-                pid = f.getLong(p);
-                f.setAccessible(false);
+            if (p.getClass().getName().equals("java.lang.UNIXProcess")
+                    || p.getClass().getName().equals("java.lang.ProcessImpl")) {
+                pid = p.pid();
             }
-        } catch (Exception e) {
-            pid = -1;
+        } catch (Exception ignored) {
         }
         return pid;
     }


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Since Java 9 the Process class has had native support to get the process's id which we can now use to avoid the reflection and the warnings we see as a result.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
