### PR TITLE
Fix the Inconsistency in LR Sync Status when entering LOG_ENTRY_SYNC State

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -614,9 +614,45 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         logReplicationMetadataManager.setupTopologyConfigId(topologyDescriptor.getTopologyConfigId());
 
         if (isLeader.get()) {
-            // Reset the Replication Status on Active and Standby only for the leader node
+            // Clear the Replication Status on the leader node only.
             // Consider the case of async configuration changes, non-lead nodes could overwrite
             // the replication status if it has already completed by the lead node
+            // Note: For the cluster which was Active, this clear can race with the async 'replication stop'
+            // (stopLogReplication()) which updates the status table with STOPPED state.  So the status table
+            // can have 2 entries - 1 from the new Standby State showing the dataConsistent flag, and the other from
+            // the time it was Active, showing the replication status as 'STOPPED'.
+            // For example:
+            // Key:
+            //{
+            //  "clusterId": "b4c1ae3a-528a-4677-9f15-4a213ffd0da8"
+            //}
+            //
+            //Payload:
+            //{
+            //  "dataConsistent": true,
+            //  "status": "UNAVAILABLE"
+            //}
+            //                      and
+            //Key:
+            //{
+            //  "clusterId": "3c1bf6c7-70bd-4ad6-8a4f-7b4e5181ddb1"
+            //}
+            //
+            //Payload:
+            //{
+            //  "syncType": "LOG_ENTRY",
+            //  "status": "STOPPED",
+            //  "snapshotSyncInfo": {
+            //    "type": "FORCED",
+            //    "status": "COMPLETED",
+            //    "snapshotRequestId": "3671bdb0-d5ec-46cc-9c87-d1a9a2436083",
+            //    "completedTime": "2024-03-20T19:11:23.431973Z",
+            //    "baseSnapshot": "1575363"
+            //  }
+            //}
+            // This is a known limitation which can be ignored and does not have any functional impact.
+            // The limitation is because conflict detection between putRecord()(which sets the status to 'STOPPED') and
+            // clear() (clear of the table) is currently not available.
             resetReplicationStatusTableWithRetry();
             // In the event of Standby -> Active we should add the default replication values
             if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -345,13 +345,22 @@ public class LogReplicationAckReader {
         this.baseSnapshotTimestamp = baseSnapshotTimestamp;
     }
 
-    public void markSnapshotSyncInfoCompleted() {
+    /**
+     * This method updates the sync status on the Source cluster with:
+     * Sync Type = LOG_ENTRY
+     * Sync Status = ONGOING
+     * Additionally, it updates the timestamp and status of the last completed snapshot sync if
+     * updateSnapshotSyncInfo is true
+     * @param updateSnapshotSyncInfo
+     */
+    public void markLogEntrySyncOngoing(boolean updateSnapshotSyncInfo) {
         try {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     lock.lock();
-                    metadataManager.updateSnapshotSyncStatusCompleted(remoteClusterId,
-                            calculateRemainingEntriesToSend(baseSnapshotTimestamp), baseSnapshotTimestamp);
+                    metadataManager.setLogEntrySyncOngoing(remoteClusterId,
+                            calculateRemainingEntriesToSend(baseSnapshotTimestamp), updateSnapshotSyncInfo,
+                            baseSnapshotTimestamp);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to markSnapshotSyncInfoCompleted for remote cluster {}.", remoteClusterId, tae);
                     throw new RetryNeededException();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -362,19 +362,20 @@ public class LogReplicationAckReader {
                             calculateRemainingEntriesToSend(baseSnapshotTimestamp), updateSnapshotSyncInfo,
                             baseSnapshotTimestamp);
                 } catch (TransactionAbortedException tae) {
-                    log.error("Error while attempting to markSnapshotSyncInfoCompleted for remote cluster {}.", remoteClusterId, tae);
+                    log.error("Error while attempting markLogEntrySyncOngoing for remote cluster {}.", remoteClusterId,
+                        tae);
                     throw new RetryNeededException();
                 } finally {
                     lock.unlock();
                 }
 
                 if (log.isTraceEnabled()) {
-                    log.trace("markSnapshotSyncInfoCompleted succeeds for remote cluster {}.", remoteClusterId);
+                    log.trace("markLogEntrySyncOngoing succeeds for remote cluster {}.", remoteClusterId);
                 }
                 return null;
             }).run();
         } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to markSnapshotSyncInfoCompleted.", e);
