### PR TITLE
@rocksdb: Upgrade RocksDB JNI to 9.1

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
 
-        <rocksdb.version>8.9.1</rocksdb.version>
+        <rocksdb.version>9.1.1</rocksdb.version>
         <kryo.version>5.5.0</kryo.version>
         <kryo.serializers.version>0.45</kryo.serializers.version>
         <plexus.version>3.0.24</plexus.version>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CheckedRocksIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CheckedRocksIterator.java
@@ -7,6 +7,7 @@ import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksIteratorInterface;
+import org.rocksdb.Snapshot;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -181,6 +182,11 @@ public class CheckedRocksIterator implements RocksIteratorInterface, AutoCloseab
 
     @Override
     public void refresh() {
+        throw new UnsupportedOperationException("refresh");
+    }
+
+    @Override
+    public void refresh(Snapshot snapshot) throws RocksDBException {
         throw new UnsupportedOperationException("refresh");
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/WrappedRocksIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/WrappedRocksIterator.java
@@ -4,6 +4,7 @@ import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksIteratorInterface;
+import org.rocksdb.Snapshot;
 
 import java.nio.ByteBuffer;
 
@@ -144,6 +145,11 @@ public class WrappedRocksIterator implements RocksIteratorInterface {
 
     @Override
     public void refresh(){
+        throw new UnsupportedOperationException("refresh");
+    }
+
+    @Override
+    public void refresh(Snapshot snapshot) throws RocksDBException {
         throw new UnsupportedOperationException("refresh");
     }
 


### PR DESCRIPTION
This release brings support for batched implementation of multi-get which is leveraged by secondary indexes in disk-backed tables.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
