### PR TITLE
LR: start eventListener on leadershipAcq, and stop on leadershipRel

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -360,7 +360,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         serverCallback.complete(interClusterReplicationService);
 
         logReplicationEventListener = new LogReplicationEventListener(this);
-        logReplicationEventListener.start();
         serverStarted = true;
     }
 
@@ -493,6 +492,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                             localNodeDescriptor, logReplicationMetadataManager, serverContext.getPluginConfigFilePath(),
                             getCorfuRuntime(), replicationConfigManager);
                 }
+                logReplicationEventListener.start();
                 replicationManager.setTopology(topologyDescriptor);
                 replicationManager.start();
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
@@ -576,6 +576,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     public void processLockRelease() {
         log.debug("Lock released");
         // Unset isLeader flag after stopping log replication
+        logReplicationEventListener.stop();
         stopLogReplication();
         isLeader.set(false);
         // Signal Log Replication Server/Sink to stop receiving messages, leadership loss
@@ -603,6 +604,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         // We do not update topology until we successfully stop log replication
         if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
             stopLogReplication();
+            logReplicationEventListener.stop();
         }
 
         // Update topology, cluster, and node configs


### PR DESCRIPTION
## Overview

Description:
Currently the listener is started on bootstrap on all the 3 nodes, but the events are processed only the leader node.
If an event arrives before a node becomes the leader, that event is notified to the listener, but since no one is the leader yet, that event gets ignored by all the nodes.

To fix this, we start the listener on leadershipAcquire

Test:
The CorfuReplicationClusterConfigIT.testEnforceSnapshotSync() test already covers a scenario where the event table contains a record before LR is started.
I tried to simulate the lock revoke (add an event when the cluster is not the leader and then make it a leader), but currently there is no way to deterministically stop the cluster from acquiring a lock. 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
