### PR TITLE
JVM Safepoint Metrics

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -40,11 +40,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>11</release>
+                    <source>11</source>
+                    <target>11</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>true</showDeprecation>
                     <compilerArgs>
                         <arg>-XDignore.symbol.file</arg>
+                        <arg>--add-exports</arg>
+                        <arg>java.management/sun.management=ALL-UNNAMED</arg>
                     </compilerArgs>
                     <fork>true</fork>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -357,11 +357,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>11</release>
+                    <source>11</source>
+                    <target>11</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>false</showDeprecation>
                     <compilerArgs>
                         <arg>-XDignore.symbol.file</arg>
+                        <arg>--add-exports</arg>
+                        <arg>java.management/sun.management=ALL-UNNAMED</arg>
                     </compilerArgs>
                     <fork>true</fork>
                 </configuration>

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -68,6 +68,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.corfudb.common.metrics.micrometer.JVMMetrics.subscribeSafepointMetrics;
 import static org.corfudb.common.util.URLUtils.getVersionFormattedEndpointURL;
 
 /**


### PR DESCRIPTION
## Overview
In Java11, the JVM's safepoint logging is very verbose. Since we are only interested int stop-the-world (STW) pauses this patch tracks STW latencies with a micrometer gauge, which reports it as 2-log lines per 1min.


Why should this be merged: Required to help debug clustering/latency issues related to JVM pauses 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