+            log.error("Unrecoverable exception when attempting to markLogEntrySyncOngoing.", e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -154,7 +154,6 @@ public class InLogEntrySyncState implements LogReplicationState {
                 // Entry to this state can be 1)after a successful snapshot sync OR 2)after a simple restart or
                 // leadership change where a snapshot sync was not necessary.  In case 1), update the completion
                 // status and timestamp of the just-completed snapshot sync.
-                log.info("From Type = {}", from.getType());
                 fsm.getAckReader().markLogEntrySyncOngoing(
                     from.getType() == LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -154,6 +154,7 @@ public class InLogEntrySyncState implements LogReplicationState {
                 // Entry to this state can be 1)after a successful snapshot sync OR 2)after a simple restart or
                 // leadership change where a snapshot sync was not necessary.  In case 1), update the completion
                 // status and timestamp of the just-completed snapshot sync.
+                log.info("From Type = {}", from.getType());
                 fsm.getAckReader().markLogEntrySyncOngoing(
                     from.getType() == LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -517,6 +517,10 @@ public class LogReplicationMetadataManager {
             CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> record = txn.getRecord(replicationStatusTable, key);
 
             if (record.getPayload() == null) {
+                // If no record for the remote cluster is found, it means that no default status for it was set when
+                // that cluster was added to LR topology.  This is not expected and will eventually lead to a clear,
+                // bigger failure in LR so just log an error here instead of stopping the service.
+                log.error("Remote Cluster {} not found in Replication Status Table.  This is not expected!!!", clusterId);
                 return;
             }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -557,6 +557,8 @@ public class LogReplicationMetadataManager {
 
             txn.putRecord(replicationStatusTable, key, current, null);
             txn.commit();
+            log.info("Successfully set Log Entry Sync as ONGOING.  Previous snapshot sync info updated: {}",
+                    updateSnapshotSyncInfo);
         }
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -443,7 +443,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     }
 
     private void testStatusUpdatesFromSnapshotToLogEntrySync(boolean testReplicationStop) throws Exception {
-        initLogReplicationFSM(ReaderImplementation.STREAMS, false);
+        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
 
         final Table<ReplicationStatusKey, ReplicationStatusVal, Message> statusTable =
             this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -9,6 +9,7 @@ import org.corfudb.common.compression.Codec;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusKey;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
@@ -426,10 +427,26 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
      */
     @Test
     public void testSyncStatusUpdatesForSnapshotToLogEntryTransition() throws Exception {
+        testStatusUpdatesFromSnapshotToLogEntrySync(false);
+    }
+
+    /**
+     * Verify that the status table accurately reflects the sync type and status for a transition flow from
+     * initialized -> snapshot sync -> log entry sync -> initialized -> log entry sync
+     * Also verify that the Snapshot Sync info updated on transition to 1st log entry sync was retained after the 2nd
+     * entry to log entry sync.
+     * @throws Exception
+     */
+    @Test
+    public void testLogEntryTransitionAfterReplicationStop() throws Exception {
+        testStatusUpdatesFromSnapshotToLogEntrySync(true);
+    }
+
+    private void testStatusUpdatesFromSnapshotToLogEntrySync(boolean testReplicationStop) throws Exception {
         initLogReplicationFSM(ReaderImplementation.STREAMS, false);
 
         final Table<ReplicationStatusKey, ReplicationStatusVal, Message> statusTable =
-                this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE);
+            this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE);
 
         ReplicationStatusKey currentReplicationKey = ReplicationStatusKey.newBuilder().setClusterId(TEST_LOCAL_CLUSTER_ID).build();
         ReplicationStatusVal currentReplicationVal;
@@ -473,6 +490,34 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // for SnapshotSyncInfo should be COMPLETED
         Assert.assertEquals(SyncStatus.ONGOING, currentReplicationVal.getStatus());
         Assert.assertEquals(SyncStatus.COMPLETED, currentReplicationVal.getSnapshotSyncInfo().getStatus());
+
+        // Test the 2nd transition into Log Entry sync
+        if (testReplicationStop) {
+
+            // Capture the existing snapshot sync info
+            LogReplicationMetadata.SnapshotSyncInfo existingSnapshotSyncInfo = currentReplicationVal.getSnapshotSyncInfo();
+
+            // Transition back to Initialized state by enqueueing a REPLICATION_STOP event
+            transition(LogReplicationEventType.REPLICATION_STOP, LogReplicationStateType.INITIALIZED, snapshotSyncId,
+                    true);
+            assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.INITIALIZED);
+
+            // Transition to LogEntry sync state
+            transition(LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST, LogReplicationStateType.IN_LOG_ENTRY_SYNC, true);
+
+            // Read the replication status after 2nd transition into LogEntry sync state
+            try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+                currentReplicationVal = txn.getRecord(statusTable, currentReplicationKey).getPayload();
+            }
+
+            // Current SyncType should be LOG_ENTRY
+            Assert.assertEquals(SyncType.LOG_ENTRY, currentReplicationVal.getSyncType());
+
+            // Current SyncStatus for ReplicationInfo should be ONGOING, and SyncStatus for SnapshotSyncInfo should
+            // be unchanged from the previous value
+            Assert.assertEquals(SyncStatus.ONGOING, currentReplicationVal.getStatus());
+            Assert.assertEquals(existingSnapshotSyncInfo, currentReplicationVal.getSnapshotSyncInfo());
+        }
     }
 
     /**

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -305,8 +305,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // and then gets updated to ONGOING in entry of InLogEntrySyncState
         SyncStatus replicationSyncStatusAfterEntry = SyncStatus.ONGOING;
         // snapshotInfoSyncStatus (inner) starts as NOT_STARTED by initializeReplicationStatusTable,
-        // and then gets updated to COMPLETED in entry of InLogEntrySyncState
-        SyncStatus snapshotInfoSyncStatusAfterEntry = SyncStatus.COMPLETED;
+        // and does not get updated in entry of InLogEntrySyncState as no snapshot sync has been triggered in the test
+        SyncStatus snapshotInfoSyncStatusAfterEntry = SyncStatus.NOT_STARTED;
 
         Assert.assertEquals(expectedSyncTypes, actualSyncTypes);
         Assert.assertEquals(replicationSyncStatusAfterEntry, actualSyncStatus);
@@ -397,8 +397,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Set<SyncType> expectedSyncTypes = new HashSet<>(Collections.singletonList(SyncType.LOG_ENTRY));
         // Outer sync status should be ongoing for both updates
         Set<SyncStatus> expectedSyncStatus = new HashSet<>(Collections.singletonList(SyncStatus.ONGOING));
-        // Inner sync status should be completed for both updates
-        Set<SyncStatus> expectedSnapshotInfoSyncStatus = new HashSet<>(Collections.singletonList(SyncStatus.COMPLETED));
+        // Inner sync status for the last completed Snapshot Sync should be NOT_STARTED(the initial value on startup
+        // as no snapshot sync has been triggered).
+        Set<SyncStatus> expectedSnapshotInfoSyncStatus = new HashSet<>(Collections.singletonList(SyncStatus.NOT_STARTED));
         Set<SyncType> actualSyncTypes = new HashSet<>();
         Set<SyncStatus> actualSyncStatus = new HashSet<>();
         Set<SyncStatus> actualSnapshotInfoSyncStatus = new HashSet<>();
@@ -509,7 +510,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // Current SyncStatus for ReplicationInfo should be ONGOING, and SyncStatus
         // for SnapshotSyncInfo should be COMPLETED
         Assert.assertEquals(SyncStatus.ONGOING, currentReplicationVal.getStatus());
-        Assert.assertEquals(SyncStatus.COMPLETED, currentReplicationVal.getSnapshotSyncInfo().getStatus());
+        Assert.assertEquals(SyncStatus.NOT_STARTED, currentReplicationVal.getSnapshotSyncInfo().getStatus());
 
         // Transition #2: Snapshot Sync Request
         transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, true);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -247,8 +247,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     }
 
     /**
-     * Verify the lastSyncType flag is being initialized properly and SnapshotSyncInfo
-     * reflects accurate sync type for log entry sync.
+     * Verify the lastSyncType flag is being initialized properly and Log Entry and last snapshot sync info
+     * reflect the expected values.
      *
      */
     @Test


### PR DESCRIPTION
## Overview
Entry into LOG_ENTRY_SYNC state can be after 1)completion of a Snapshot Sync OR 2)a simple LR restart or leadership change where a Snapshot Sync was not performed.  The status of the last completed Snapshot Sync must be updated in case 1 but not in case 2.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
