### PR TITLE
Add tests for dropped SNAPSHOT_START and out-of-order messages + Minor cleanup in LogReplicationIT.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -42,7 +42,6 @@ public class LogReplicationSourceManager {
 
     private static final int DEFAULT_FSM_WORKER_THREADS = 1;
 
-    @VisibleForTesting
     private final LogReplicationFSM logReplicationFSM;
 
     private final LogReplicationRuntimeParameters parameters;
@@ -53,10 +52,8 @@ public class LogReplicationSourceManager {
 
     private final LogReplicationAckReader ackReader;
 
-    @VisibleForTesting
     private int countACKs = 0;
 
-    @VisibleForTesting
     private ObservableAckMsg ackMessages = new ObservableAckMsg();
 
     /**


### PR DESCRIPTION
## Overview
This PR brings back the tests added in PR [3644](https://github.com/CorfuDB/CorfuDB/pull/3644) which got reverted as part of LR v2 revert ([PR 3922](https://github.com/CorfuDB/CorfuDB/pull/3922))

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
