### PR TITLE
Restart the JVM when unrecoverable errors are encountered in the Batc…

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -106,9 +106,7 @@ public class BaseServer extends AbstractServer {
     }
 
     /**
-     * Reset the JVM. This mechanism leverages that corfu_server runs in a bash script
-     * which monitors the exit code of Corfu. If the exit code is 100, then it resets
-     * the server and DELETES ALL EXISTING DATA.
+     * Restart the CorfuServer and reset the server state by DELETING ALL EXISTING DATA.
      *
      * @param req The incoming request message.
      * @param ctx The channel context.
@@ -126,9 +124,7 @@ public class BaseServer extends AbstractServer {
     }
 
     /**
-     * Restart the JVM. This mechanism leverages that corfu_server runs in a bash script
-     * which monitors the exit code of Corfu. If the exit code is 200, then it restarts
-     * the server.
+     * Restart the CorfuServer. Do NOT reset any of the server state.
      *
      * @param req   The incoming request message.
      * @param ctx   The channel context.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -48,7 +48,7 @@ public class CorfuServer {
     // If set to true - triggers a reset of the server by wiping off all the data.
     private static volatile boolean cleanupServer = false;
     // Error code required to detect an ungraceful shutdown.
-    private static final int EXIT_ERROR_CODE = 100;
+    static final int EXIT_ERROR_CODE = 100;
 
     private static final String DEFAULT_METRICS_LOGGER_NAME = "org.corfudb.metricsdata";
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.BatchProcessor.BatchProcessorContext;
+import org.corfudb.infrastructure.BatchProcessor.ExitManager;
 import org.corfudb.infrastructure.health.Component;
 import org.corfudb.infrastructure.health.HealthMonitor;
 import org.corfudb.infrastructure.health.Issue;
@@ -60,8 +61,8 @@ import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getFlushCacheRe
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getInspectAddressesResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getKnownAddressResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getLogAddressSpaceResponseMsg;
-import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getRangeWriteLogResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getReadLogResponseMsg;
+import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getRangeWriteLogResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getResetLogUnitResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getTailResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getTrimLogResponseMsg;
@@ -527,8 +528,6 @@ public class LogUnitServer extends AbstractServer {
 
         serverContext.setLogUnitEpochWaterMark(req.getPayload().getResetLogUnitRequest().getEpoch());
 
-        batchProcessor.restart();
-
         batchProcessor.addTask(BatchWriterOperation.Type.RESET, req)
                 .thenRun(() -> {
                     dataCache.invalidateAll();
@@ -630,7 +629,7 @@ public class LogUnitServer extends AbstractServer {
                                            @Nonnull ServerContext serverContext,
                                            @Nonnull BatchProcessorContext batchProcessorContext) {
             return new BatchProcessor(
-                    streamLog, batchProcessorContext, serverContext.getServerEpoch(), !config.isNoSync()
+                    streamLog, batchProcessorContext, new ExitManager(), serverContext.getServerEpoch(), !config.isNoSync()
             );
         }
 


### PR DESCRIPTION
This patch disables the failure detector mechanism for BatchProcessor failures, introduced in PR3538, and replaces the recovery mechanism by restarting the JVM.  Due to a bug occurring during cluster reconfiguration, the heal node workflow was never exercising this mechanism.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
