### PR TITLE
@disk-backed-table: make index alias optional

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>net.jqwik</groupId>
             <artifactId>jqwik</artifactId>
-            <version>1.7.3</version>
+            <version>1.8.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
When defining secondary indexes, make index name (alias) optional. The previous implementation assumed that both the name and the path are mandatory.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
