### PR TITLE
Copy GC logs for LR JVM from /dev/shm to the LR logs directory.

### DIFF
--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -232,12 +232,19 @@ class CompactorRunner(object):
         with open(self._config.configPath, "r") as config:
             compactor_config = yaml.load(config, yaml.FullLoader)
         corfu_paths = compactor_config["CorfuPaths"]
+        log_replicator_paths = None
+        if "LogReplicator" in compactor_config:
+            log_replicator_paths = compactor_config["LogReplicatorPaths"]
+
         logging.basicConfig(filename=corfu_paths["CompactorLogfile"],
                     format='%(asctime)s.%(msecs)03dZ %(levelname)5s Runner - %(message)s',
                     datefmt='%Y-%m-%dT%H:%M:%S')
-        # Copy mem jvm gc log files to disk
+        # Copy Corfu and LogReplicator(if running) jvm gc log files to disk
         try:
             self._rsync_log(corfu_paths["CorfuMemLogPrefix"], corfu_paths["CorfuDiskLogDir"])
+            if log_replicator_paths is not None:
+                self._rsync_log(log_replicator_paths["LogReplicatorMemLogPrefix"],
+                                log_replicator_paths["LogReplicatorDiskLogDir"])
         except Exception as ex:
             self._print_and_log("Failed to run rsync_log " + " error: " + str(ex))
 

--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -233,7 +233,7 @@ class CompactorRunner(object):
             compactor_config = yaml.load(config, yaml.FullLoader)
         corfu_paths = compactor_config["CorfuPaths"]
         log_replicator_paths = None
-        if "LogReplicator" in compactor_config:
+        if "LogReplicatorPaths" in compactor_config:
             log_replicator_paths = compactor_config["LogReplicatorPaths"]
 
         logging.basicConfig(filename=corfu_paths["CompactorLogfile"],
@@ -242,7 +242,7 @@ class CompactorRunner(object):
         # Copy Corfu and LogReplicator(if running) jvm gc log files to disk
         try:
             self._rsync_log(corfu_paths["CorfuMemLogPrefix"], corfu_paths["CorfuDiskLogDir"])
-            if log_replicator_paths is not None and os.path.isdir(corfu_paths["LogReplicatorDiskLogDir"]):
+            if log_replicator_paths is not None and os.path.isdir(log_replicator_paths["LogReplicatorDiskLogDir"]):
                 self._rsync_log(log_replicator_paths["LogReplicatorMemLogPrefix"],
                                 log_replicator_paths["LogReplicatorDiskLogDir"])
         except Exception as ex:

--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -242,7 +242,7 @@ class CompactorRunner(object):
         # Copy Corfu and LogReplicator(if running) jvm gc log files to disk
         try:
             self._rsync_log(corfu_paths["CorfuMemLogPrefix"], corfu_paths["CorfuDiskLogDir"])
-            if log_replicator_paths is not None:
+            if log_replicator_paths is not None and os.path.isdir(corfu_paths["LogReplicatorDiskLogDir"]):
                 self._rsync_log(log_replicator_paths["LogReplicatorMemLogPrefix"],
                                 log_replicator_paths["LogReplicatorDiskLogDir"])
         except Exception as ex:


### PR DESCRIPTION
Description:
Currently, the compactor script copies GC logs for Corfu Server JVM from /dev/shm to Corfu's log directory.  Similarly, GC logs for LR JVM should be copied to the respective log directory.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
