### PR TITLE
LR: few bug fixes on LR V1

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -360,7 +360,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         serverCallback.complete(interClusterReplicationService);
 
         logReplicationEventListener = new LogReplicationEventListener(this);
-        logReplicationEventListener.start();
         serverStarted = true;
     }
 
@@ -493,6 +492,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                             localNodeDescriptor, logReplicationMetadataManager, serverContext.getPluginConfigFilePath(),
                             getCorfuRuntime(), replicationConfigManager);
                 }
+                logReplicationEventListener.start();
                 replicationManager.setTopology(topologyDescriptor);
                 replicationManager.start();
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
@@ -576,6 +576,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     public void processLockRelease() {
         log.debug("Lock released");
         // Unset isLeader flag after stopping log replication
+        logReplicationEventListener.stop();
         stopLogReplication();
         isLeader.set(false);
         // Signal Log Replication Server/Sink to stop receiving messages, leadership loss
@@ -603,6 +604,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         // We do not update topology until we successfully stop log replication
         if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
             stopLogReplication();
+            logReplicationEventListener.stop();
         }
 
         // Update topology, cluster, and node configs

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -614,9 +614,45 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         logReplicationMetadataManager.setupTopologyConfigId(topologyDescriptor.getTopologyConfigId());
 
         if (isLeader.get()) {
-            // Reset the Replication Status on Active and Standby only for the leader node
+            // Clear the Replication Status on the leader node only.
             // Consider the case of async configuration changes, non-lead nodes could overwrite
             // the replication status if it has already completed by the lead node
+            // Note: For the cluster which was Active, this clear can race with the async 'replication stop'
+            // (stopLogReplication()) which updates the status table with STOPPED state.  So the status table
+            // can have 2 entries - 1 from the new Standby State showing the dataConsistent flag, and the other from
+            // the time it was Active, showing the replication status as 'STOPPED'.
+            // For example:
+            // Key:
+            //{
+            //  "clusterId": "b4c1ae3a-528a-4677-9f15-4a213ffd0da8"
+            //}
+            //
+            //Payload:
+            //{
+            //  "dataConsistent": true,
+            //  "status": "UNAVAILABLE"
+            //}
+            //                      and
+            //Key:
+            //{
+            //  "clusterId": "3c1bf6c7-70bd-4ad6-8a4f-7b4e5181ddb1"
+            //}
+            //
+            //Payload:
+            //{
+            //  "syncType": "LOG_ENTRY",
+            //  "status": "STOPPED",
+            //  "snapshotSyncInfo": {
+            //    "type": "FORCED",
+            //    "status": "COMPLETED",
+            //    "snapshotRequestId": "3671bdb0-d5ec-46cc-9c87-d1a9a2436083",
+            //    "completedTime": "2024-03-20T19:11:23.431973Z",
+            //    "baseSnapshot": "1575363"
+            //  }
+            //}
+            // This is a known limitation which can be ignored and does not have any functional impact.
+            // The limitation is because conflict detection between putRecord()(which sets the status to 'STOPPED') and
+            // clear() (clear of the table) is currently not available.
             resetReplicationStatusTableWithRetry();
             // In the event of Standby -> Active we should add the default replication values
             if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -9,26 +9,46 @@ import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.CorfuStreamEntry;
-import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.StreamListenerResumeOrFullSync;
 
+import java.util.Collections;
 import java.util.List;
 
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STREAM_TAG;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.NAMESPACE;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_EVENT_TABLE_NAME;
+
 @Slf4j
-public final class LogReplicationEventListener implements StreamListener {
+public final class LogReplicationEventListener extends StreamListenerResumeOrFullSync {
     private final CorfuReplicationDiscoveryService discoveryService;
 
     public  LogReplicationEventListener(CorfuReplicationDiscoveryService discoveryService) {
+        super(discoveryService.getLogReplicationMetadataManager().getCorfuStore(), NAMESPACE, LR_STREAM_TAG,
+                Collections.singletonList(REPLICATION_EVENT_TABLE_NAME));
         this.discoveryService = discoveryService;
     }
 
     public void start() {
         // perform full sync before subscribing to the table
+        CorfuStoreMetadata.Timestamp timestamp = performFullSync();
+        discoveryService.getLogReplicationMetadataManager().subscribeReplicationEventTable(this, timestamp);
+    }
+
+    @Override
+    public CorfuStoreMetadata.Timestamp performFullSync() {
+        log.info("Performing full sync of event table");
         Pair<List<CorfuStoreEntry<LogReplicationMetadata.ReplicationEventKey, ReplicationEvent, Message>>, CorfuStoreMetadata.Timestamp> eventsAndSubscriptionTs =
                 discoveryService.getLogReplicationMetadataManager().getoutstandingEvents();
         for(CorfuStoreEntry<LogReplicationMetadata.ReplicationEventKey, ReplicationEvent, Message> event: eventsAndSubscriptionTs.getLeft()) {
+            // The event table only contains force snapshot sync requests.
+            // Incase there are multiple snapshot sync requests already enqueued by now, process any one of them.
+            // Upon successfully processing an event, clear the event table. This ensures that LR doesn't perform
+            // snapshot sync unnecessarily in a loop.
             processEvent(event.getPayload());
+            break;
         }
-        discoveryService.getLogReplicationMetadataManager().subscribeReplicationEventTable(this, eventsAndSubscriptionTs.getValue());
+
+        return eventsAndSubscriptionTs.getRight();
     }
 
     public void stop() {
@@ -74,10 +94,5 @@ public final class LogReplicationEventListener implements StreamListener {
                     event.getClusterId(),
                     event.getEventId()));
         }
-    }
-
-    @Override
-    public void onError(Throwable throwable) {
-        log.error("onError with a throwable ", throwable);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -24,7 +24,7 @@ public final class LogReplicationEventListener implements StreamListener {
     public void start() {
         // perform full sync before subscribing to the table
         Pair<List<CorfuStoreEntry<LogReplicationMetadata.ReplicationEventKey, ReplicationEvent, Message>>, CorfuStoreMetadata.Timestamp> eventsAndSubscriptionTs =
-                discoveryService.getLogReplicationMetadataManager().getReplicationEventTable();
+                discoveryService.getLogReplicationMetadataManager().getoutstandingEvents();
         for(CorfuStoreEntry<LogReplicationMetadata.ReplicationEventKey, ReplicationEvent, Message> event: eventsAndSubscriptionTs.getLeft()) {
             processEvent(event.getPayload());
         }
@@ -44,7 +44,6 @@ public final class LogReplicationEventListener implements StreamListener {
                 log.info("The onNext call with {} will be skipped as the current node as it is not the leader.", results);
                 return;
             }
-
 
             log.info("LogReplicationEventListener onNext {} will be processed at node {} in the cluster {}",
                     results, discoveryService.getLocalNodeDescriptor(), discoveryService.getLocalClusterDescriptor());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -345,27 +345,37 @@ public class LogReplicationAckReader {
         this.baseSnapshotTimestamp = baseSnapshotTimestamp;
     }
 
-    public void markSnapshotSyncInfoCompleted() {
+    /**
+     * This method updates the sync status on the Source cluster with:
+     * Sync Type = LOG_ENTRY
+     * Sync Status = ONGOING
+     * Additionally, it updates the timestamp and status of the last completed snapshot sync if
+     * updateSnapshotSyncInfo is true
+     * @param updateSnapshotSyncInfo
+     */
+    public void markLogEntrySyncOngoing(boolean updateSnapshotSyncInfo) {
         try {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     lock.lock();
-                    metadataManager.updateSnapshotSyncStatusCompleted(remoteClusterId,
-                            calculateRemainingEntriesToSend(baseSnapshotTimestamp), baseSnapshotTimestamp);
+                    metadataManager.setLogEntrySyncOngoing(remoteClusterId,
+                            calculateRemainingEntriesToSend(baseSnapshotTimestamp), updateSnapshotSyncInfo,
+                            baseSnapshotTimestamp);
                 } catch (TransactionAbortedException tae) {
-                    log.error("Error while attempting to markSnapshotSyncInfoCompleted for remote cluster {}.", remoteClusterId, tae);
+                    log.error("Error while attempting markLogEntrySyncOngoing for remote cluster {}.", remoteClusterId,
+                        tae);
                     throw new RetryNeededException();
                 } finally {
                     lock.unlock();
                 }
 
                 if (log.isTraceEnabled()) {
-                    log.trace("markSnapshotSyncInfoCompleted succeeds for remote cluster {}.", remoteClusterId);
+                    log.trace("markLogEntrySyncOngoing succeeds for remote cluster {}.", remoteClusterId);
                 }
                 return null;
             }).run();
         } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to markSnapshotSyncInfoCompleted.", e);
+            log.error("Unrecoverable exception when attempting to markLogEntrySyncOngoing.", e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -119,7 +119,6 @@ public class InSnapshotSyncState implements LogReplicationState {
                 // If cancel was intended for current snapshot sync task, cancel and transition to new state
                 if (fsm.isValidTransition(transitionSyncId, event.getMetadata().getSyncId())) {
                     cancelSnapshotSync("cancellation request.");
-                    // Re-trigger SnapshotSync due to error, generate a new event Id for the new snapshot sync
                     LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
                     // If the cancelled sync is a force snapshot sync, retain the syncID. This is to track and clear
                     // the snapshot sync requests in the eventTable

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -186,7 +186,7 @@ public class WaitSnapshotApplyState implements LogReplicationState {
 
     private void deleteForcedSyncRequestFromEventTable() {
         List<CorfuStoreEntry<LogReplicationMetadata.ReplicationEventKey, LogReplicationMetadata.ReplicationEvent, Message>> eventsEnqueued =
-                fsm.getAckReader().getMetadataManager().getReplicationEventTable().getLeft();
+                fsm.getAckReader().getMetadataManager().getoutstandingEvents().getLeft();
 
         for(CorfuStoreEntry<LogReplicationMetadata.ReplicationEventKey, LogReplicationMetadata.ReplicationEvent, Message> event : eventsEnqueued) {
             if (event.getPayload() != null && event.getPayload().getEventId().equals(transitionSyncId.toString())) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -60,8 +60,9 @@ public class LogReplicationMetadataManager {
     public static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
     public static final String LR_STATUS_STREAM_TAG = "lr_status";
     public static final String REPLICATION_EVENT_TABLE_NAME = "LogReplicationEventTable";
-    private static final String LR_STREAM_TAG = "log_replication";
+    public static final String LR_STREAM_TAG = "log_replication";
 
+    @Getter
     private final CorfuStore corfuStore;
 
     private final String metadataTableName;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -762,8 +762,6 @@ public class LogReplicationMetadataManager {
 
         long currentSnapshotSyncIdLong = currentSnapshotSyncId.getMostSignificantBits() & Long.MAX_VALUE;
 
-        // Update if current Snapshot Sync differs from the persisted one, otherwise ignore.
-        // It could have already been updated in the case that leader changed in between a snapshot sync cycle
         appendUpdate(txn, LogReplicationMetadataType.CURRENT_SNAPSHOT_CYCLE_ID, currentSnapshotSyncIdLong);
         appendUpdate(txn, LogReplicationMetadataType.CURRENT_CYCLE_MIN_SHADOW_STREAM_TS, shadowStreamTs.getSequence());
     }
@@ -795,7 +793,7 @@ public class LogReplicationMetadataManager {
         }
     }
 
-    public Pair<List<CorfuStoreEntry<ReplicationEventKey, ReplicationEvent, Message>>, CorfuStoreMetadata.Timestamp> getReplicationEventTable() {
+    public Pair<List<CorfuStoreEntry<ReplicationEventKey, ReplicationEvent, Message>>, CorfuStoreMetadata.Timestamp> getoutstandingEvents() {
         List<CorfuStoreEntry<ReplicationEventKey, ReplicationEvent, Message>> outstandingEvents;
         CorfuStoreMetadata.Timestamp ts;
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -387,7 +387,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      *
      * @param entry a SNAPSHOT_START message
      */
-    private void processSnapshotStart(LogReplication.LogReplicationEntryMsg entry) {
+    private synchronized void processSnapshotStart(LogReplication.LogReplicationEntryMsg entry) {
         long topologyId = entry.getMetadata().getTopologyConfigID();
         long timestamp = entry.getMetadata().getSnapshotTimestamp();
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -79,4 +79,11 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
         final int totalNumMaps = 3;
         testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, true, true);
     }
+
+    @Test
+    public void testEventListenerE2E() throws Exception {
+        log.debug("Using plugin :: {}", pluginConfigFilePath);
+        final int totalNumMaps = 3;
+        testEventListenerEndToEnd(totalNumMaps);
+    }
 }

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -1,5 +1,6 @@
 package org.corfudb.integration;
 
+import com.google.protobuf.Message;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuInterClusterReplicationServer;
@@ -60,6 +61,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_EVENT_TABLE_NAME;
 import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_STATUS_TABLE;
 import static org.junit.Assert.fail;
 
@@ -151,23 +153,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
             log.debug("Wait ... Delta log replication in progress ...");
             verifyDataOnStandbyNonUFO((numWrites + (numWrites / 2)));
         } finally {
-            executorService.shutdownNow();
-
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
-            }
-
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
-            }
-
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
-            }
-
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
-            }
+            tearDown();
         }
 
     }
@@ -256,23 +242,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
             }
 
         } finally {
-            executorService.shutdownNow();
-
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
-            }
-
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
-            }
-
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
-            }
-
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
-            }
+            tearDown();
         }
     }
 
