### PR TITLE
Revert "Validate maxWriteSize of a transaction before compression (#3828)"

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CompactorBaseConfig.java
@@ -71,8 +71,20 @@ public class CompactorBaseConfig {
             }
         });
 
-        builder.maxWriteSize(getOpt("--maxWriteSize").map(Integer::parseInt).orElse(
-                persistedCacheRoot.isPresent() ? DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE : DEFAULT_CP_MAX_WRITE_SIZE));
+        Optional<String> maybeMaxWriteSize = getOpt("--maxWriteSize");
+        int maxWriteSize;
+        if (maybeMaxWriteSize.isPresent()) {
+            maxWriteSize = Integer.parseInt(maybeMaxWriteSize.get());
+        } else {
+            if (!persistedCacheRoot.isPresent()) {
+                // in-memory compaction
+                maxWriteSize = DEFAULT_CP_MAX_WRITE_SIZE;
+            } else {
+                // disk-backed compaction
+                maxWriteSize = DISK_BACKED_DEFAULT_CP_MAX_WRITE_SIZE;
+            }
+        }
+        builder.maxWriteSize(maxWriteSize);
 
         getOpt("--bulkReadSize").ifPresent(bulkReadSizeStr -> {
             builder.bulkReadSize(Integer.parseInt(bulkReadSizeStr));

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -4,7 +4,6 @@ import org.corfudb.common.util.Memory;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import static java.lang.Math.toIntExact;
@@ -54,12 +53,11 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
          * to the log data.
          *
          * @param data     the log data to manage
-         * @param limit if a value is passed, validate size of data against the limit
          * @param metadata whether metadata needs to be serialized
          */
-        public SerializationHandle(ILogData data, boolean metadata, Optional<Integer> limit) {
+        public SerializationHandle(ILogData data, boolean metadata) {
             this.data = data;
-            data.acquireBuffer(metadata, limit);
+            data.acquireBuffer(metadata);
         }
 
         /**
@@ -79,19 +77,7 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * @return a serialization handle of this entry
      */
     default SerializationHandle getSerializedForm(boolean metadata) {
-        return getSerializedForm(metadata, Optional.empty());
-    }
-
-    /**
-     * Get the serialization handle of this entry that manages
-     * the lifetime of the serialized copy.
-     *
-     * @param metadata whether metadata needs to be serialized
-     * @param limit if a value is passed, validate size of data against the limit
-     * @return a serialization handle of this entry
-     */
-    default SerializationHandle getSerializedForm(boolean metadata, Optional<Integer> limit) {
-        return new SerializationHandle(this, metadata, limit);
+        return new SerializationHandle(this, metadata);
     }
 
     /**
@@ -103,9 +89,8 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * Acquire the serialization buffer.
      *
      * @param metadata whether metadata needs to be serialized
-     * @param limit if a value is passed, validate size of data against the limit
      */
-    void acquireBuffer(boolean metadata, Optional<Integer> limit);
+    void acquireBuffer(boolean metadata);
 
     /**
      * Return the payload as a log entry.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -19,7 +19,6 @@ import org.corfudb.util.serializer.Serializers;
 import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -150,9 +149,9 @@ public class LogData implements IMetadata, ILogData {
     }
 
     @Override
-    public synchronized void acquireBuffer(boolean metadata, Optional<Integer> limit) {
+    public synchronized void acquireBuffer(boolean metadata) {
         if (serializedCache == null) {
-            acquireBufferInternal(metadata, limit);
+            acquireBufferInternal(metadata);
         } else {
             if (metadata) {
                 serializedCache.buffer.resetReaderIndex();
@@ -166,16 +165,16 @@ public class LogData implements IMetadata, ILogData {
     public synchronized void updateAcquiredBuffer(boolean metadata) {
         Preconditions.checkState(serializedCache != null,
                 "updateAcquiredBuffer requires serialized form");
-        acquireBufferInternal(metadata, Optional.empty());
+        acquireBufferInternal(metadata);
     }
 
-    private void acquireBufferInternal(boolean metadata, Optional<Integer> limit) {
+    private void acquireBufferInternal(boolean metadata) {
         ByteBuf buf = Unpooled.buffer();
         if (metadata) {
-            int metadataOffset = doSerializeInternal(buf, limit);
+            int metadataOffset = doSerializeInternal(buf);
             serializedCache = new SerializedCache(buf, metadataOffset);
         } else {
-            doSerializePayloadInternal(buf, limit);
+            doSerializePayloadInternal(buf);
             serializedCache = new SerializedCache(buf, buf.writerIndex());
         }
     }
@@ -300,19 +299,19 @@ public class LogData implements IMetadata, ILogData {
             serializedCache.buffer.resetReaderIndex();
             buf.writeBytes(serializedCache.buffer);
         } else {
-            doSerializeInternal(buf, Optional.empty());
+            doSerializeInternal(buf);
         }
     }
 
-    private int doSerializeInternal(ByteBuf buf, Optional<Integer> limit) {
-        doSerializePayloadInternal(buf, limit);
+    private int doSerializeInternal(ByteBuf buf) {
+        doSerializePayloadInternal(buf);
         int metadataOffset = buf.writerIndex();
         doSerializeMetadataInternal(buf);
 
         return metadataOffset;
     }
 
-    private void doSerializePayloadInternal(ByteBuf buf, Optional<Integer> limit) {
+    private void doSerializePayloadInternal(ByteBuf buf) {
         CorfuProtocolCommon.serialize(buf, type.asByte());
         if (type == DataType.DATA) {
             if (data == null) {
@@ -322,11 +321,9 @@ public class LogData implements IMetadata, ILogData {
                     // If the payload has a codec we need to also compress the payload
                     ByteBuf serializeBuf = Unpooled.buffer();
                     Serializers.CORFU.serialize(payload.get(), serializeBuf);
-                    checkMaxUncompressedWriteSizeIfRequired(limit, serializeBuf.writerIndex() - (lengthIndex + 4));
                     doCompressInternal(serializeBuf, buf);
                 } else {
                     Serializers.CORFU.serialize(payload.get(), buf);
-                    checkMaxUncompressedWriteSizeIfRequired(limit, buf.writerIndex() - (lengthIndex + 4));
                 }
                 int size = buf.writerIndex() - (lengthIndex + 4);
                 buf.writerIndex(lengthIndex);
@@ -385,17 +382,6 @@ public class LogData implements IMetadata, ILogData {
         return "LogData[" + getGlobalAddress() + "]";
     }
 
-    private void checkMaxUncompressedWriteSizeIfRequired(Optional<Integer> limit, int payloadSize) {
-        if (!limit.isPresent()) {
-            return;
-        }
-        log.trace("checkMaxUncompressedWriteSizeIfRequired: uncompressed payload size is {} bytes.", payloadSize);
-        if (payloadSize > limit.get()) {
-            throw new WriteSizeException("Trying to write " + payloadSize + " bytes but max uncompressed write limit is "
-                    + limit.get() + " bytes");
-        }
-    }
-
     /**
      * Verify that max payload is enforced for the specified limit.
      *
@@ -406,7 +392,10 @@ public class LogData implements IMetadata, ILogData {
         Preconditions.checkState(serializedCache != null, "checkMaxWriteSize requires serialized form");
 
         int payloadSize = getSizeEstimate();
-        log.trace("checkMaxWriteSize: payload size is {} bytes", payloadSize);
+        if (log.isTraceEnabled()) {
+            log.trace("checkMaxWriteSize: payload size is {} bytes.", payloadSize);
+        }
+
         if (payloadSize > limit) {
             throw new WriteSizeException(payloadSize, limit);
         }

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -72,6 +72,13 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
     @Setter
     private int batchSize;
 
+    /**
+     *  Max uncompressed checkpoint entry size: Maximum uncompressed size of a single Checkpoint CONTINUATION Entry.
+     */
+    @Getter
+    @Setter
+    private long maxUncompressedCpEntrySize;
+
     @SuppressWarnings("checkstyle:abbreviation")
     private final UUID checkpointStreamID;
     private final Map<CheckpointEntry.CheckpointDictKey, String> mdkv = new HashMap<>();
@@ -128,6 +135,7 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
         checkpointId = UUID.randomUUID();
         checkpointStreamID = CorfuRuntime.getCheckpointStreamIdFromId(streamId);
         sv = rt.getStreamsView();
+        maxUncompressedCpEntrySize = rt.getParameters().getMaxUncompressedCpEntrySize();
         batchSize = rt.getParameters().getCheckpointBatchSize();
     }
 
@@ -343,11 +351,11 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
             inputBuffer.clear();
 
             /* CheckpointEntry has some metadata and make the total size larger than the actual size
-             * of SMR entries. It's a safeguard against the smr entries amounting to the actual
+             * of SMR entries. Its a safeguard against the smr entries amounting to the actual
              * boundary limit.
              */
-            if (numBytesPerUncompressedCheckpointEntry > rt.getParameters().getMaxUncompressedWriteSize() ||
-                numBytesPerCheckpointEntry > maxWriteSizeLimit || smrEntries.getUpdates().size() >= batchSize) {
+            if (numBytesPerUncompressedCheckpointEntry > maxUncompressedCpEntrySize
+                    || numBytesPerCheckpointEntry > maxWriteSizeLimit || smrEntries.getUpdates().size() >= batchSize) {
                 convertAndAppendCheckpointEntry(smrEntries, kvCopy);
                 log.trace("Batched size of checkpoint log entry consists {} smr entries",
                         smrEntries.getUpdates().size());

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -212,14 +212,9 @@ public class CorfuRuntime {
     public static class CorfuRuntimeParameters extends RuntimeParameters {
 
         /*
-         * Max uncompressed size for a write request.
+         * Max size for a write request.
          */
-        int maxUncompressedWriteSize = MAX_UNCOMPRESSED_WRITE_SIZE;
-
-        /*
-         * Max compressed size for a write request.
-         */
-        int maxWriteSize = 25 << 20;
+        int maxWriteSize = Integer.MAX_VALUE;
 
         /*
          * Set the bulk read size.
@@ -317,6 +312,11 @@ public class CorfuRuntime {
          * The maximum number of SMR entries that will be grouped in a CheckpointEntry.CONTINUATION
          */
         int checkpointBatchSize = 50;
+
+        /*
+         * The maximum size of an uncompressed CheckpointEntry.CONTINUATION that can be written
+         */
+        long maxUncompressedCpEntrySize = 100_000_000;
 
         /*
          * The maximum number of SMR entries that will be grouped in a MultiSMREntry during Restore
@@ -439,11 +439,7 @@ public class CorfuRuntime {
         }
 
         public static class CorfuRuntimeParametersBuilder extends RuntimeParametersBuilder {
-
-            //Max uncompressed size for a write request.
-            private int maxUncompressedWriteSize = MAX_UNCOMPRESSED_WRITE_SIZE;
-            //Max compressed size for a write request
-            private int maxWriteSize = 25 << 20;
+            private int maxWriteSize = Integer.MAX_VALUE;
             private int bulkReadSize = 10;
             private int holeFillRetry = 10;
             private Duration holeFillRetryThreshold = Duration.ofSeconds(1L);
@@ -461,6 +457,7 @@ public class CorfuRuntime {
             private int trimRetry = 2;
             private int checkpointRetries = 5;
             private int checkpointBatchSize = 50;
+            private long maxUncompressedCpEntrySize = 100_000_000;
             private int restoreBatchSize = 50;
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 1;
@@ -631,11 +628,6 @@ public class CorfuRuntime {
                 return this;
             }
 
-            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder maxUncompressedWriteSize(int maxUncompressedWriteSize) {
-                this.maxUncompressedWriteSize = maxUncompressedWriteSize;
-                return this;
-            }
-
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder bulkReadSize(int bulkReadSize) {
                 this.bulkReadSize = bulkReadSize;
                 return this;
@@ -718,6 +710,11 @@ public class CorfuRuntime {
 
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder checkpointBatchSize(int checkpointBatchSize) {
                 this.checkpointBatchSize = checkpointBatchSize;
+                return this;
+            }
+
+            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder maxUncompressedCpEntrySize(long maxUncompressedCpEntrySize) {
+                this.maxUncompressedCpEntrySize = maxUncompressedCpEntrySize;
                 return this;
             }
 
@@ -820,7 +817,6 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setSystemDownHandler(systemDownHandler);
                 corfuRuntimeParameters.setBeforeRpcHandler(beforeRpcHandler);
                 corfuRuntimeParameters.setMaxWriteSize(maxWriteSize);
-                corfuRuntimeParameters.setMaxUncompressedWriteSize(maxUncompressedWriteSize);
                 corfuRuntimeParameters.setBulkReadSize(bulkReadSize);
                 corfuRuntimeParameters.setHoleFillRetry(holeFillRetry);
                 corfuRuntimeParameters.setHoleFillRetryThreshold(holeFillRetryThreshold);
@@ -838,6 +834,7 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setTrimRetry(trimRetry);
                 corfuRuntimeParameters.setCheckpointRetries(checkpointRetries);
                 corfuRuntimeParameters.setCheckpointBatchSize(checkpointBatchSize);
+                corfuRuntimeParameters.setMaxUncompressedCpEntrySize(maxUncompressedCpEntrySize);
                 corfuRuntimeParameters.setRestoreBatchSize(restoreBatchSize);
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/WriteSizeException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/WriteSizeException.java
@@ -8,8 +8,4 @@ public class WriteSizeException extends RuntimeException {
     public WriteSizeException(int size, int max) {
         super("Trying to write " + size + " bytes but max write limit is " + max + " bytes");
     }
-
-    public WriteSizeException(String message) {
-        super(message);
-    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
@@ -21,7 +22,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -150,12 +150,19 @@ public class StreamsView extends AbstractView {
         // The serialization here only serializes the payload because the token is not
         // acquired yet, thus metadata is incomplete. Once a token is acquired, the
         // writer will append the serialized metadata to the buffer.
-        try (ILogData.SerializationHandle sh = ld.getSerializedForm(serializeMetadata,
-                skipWriteSizeCheck ? Optional.empty() : Optional.of(runtime.getParameters().getMaxUncompressedWriteSize()))) {
+        try (ILogData.SerializationHandle sh = ld.getSerializedForm(serializeMetadata)) {
+            int payloadSize;
+            if (skipWriteSizeCheck) {
+                payloadSize = ld.getSizeEstimate();
+                if (log.isTraceEnabled()) {
+                    log.trace("append: payload size is {} bytes.", payloadSize);
+                }
+            } else {
+                payloadSize = ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
+            }
 
-            int payloadSize = skipWriteSizeCheck ? ld.getSizeEstimate() :
-                    ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
-
+            MicroMeterUtils.measure(payloadSize, "logdata.payload.bytes", "clientId",
+                    runtime.getParameters().getClientId().toString());
             for (int retry = 0; retry < runtime.getParameters().getWriteRetry(); retry++) {
                 // Go to the sequencer, grab a token to write.
                 tokenResponse = conflictInfo == null
@@ -206,10 +213,11 @@ public class StreamsView extends AbstractView {
                 }
             }
 
-            log.error("append[{}]: failed after {} retries, streams {}, write size {} bytes (compressed)",
+            log.error("append[{}]: failed after {} retries, streams {}, write size {} bytes",
                     tokenResponse == null ? -1 : tokenResponse.getSequence(),
                     runtime.getParameters().getWriteRetry(),
-                    Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()), payloadSize);
+                    Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()),
+                    payloadSize);
         }
 
         throw new AppendException();

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Function;
@@ -186,9 +185,8 @@ public abstract class AbstractQueuedStreamView extends
         // The serialization here only serializes the payload because the token is not
         // acquired yet, thus metadata is incomplete. Once a token is acquired, the
         // writer will append the serialized metadata to the buffer.
-        // Also, validate if the  size of the log data is under max write size.
-        try (ILogData.SerializationHandle sh = ld.getSerializedForm(false,
-                Optional.of(runtime.getParameters().getMaxUncompressedWriteSize()))) {
+        try (ILogData.SerializationHandle sh = ld.getSerializedForm(false)) {
+            // Validate if the  size of the log data is under max write size.
             int payloadSize = ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
 
             // First, we get a token from the sequencer.

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
@@ -1,14 +1,5 @@
 package org.corfudb.runtime.object.transactions;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
@@ -20,6 +11,14 @@ import org.corfudb.runtime.exceptions.AppendException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * These tests generate workloads with mixed reads/writes on multiple maps.
@@ -66,42 +65,6 @@ public class StreamTest extends AbstractTransactionsTest {
         assertThatThrownBy(() -> getRuntime().getStreamsView().append(
                 new byte[payloadSize], null, svId))
                 .isInstanceOf(AppendException.class);
-    }
-
-    @Test
-    public void testMaxWriteSizeLimitExceeded() {
-        ICorfuTable<String, String> map = instantiateCorfuObject(PersistentCorfuTable.class, "TestTable");
-
-        //Max uncompressed write size check
-        byte[] array1 = new byte[getRuntime().getParameters().getMaxUncompressedWriteSize()];
-        new Random().nextBytes(array1);
-        String payloadString = new String(array1, Charset.forName("UTF-8"));
-        boolean abortException = false;
-        try {
-            TXBegin();
-            map.insert(Integer.toString(0), payloadString);
-            TXEnd();
-        } catch (TransactionAbortedException tae) {
-            assertThat(tae.getAbortCause()).isEqualTo(AbortCause.SIZE_EXCEEDED);
-            abortException = true;
-        }
-        assertThat(abortException).isTrue();
-
-        //Max compressed write size check
-        byte[] array2 = new byte[getRuntime().getParameters().getMaxWriteSize()];
-        getRuntime().getParameters().setMaxWriteSize(1);
-        new Random().nextBytes(array2);
-        payloadString = new String(array2, Charset.forName("UTF-8"));
-        abortException = false;
-        try {
-            TXBegin();
-            map.insert(Integer.toString(0), payloadString);
-            TXEnd();
-        } catch (TransactionAbortedException tae) {
-            assertThat(tae.getAbortCause()).isEqualTo(AbortCause.SIZE_EXCEEDED);
-            abortException = true;
-        }
-        assertThat(abortException).isTrue();
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 80118a61868d4648630b6509c2f3392d7e316d4b.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
