### PR TITLE
Decrease Compactor heartbeat interval to 8 seconds

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointLivenessUpdater.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointLivenessUpdater.java
@@ -28,7 +28,7 @@ public class CheckpointLivenessUpdater implements LivenessUpdater {
 
     private volatile Optional<TableName> currentTable = Optional.empty();
 
-    private static final Duration UPDATE_INTERVAL = Duration.ofSeconds(15);
+    private static final Duration UPDATE_INTERVAL = Duration.ofSeconds(8);
 
     private final Table<TableName, ActiveCPStreamMsg, Message> activeCheckpointsTable;
 
@@ -91,12 +91,12 @@ public class CheckpointLivenessUpdater implements LivenessUpdater {
     }
 
     @Override
-    public void updateLiveness(TableName tableName) {
+    public void setCurrentTable(TableName tableName) {
         this.currentTable = Optional.of(tableName);
     }
 
     @Override
-    public void notifyOnSyncComplete() {
+    public void unsetCurrentTable() {
         currentTable = Optional.empty();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -186,7 +186,9 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
             // as the latter discards holes for resolution, hence if last address is a hole it would diverge
             // from the stream address space maintained by the sequencer.
 
-            livenessUpdater.ifPresent(LivenessUpdater::notifyOnSyncComplete);
+            // After the table has been synced, stop updating heartbeat for it.
+            // The liveness will start to be checked via checkpoint stream tail.
+            livenessUpdater.ifPresent(LivenessUpdater::unsetCurrentTable);
 
             startCheckpoint(snapshotTimestamp);
             int entryCount = appendObjectState(entries);

--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
@@ -166,7 +166,7 @@ public abstract class DistributedCheckpointer {
         log.info("{} Starting checkpoint: {}${}", clientName,
                 tableName.getNamespace(), tableName.getTableName());
 
-        this.livenessUpdater.updateLiveness(tableName);
+        this.livenessUpdater.setCurrentTable(tableName);
         StatusType returnStatus = StatusType.FAILED;
         for (int retry = 0; retry < MAX_RETRIES; retry++) {
             CheckpointWriter<ICorfuTable<?,?>> cpw = null;
@@ -188,7 +188,7 @@ public abstract class DistributedCheckpointer {
                 }
              }
         }
-        this.livenessUpdater.notifyOnSyncComplete();
+        this.livenessUpdater.unsetCurrentTable();
         return CheckpointingStatus.newBuilder()
                 .setStatus(returnStatus).setClientName(clientName)
                 .setCycleCount(compactorCycleCount).setTimeTaken(System.currentTimeMillis() - tableCkptStartTime)

--- a/runtime/src/main/java/org/corfudb/runtime/LivenessUpdater.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LivenessUpdater.java
@@ -3,9 +3,9 @@ package org.corfudb.runtime;
 public interface LivenessUpdater {
     void start();
 
-    void updateLiveness(CorfuStoreMetadata.TableName tableName);
+    void setCurrentTable(CorfuStoreMetadata.TableName tableName);
 
-    void notifyOnSyncComplete();
+    void unsetCurrentTable();
 
     void shutdown();
 }

--- a/test/src/test/java/org/corfudb/integration/LivenessUpdaterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LivenessUpdaterIT.java
@@ -88,13 +88,13 @@ public class LivenessUpdaterIT extends AbstractIT {
             Assert.fail("Transaction Failed due to " + e.getStackTrace());
         }
 
-        livenessUpdater.updateLiveness(tableNameBuilder);
+        livenessUpdater.setCurrentTable(tableNameBuilder);
         try {
             TimeUnit.SECONDS.sleep(interval.getSeconds());
         } catch (InterruptedException e) {
             System.out.println("Sleep interrupted: " + e);
         }
-        livenessUpdater.notifyOnSyncComplete();
+        livenessUpdater.unsetCurrentTable();
 
         try (TxnContext txn = store.txn(CORFU_SYSTEM_NAMESPACE)) {
             CorfuCompactorManagement.ActiveCPStreamMsg newStatus = (CorfuCompactorManagement.ActiveCPStreamMsg)

--- a/test/src/test/java/org/corfudb/runtime/CheckpointLivenessUpdaterUnitTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CheckpointLivenessUpdaterUnitTest.java
@@ -55,13 +55,13 @@ public class CheckpointLivenessUpdaterUnitTest {
         when((ActiveCPStreamMsg) corfuStoreEntry.getPayload()).thenReturn(activeCPStreamMsg);
 
         livenessUpdater.start();
-        livenessUpdater.updateLiveness(tableName);
+        livenessUpdater.setCurrentTable(tableName);
         try {
             TimeUnit.SECONDS.sleep(INTERVAL.getSeconds());
         } catch (InterruptedException e) {
             log.warn("Sleep interrupted: ", e);
         }
-        livenessUpdater.notifyOnSyncComplete();
+        livenessUpdater.unsetCurrentTable();
 
         ArgumentCaptor<ActiveCPStreamMsg> captor = ArgumentCaptor.forClass(ActiveCPStreamMsg.class);
         verify(txn).putRecord(any(), any(), captor.capture(), any());
@@ -73,9 +73,9 @@ public class CheckpointLivenessUpdaterUnitTest {
         ActiveCPStreamMsg activeCPStreamMsg = ActiveCPStreamMsg.newBuilder().setSyncHeartbeat(0).build();
         when((ActiveCPStreamMsg) corfuStoreEntry.getPayload()).thenReturn(activeCPStreamMsg);
 
-        livenessUpdater.updateLiveness(tableName);
+        livenessUpdater.setCurrentTable(tableName);
         livenessUpdater.updateHeartbeat();
-        livenessUpdater.notifyOnSyncComplete();
+        livenessUpdater.unsetCurrentTable();
 
         livenessUpdater.updateHeartbeat();
 
@@ -92,13 +92,13 @@ public class CheckpointLivenessUpdaterUnitTest {
                 .thenReturn(activeCPStreamMsg);
         livenessUpdater.start();
 
-        livenessUpdater.updateLiveness(tableName);
+        livenessUpdater.setCurrentTable(tableName);
         try {
             TimeUnit.SECONDS.sleep(INTERVAL.getSeconds()*2);
         } catch (InterruptedException e) {
             log.warn("Sleep interrupted: ", e);
         }
-        livenessUpdater.notifyOnSyncComplete();
+        livenessUpdater.unsetCurrentTable();
 
         ArgumentCaptor<ActiveCPStreamMsg> captor = ArgumentCaptor.forClass(ActiveCPStreamMsg.class);
         verify(txn).putRecord(any(), any(), captor.capture(), any());

--- a/test/src/test/java/org/corfudb/runtime/DistributedCheckpointerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/DistributedCheckpointerTest.java
@@ -552,7 +552,7 @@ public class DistributedCheckpointerTest extends AbstractViewTest {
                     ActiveCPStreamMsg.getDefaultInstance(),
                     null);
             txn.commit();
-            mockLivenessUpdater.updateLiveness(table);
+            mockLivenessUpdater.setCurrentTable(table);
         }
 
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -568,7 +568,7 @@ public class DistributedCheckpointerTest extends AbstractViewTest {
 
         try {
             TimeUnit.MILLISECONDS.sleep(WAIT_IN_SYNC_STATE);
-            mockLivenessUpdater.notifyOnSyncComplete();
+            mockLivenessUpdater.unsetCurrentTable();
 
             distributedCheckpointer.checkpointTables();
             while (!pollForFinishCheckpointing()) {

--- a/test/src/test/java/org/corfudb/runtime/MockLivenessUpdater.java
+++ b/test/src/test/java/org/corfudb/runtime/MockLivenessUpdater.java
@@ -57,7 +57,7 @@ public class MockLivenessUpdater implements LivenessUpdater {
     }
 
     @Override
-    public void updateLiveness(TableName tableName) {
+    public void setCurrentTable(TableName tableName) {
         this.tableName = tableName;
         // update validity counter every 250ms
         executorService = Executors.newSingleThreadScheduledExecutor();
@@ -100,7 +100,7 @@ public class MockLivenessUpdater implements LivenessUpdater {
     }
 
     @Override
-    public void notifyOnSyncComplete() {
+    public void unsetCurrentTable() {
         executorService.shutdownNow();
         changeStatus();
     }


### PR DESCRIPTION
Currently checkpointer heartbeat is checked every 10 seconds, but it's updated by checkpointer every 15 seconds, resulting in noisy logs (i.e. HeartBeat not moving forward for table).

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
