### PR TITLE
@disk-backed-table: Add support for block-cache

### DIFF
--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -38,6 +38,7 @@ message PersistenceOptions {
     optional ConsistencyModel consistencyModel = 2;
     optional SizeComputationModel sizeComputationModel = 3;
     optional int64 writeBufferSize = 4; // In bytes.
+    optional int32 blockCacheIndex = 5; // In bytes.
 }
 
 message ReplicationLogicalGroup {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -40,6 +40,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static org.corfudb.runtime.object.PersistenceOptions.DISABLE_BLOCK_CACHE;
+
 /**
  * Wrapper over the CorfuTable.
  * It accepts a primary key - which is a protobuf message.
@@ -238,6 +240,17 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
             }
             if (tableParameters.getPersistenceOptions().hasWriteBufferSize()) {
                 persistenceOptions.writeBufferSize(Optional.of(tableParameters.getPersistenceOptions().getWriteBufferSize()));
+            }
+
+            if (tableParameters.getPersistenceOptions().hasBlockCacheIndex()) {
+                final int blockCacheIndex = tableParameters.getPersistenceOptions().getBlockCacheIndex();
+                if (blockCacheIndex == DISABLE_BLOCK_CACHE) {
+                    persistenceOptions.disableBlockCache(true);
+                    log.info("Disabling block cache for this table.");
+                } else {
+                    log.info("Using block cache with index {} for this table.", blockCacheIndex);
+                    persistenceOptions.blockCache(Optional.of(PersistenceOptions.getBlockCache(blockCacheIndex)));
+                }
             }
 
             ISerializer safeSerializer = new SafeProtobufSerializer(serializer);

--- a/runtime/src/main/java/org/corfudb/runtime/object/PersistenceOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/PersistenceOptions.java
@@ -2,19 +2,29 @@ package org.corfudb.runtime.object;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuOptions.ConsistencyModel;
 import org.corfudb.runtime.CorfuOptions.SizeComputationModel;
+import org.rocksdb.Cache;
+import org.rocksdb.LRUCache;
+import org.rocksdb.RocksDB;
 
 import java.nio.file.Path;
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Reflects {@link org.corfudb.runtime.CorfuOptions.PersistenceOptions}
+ * Reflects {@link CorfuOptions.PersistenceOptions}
  * since Protobuf does not allow for explicit default options
  */
+@Slf4j
 @Getter
 @Builder
 public class PersistenceOptions {
+    public static final int DISABLE_BLOCK_CACHE = -1;
+    private static final ConcurrentHashMap<Integer, Cache> blockCacheMap = new ConcurrentHashMap<>();
 
     Path dataPath;
 
@@ -27,4 +37,65 @@ public class PersistenceOptions {
     @Builder.Default
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     Optional<Long> writeBufferSize = Optional.empty();
+
+    @Builder.Default
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    Optional<Cache> blockCache = Optional.empty();
+
+    @Builder.Default
+    boolean disableBlockCache = false;
+
+    public static synchronized Cache getBlockCache(int blockCacheIndex) {
+        if (!blockCacheMap.containsKey(blockCacheIndex)) {
+            throw new NoSuchElementException("Specified block cache does not exist.");
+        }
+
+        return blockCacheMap.get(blockCacheIndex);
+    }
+
+    /**
+     * Create a new block cache and return its index. The client is
+     * responsible for disposing of the object cache when no longer
+     * needed. See {@link PersistenceOptions::disposeBlockCache}.
+     * <p>
+     * For usage patterns, please take a look at
+     * CorfuStoreShimTest::testBlockCache.
+     *
+     * @param size The size of a block cache in bytes.
+     * @return A handle to the new block cache.
+     */
+    synchronized public static int newBlockCache(int size) {
+        synchronized (blockCacheMap) {
+            RocksDB.loadLibrary();
+
+            final int index = blockCacheMap.size();
+            blockCacheMap.put(index, new LRUCache(size));
+            log.info("Creating new block cache of size {} at index {}.", size, index);
+            return index;
+        }
+    }
+
+    /**
+     * Dispose of the previously created block cache.
+     *
+     * @param index Previously return block cache index.
+     */
+    public static void disposeBlockCache(int index) {
+        synchronized (blockCacheMap) {
+            RocksDB.loadLibrary();
+
+            if (index >= blockCacheMap.size() || index < 0) {
+                log.info("Invalid block cache at index {}.", index);
+                return;
+            }
+
+            if (blockCacheMap.get(index) == null) {
+                log.info("Block cache at index {} already disposed.", index);
+                return;
+            }
+
+            log.info("Disposing block cache at index {}.", index);
+            blockCacheMap.remove(index).close();
+        }
+    }
 }


### PR DESCRIPTION
Allow clients to set and/or share the underlying block cache between multiple disk-backed tables.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
