### PR TITLE
Java 11: Fix _rsync_log

### DIFF
--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -211,7 +211,10 @@ class CompactorRunner(object):
         flist = glob.glob(src_file_prefix + "*")
         for file in flist:
             try:
-                if file.find("current") == -1:
+                # Java 11 log rotation naming scheme:
+                # 1. The active GC log file has a ".log" extension
+                # 2. Rotated GC files have a ".log.[0-9]" extension
+                if file.split(".")[-1] != 'log':
                     cmd = "cp --preserve " + file + " " + dst_dir
                     output = check_output(cmd, shell=True)
                     os.remove(file)


### PR DESCRIPTION
## Overview
_rsync_log should only move rotated log files, but with Java 11 the log rotation naming scheme has changed causing it to move active logs. This patch fixes that by matching files against the new naming scheme.

Why should this be merged: Fixes the log archiving script

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
