### PR TITLE
LR: event listener resubscribe onError

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -60,8 +60,9 @@ public class LogReplicationMetadataManager {
     public static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
     public static final String LR_STATUS_STREAM_TAG = "lr_status";
     public static final String REPLICATION_EVENT_TABLE_NAME = "LogReplicationEventTable";
-    private static final String LR_STREAM_TAG = "log_replication";
+    public static final String LR_STREAM_TAG = "log_replication";
 
+    @Getter
     private final CorfuStore corfuStore;
 
     private final String metadataTableName;

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -79,4 +79,11 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
         final int totalNumMaps = 3;
         testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, true, true);
     }
+
+    @Test
+    public void testEventListenerE2E() throws Exception {
+        log.debug("Using plugin :: {}", pluginConfigFilePath);
+        final int totalNumMaps = 3;
+        testEventListenerEndToEnd(totalNumMaps);
+    }
 }

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -400,6 +400,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
             standbyListener.reset(new CountDownLatch(totalStandbyStatusUpdates));
 
             // Add an invalid entry to the table so the event listener's onError() gets called in a loop, giving the test to CP/trim
+            // (The eventId is empty, so the streamListener thread encounters an error while constructing DiscoveryServiceEvent)
             try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
                 txn.putRecord(replicationEventTable, key, LogReplicationMetadata.ReplicationEvent.newBuilder().build(), null);
                 txn.commit();


### PR DESCRIPTION
## Overview
This change is to automatically resubscribe to the event listener when the streaming task encounters an error.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
