### PR TITLE
@disk-backed-tables: Change reporting frequency

### DIFF
--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -39,6 +39,12 @@ message PersistenceOptions {
     optional SizeComputationModel sizeComputationModel = 3;
     optional int64 writeBufferSize = 4; // In bytes.
     optional int32 blockCacheIndex = 5; // In bytes.
+
+    // Observability settings start at index 100.
+
+    // How often should RocksDB statistics be gathered.
+    // For example, 5 would indicate every 5th iteration.
+    optional uint32 reportingFrequency = 100;
 }
 
 message ReplicationLogicalGroup {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -241,6 +241,10 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
             if (tableParameters.getPersistenceOptions().hasWriteBufferSize()) {
                 persistenceOptions.writeBufferSize(Optional.of(tableParameters.getPersistenceOptions().getWriteBufferSize()));
             }
+            if (tableParameters.getPersistenceOptions().hasReportingFrequency()) {
+                final long reportingFrequency = tableParameters.getPersistenceOptions().getReportingFrequency();
+                persistenceOptions.reportingFrequency(reportingFrequency);
+            }
 
             if (tableParameters.getPersistenceOptions().hasBlockCacheIndex()) {
                 final int blockCacheIndex = tableParameters.getPersistenceOptions().getBlockCacheIndex();

--- a/runtime/src/main/java/org/corfudb/runtime/object/PersistenceOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/PersistenceOptions.java
@@ -45,6 +45,9 @@ public class PersistenceOptions {
     @Builder.Default
     boolean disableBlockCache = false;
 
+    @Builder.Default
+    Long reportingFrequency = 5L;
+
     public static synchronized Cache getBlockCache(int blockCacheIndex) {
         if (!blockCacheMap.containsKey(blockCacheIndex)) {
             throw new NoSuchElementException("Specified block cache does not exist.");

--- a/test/src/test/java/org/corfudb/runtime/collections/PersistedCorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/PersistedCorfuTableTest.java
@@ -1296,7 +1296,7 @@ public class PersistedCorfuTableTest extends AbstractViewTest implements AutoClo
     public void testExternalProvider() throws InterruptedException, IOException {
         final Logger logger = Mockito.mock(Logger.class);
         final List<String> logMessages = new ArrayList<>();
-        final CountDownLatch countDownLatch = new CountDownLatch(10);
+        final CountDownLatch countDownLatch = new CountDownLatch(100);
         final String tableFolderName = "metered-table";
 
         Mockito.doAnswer(invocation -> {
@@ -1310,7 +1310,7 @@ public class PersistedCorfuTableTest extends AbstractViewTest implements AutoClo
             }
         }).when(logger).debug(logCaptor.capture());
 
-        final Duration loggingInterval = Duration.ofMillis(100);
+        final Duration loggingInterval = Duration.ofMillis(10);
         initClientMetrics(logger, loggingInterval, PersistedCorfuTableTest.class.toString());
 
         PersistedCorfuTable<String, String> table = setupTable(tableFolderName);


### PR DESCRIPTION
Reduce the frequency at which RocksDB statistics will be reported. Also, allow the clients to specify the frequency if needed.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