@@ -321,6 +291,170 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
 
         assertThat(replicationStatusVal.getRemainingEntriesToSend()).isEqualTo(0);
+    }
+
+    /**
+     * This test verifies that the eventListener is resubscribed correctly when the streaming layer encounters an error.
+     * 1. Validate that the setup created is stable by validating the snapshot_sync data
+     * 2. Add a valid force snapshot_sync event in the event Table.
+     * 3. Ensure that the snapshot sync was completed for the event and the event is effectively removed once processed
+     * 4. Add an invalid record to the event table. This makes the eventListener in LR stall by repeatedly trying to
+     * read the invalid record and encountering an error.
+     * While LR is in that state, delete theinvalid event and run the CP/trim twice. This results in the listener
+     * hitting the Trimmed Exception.
+     * 5. Write a valid force snapshot_sync event in the event Table.
+     * A successful snapshot sync indicates that the eventListener was able to resubscribe to the eventTable even after encountering few errors.
+     */
+    protected void testEventListenerEndToEnd(int totalNumMaps) throws Exception {
+        // For the purpose of this test, standby should only update status 2 times:
+        // (1) When starting snapshot sync apply : is_data_consistent = false
+        // (2) When completing snapshot sync apply : is_data_consistent = true
+        final int totalStandbyStatusUpdates = 2;
+
+        try {
+            log.info(">> Setup active and standby Corfu's");
+            setupActiveAndStandbyCorfu();
+
+            // Subscribe to replication status table on Standby (to be sure data change on status are captured)
+            corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+                    REPLICATION_STATUS_TABLE,
+                    LogReplicationMetadata.ReplicationStatusKey.class,
+                    LogReplicationMetadata.ReplicationStatusVal.class,
+                    null,
+                    TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+
+            Table<LogReplicationMetadata.ReplicationEventKey, LogReplicationMetadata.ReplicationEvent, Message> replicationEventTable =
+                    corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+                    REPLICATION_EVENT_TABLE_NAME,
+                    LogReplicationMetadata.ReplicationEventKey.class,
+                    LogReplicationMetadata.ReplicationEvent.class,
+                    null,
+                    TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationEvent.class));
+
+            CountDownLatch statusUpdateLatch = new CountDownLatch(totalStandbyStatusUpdates);
+            ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
+            corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+                    LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+
+            log.info(">> Open map(s) on active and standby");
+            openMaps(totalNumMaps, false);
+
+            log.info(">> Write data to active CorfuDB before LR is started ...");
+            // Add Data for Snapshot Sync
+            writeToActive(0, numWrites);
+
+            // Confirm data does exist on Active Cluster
+            for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+                assertThat(map.count()).isEqualTo(numWrites);
+            }
+
+            // Confirm data does not exist on Standby Cluster
+            for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+                assertThat(map.count()).isZero();
+            }
+
+            startLogReplicatorServers();
+
+            // Verify Standby Status Listener received all expected updates (is_data_consistent)
+            log.info(">> Wait ... Replication status UPDATE ...");
+            statusUpdateLatch.await();
+
+            verifyDataOnStandby(numWrites);
+
+            // Confirm replication status reflects snapshot sync completed
+            log.info(">> Verify replication status completed on active");
+            verifyReplicationStatusFromActive();
+
+            verifySnapshotSync(standbyListener, totalStandbyStatusUpdates);
+
+            //reset the listener
+            standbyListener.reset(new CountDownLatch(totalStandbyStatusUpdates));
+
+
+            LogReplicationMetadata.ReplicationEventKey key = LogReplicationMetadata.ReplicationEventKey
+                    .newBuilder().setKey(UUID.randomUUID().toString()).build();
+            LogReplicationMetadata.ReplicationEvent event = LogReplicationMetadata.ReplicationEvent.newBuilder()
+                    .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                    .setEventId(UUID.randomUUID().toString())
+                    .setType(LogReplicationMetadata.ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC)
+                    .build();
+
+            // add a valid snapshot sync event in the event table
+            try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+                txn.putRecord(replicationEventTable, key, event, null);
+                txn.commit();
+            }
+
+            standbyListener.countDownLatch.await();
+            verifySnapshotSync(standbyListener, totalStandbyStatusUpdates);
+
+            while(replicationEventTable.count() != 0) {
+                //wait
+            }
+            // verify the event table is cleared after an event is processed
+            try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+                assertThat(txn.getTable(REPLICATION_EVENT_TABLE_NAME).count()).isZero();
+            }
+
+            //reset the listener
+            standbyListener.reset(new CountDownLatch(totalStandbyStatusUpdates));
+
+            // Add an invalid entry to the table so the event listener's onError() gets called in a loop, giving the test to CP/trim
+            // (The eventId is empty, so the streamListener thread encounters an error while constructing DiscoveryServiceEvent)
+            try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+                txn.putRecord(replicationEventTable, key, LogReplicationMetadata.ReplicationEvent.newBuilder().build(), null);
+                txn.commit();
+            }
+
+            // delete the invalid entry, so the full sync upon resubscription doesn't see the invalid record
+            try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+                txn.delete(replicationEventTable, key);
+                txn.commit();
+            }
+
+            // run CP twice so the listener hits a trimmed exception
+            checkpointAndTrim(true);
+            checkpointAndTrim(true);
+
+            // add a valid entry and ensure that the listener process it
+            try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+                txn.putRecord(replicationEventTable, key, event, null);
+                txn.commit();
+            }
+            standbyListener.countDownLatch.await();
+            verifySnapshotSync(standbyListener, totalStandbyStatusUpdates);
+
+
+        } finally {
+            tearDown();
+        }
+    }
+
+    private void verifySnapshotSync(ReplicationStatusListener standbyListener, int totalStandbyStatusUpdates) {
+        assertThat(standbyListener.getAccumulatedStatus().size()).isEqualTo(totalStandbyStatusUpdates);
+        // Confirm last updates are set to true (corresponding to snapshot sync completed and log entry sync started)
+        assertThat(standbyListener.getAccumulatedStatus().get(standbyListener.getAccumulatedStatus().size() - 1)).isTrue();
+        assertThat(standbyListener.getAccumulatedStatus()).contains(false);
+    }
+
+    private void tearDown() {
+        executorService.shutdownNow();
+
+        if (activeCorfu != null) {
+            activeCorfu.destroy();
+        }
+
+        if (standbyCorfu != null) {
+            standbyCorfu.destroy();
+        }
+
+        if (activeReplicationServer != null) {
+            activeReplicationServer.destroy();
+        }
+
+        if (standbyReplicationServer != null) {
+            standbyReplicationServer.destroy();
+        }
     }
 
     private void verifyReplicationStatusFromActive() throws Exception {
@@ -400,7 +534,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         @Getter
         List<Boolean> accumulatedStatus = new ArrayList<>();
 
-        private final CountDownLatch countDownLatch;
+        private CountDownLatch countDownLatch;
         private boolean waitSnapshotStatusComplete;
 
         public ReplicationStatusListener(CountDownLatch countdownLatch, boolean waitSnapshotStatusComplete) {
@@ -426,6 +560,11 @@ public class LogReplicationAbstractIT extends AbstractIT {
         @Override
         public void onError(Throwable throwable) {
             fail("onError for ReplicationStatusListener : " + throwable.toString());
+        }
+
+        private void reset(CountDownLatch countdownLatch) {
+            this.countDownLatch = countdownLatch;
+            accumulatedStatus.clear();
         }
     }
 


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
contains the following fixes:
[LR: remove stopSnapshotApply gating from WaitSnapshotApply]
[LR: start eventListener on leadershipAcq, and stop on leadershipRel]
[LR: event listener resubscribe onError]
[Fix the Inconsistency in LR Sync Status when entering LOG_ENTRY_SYNC]
[Clear Event Table on Force Sync Completion]

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
