### PR TITLE
CorfuStoreBrowser: Allow addRecord on null metadata tables

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -407,9 +407,20 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
         DynamicMessage newValueMsg =
             dynamicProtobufSerializer.createDynamicMessageFromJson(defaultValueAny,
                 newValue);
+
+        // If the table did not have metadata configured, then when the table's entry
+        // is created in the registry table, its section of google.protobuf.Any metadata = 4;
+        // is never filled in. So reading that unfilled section into defaultMetadataAny gets us
+        // a defaultInstance of the Any type which has type Url as an empty string.
+        if (!defaultMetadataAny.getTypeUrl().isEmpty() && newMetadata == null) {
+            log.error("Please supply metadata! Table has metadata schema defined as {}. At least pass an '{ }'",
+                    defaultMetadataAny.getTypeUrl());
+            return null;
+        }
         DynamicMessage newMetadataMsg =
+                !defaultMetadataAny.getTypeUrl().isEmpty() ?
             dynamicProtobufSerializer.createDynamicMessageFromJson(defaultMetadataAny,
-                newMetadata);
+                newMetadata) : null;
 
         // Metadata can be empty or null but key or value should not
         if (newKeyMsg == null || newValueMsg == null) {

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
@@ -310,8 +310,6 @@ public class CorfuStoreBrowserEditorMain {
                         "Key To Add is Null.");
                 Preconditions.checkNotNull(valueToAdd,
                         "New Value is null");
-                Preconditions.checkNotNull(metadataToAdd,
-                        "New Metadata is null");
                 CorfuDynamicRecord addedRecord = browser.addRecord(namespace, tableName, keyToAdd,
                         valueToAdd, metadataToAdd);
                 return addedRecord != null ? 1: 0;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuDynamicRecord.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuDynamicRecord.java
@@ -44,8 +44,13 @@ public class CorfuDynamicRecord {
                               @Nullable DynamicMessage metadata) {
         this.payloadTypeUrl = payloadTypeUrl;
         this.payload = new CorfuDynamicMessage(payload);
-        this.metadataTypeUrl = metadataTypeUrl;
-        this.metadata = new CorfuDynamicMessage(metadata);
+        if (metadata != null) {
+            this.metadataTypeUrl = metadataTypeUrl;
+            this.metadata = new CorfuDynamicMessage(metadata);
+        } else {
+            this.metadataTypeUrl = "";
+            this.metadata = null;
+        }
     }
 
     public DynamicMessage getPayload() {
@@ -53,7 +58,7 @@ public class CorfuDynamicRecord {
     }
 
     public DynamicMessage getMetadata() {
-        return metadata.getPayload();
+        return metadata != null ? metadata.getPayload() : null;
     }
 
 
@@ -73,8 +78,9 @@ public class CorfuDynamicRecord {
         boolean payloadMatch = payloadTypeUrl.equals(corfuDynamicRecord.payloadTypeUrl)
                 && payload.equals(corfuDynamicRecord.payload);
 
-        // Compare the metadata.
-        boolean metadataMatch = metadata.equals(corfuDynamicRecord.metadata);
+        // Compare the metadata only if both are not null.
+        boolean metadataMatch = metadata == corfuDynamicRecord.metadata || // true when both are null
+                Objects.equals(metadata, corfuDynamicRecord.metadata);
 
         // Compare the metadata typeUrl. The typeUrl is null if there is no metadata.
         boolean metadataTypeUrlMatch;


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
If the table does not have a metadata section browser's addRecord fails with a NullPointerException

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
