### PR TITLE
Release SMR objects from the objectCache

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedCorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedCorfuTable.java
@@ -11,7 +11,6 @@ import org.corfudb.runtime.object.ICorfuSMRUpcallTarget;
 import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -68,7 +67,7 @@ public class PersistedCorfuTable<K, V> implements
 
     @Override
     public void close() {
-        proxy.getUnderlyingMVO().close();
+        proxy.close();
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistentCorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistentCorfuTable.java
@@ -63,8 +63,7 @@ public class PersistentCorfuTable<K, V> implements
 
     @Override
     public void close() {
-        // Evict all versions of this Table from MVOCache
-        proxy.getUnderlyingMVO().getMvoCache().invalidateAllVersionsOf(getCorfuSMRProxy().getStreamID());
+        proxy.close();
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -213,13 +213,12 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
                 .type(getUnderlyingType())
                 .build();
 
-        corfuTable.close();
-
-        Object tableObject = runtime.getObjectsView().getObjectCache().remove(oid);
+        Object tableObject = runtime.getObjectsView().getObjectCache().get(oid);
         if (tableObject == null) {
             throw new NoSuchElementException("resetTableData: No object cache entry for "+ fullyQualifiedTableName);
         }
 
+        corfuTable.close();
         initializeCorfuTable(runtime);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -55,7 +55,7 @@ public class CorfuCompileWrapperBuilder {
             MVOCache<S> mvoCache = rt.getObjectsView().getMvoCache();
             // Note: args are used when invoking the internal immutable data structure constructor
             wrapperObject.setCorfuSMRProxy(new MVOCorfuCompileProxy<>(rt, streamID,
-                    immutableClass, args, serializer, streamTags, wrapperObject, objectOpenOption,
+                    immutableClass, wrapperClass, args, serializer, streamTags, wrapperObject, objectOpenOption,
                     mvoCache));
             return (T) wrapperObject;
         } else if (type.getName().equals(PERSISTED_CORFU_TABLE_CLASS_NAME)) {
@@ -76,7 +76,7 @@ public class CorfuCompileWrapperBuilder {
             // good reason to enforce a global cache.
             MVOCache<S> mvoCache = new MVOCache<>(rt.getParameters().getMvoCacheExpiry());
             wrapperObject.setCorfuSMRProxy(new MVOCorfuCompileProxy<>(rt, streamID,
-                    coreClass, args, serializer, streamTags, wrapperObject, objectOpenOption,
+                    coreClass, wrapperClass, args, serializer, streamTags, wrapperObject, objectOpenOption,
                     mvoCache));
             return (T) wrapperObject;
         }

--- a/runtime/src/main/java/org/corfudb/runtime/object/DiskBackedSMRSnapshot.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/DiskBackedSMRSnapshot.java
@@ -52,17 +52,14 @@ public class DiskBackedSMRSnapshot<S extends SnapshotGenerator<S>> implements SM
     }
 
     private boolean isInvalid() {
-        if (!this.readOptions.isOwningHandle()) {
-            return true; // The snapshot has already been released.
-        }
-
         if (!this.rocksDb.isOwningHandle()) {
             log.error("Invalid RocksDB instance {} for snapshot {}.",
                     rocksDb.getNativeHandle(), version);
             return true; // RocksDB instance has already been closed.
         }
 
-        return false;
+        // Check if the snapshot has already been released.
+        return !this.readOptions.isOwningHandle();
     }
 
     public <V> V executeInSnapshot(Function<ReadOptions, V> function) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -12,7 +12,7 @@ import java.util.UUID;
  * @param <S> The type of the SMR object which must extend
  *            {@link SnapshotGenerator} and {@link ConsistencyView}
  */
-public interface ICorfuSMRProxy<S extends SnapshotGenerator<S> & ConsistencyView> {
+public interface ICorfuSMRProxy<S extends SnapshotGenerator<S> & ConsistencyView> extends AutoCloseable {
 
     /**
      * Access the state of the object.
@@ -70,4 +70,10 @@ public interface ICorfuSMRProxy<S extends SnapshotGenerator<S> & ConsistencyView
      * @return the serializer associated with this SMR object.
      */
     ISerializer getSerializer();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void close();
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
@@ -485,6 +485,7 @@ public class MultiVersionObject<S extends SnapshotGenerator<S> & ConsistencyView
      */
     private void releaseSnapshots() {
         snapshotFifo.forEach(SMRSnapshot::release);
+        // Evict all versions of this Table from MVOCache
         mvoCache.invalidateAllVersionsOf(getSmrStream().getID());
     }
 

--- a/runtime/src/main/java/org/corfudb/util/ReflectionUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/ReflectionUtils.java
@@ -98,8 +98,7 @@ public class ReflectionUtils {
             @NonNull Constructor[] constructors, @NonNull Object[] args)
             throws IllegalAccessException, InvocationTargetException, InstantiationException {
         // Figure out the argument types.
-        final List<Class> argTypes = Arrays
-                .stream(args).map(Object::getClass)
+        final List<Class> argTypes = Arrays.stream(args).map(Object::getClass)
                 .collect(Collectors.toList());
         // Filter out the constructors that do not have the same arity.
         final List<Constructor> constructorCandidates = Arrays.stream(constructors)

--- a/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
@@ -157,6 +157,7 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
                 runtime,
                 UUID.nameUUIDFromBytes(fullyQualifiedTableName.getBytes()),
                 ImmutableCorfuTable.<K, CorfuRecord<V, M>>getTypeToken().getRawType(),
+                PersistentCorfuTable.class,
                 args,
                 runtime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE),
                 new HashSet<UUID>(),


### PR DESCRIPTION
## Overview

Description:
    
    Release SMR objects from the objectCache whenever the object is
    closed. Previously, when the object was closed, it was not removed
    from the objectCache. Consequently, on the subsequent open, the
    cached version was returned which is no longer valid as it had
    previously been closed.


Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
