### PR TITLE
Minor tweak on compactor GC logging

### DIFF
--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -90,7 +90,7 @@ class CommandBuilder(object):
         if "PrintGCDetails" in GCParameters and GCParameters['PrintGCDetails'] is True:
             gc_str = '-Xlog:safepoint,gc*=debug:file=' + GCParameters["Logpath"]
             if 'PrintGCTimeStamps' in GCParameters and GCParameters['PrintGCTimeStamps'] is True:
-                gc_str += ':time'
+                gc_str += ':time,uptime,level'
             if 'UseGCLogFileRotation' in GCParameters and GCParameters['UseGCLogFileRotation'] is True:
                 gc_str += ':filecount=' + str(GCParameters['NumberOfGCLogFiles']) + ',filesize=' + GCParameters['GCLogFileSize']
             cmd.append(gc_str)
@@ -126,7 +126,6 @@ class CommandBuilder(object):
         cmd = []
         cmd.append("MALLOC_TRIM_THRESHOLD_=1310720")
         cmd.append("java")
-        cmd.append("-verbose:gc")
         cmd.append("-XX:+UseStringDeduplication")
         cmd.append("-XX:+HeapDumpOnOutOfMemoryError")
         cmd.append("-XX:+CrashOnOutOfMemoryError")


### PR DESCRIPTION
## Overview

Description:
1. Remove -verbose:gc since JDK 11 uses -Xlog.
2. Added uptime,level to timestamp for consistency.

Why should this be merged: 
-verbose:gc writes to stdout which gets redirected to corfu-compactor-audit.log. 
From Java 8 onwards, it's a good pratice to use only '-Xlog' to configure GC logging.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
