### PR TITLE
[Fix] Flakey tests in LogReplicationFSMTest

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -840,7 +840,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     public void testTransitionFromInSnapshotSyncWhenMultipleSnapshotSync() throws Exception {
         observeTransitions = true;
 
-        initLogReplicationFSM(ReaderImplementation.STREAMS, false);
+        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
 
         // Initial state: Initialized
         LogReplicationState initState = fsm.getState();
@@ -898,7 +898,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     @Test
     public void testTransitionFromWaitSnapshotApplyWhenMultipleSnapshotSync() throws Exception {
 
-        initLogReplicationFSM(ReaderImplementation.STREAMS, false);
+        initLogReplicationFSM(ReaderImplementation.EMPTY, false);
 
         // Initial state: Initialized
         LogReplicationState initState = fsm.getState();
@@ -913,9 +913,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         transition(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE, LogReplicationStateType.IN_SNAPSHOT_SYNC, snapshotSync, true);
 
         // Transition #3: transfer completed -> WAIT_SNAPSHOT_APPLY
-        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY,snapshotSync, true);
+        transition(LogReplicationEventType.SNAPSHOT_TRANSFER_COMPLETE, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, snapshotSync, true);
 
-        // Transition #4: sync cancel from a different snapshot event -> Ignored, reaming in WAIT_SNAPSHOT_APPLY
+        // Transition #4: sync cancel from a different snapshot event -> Ignored, remain in WAIT_SNAPSHOT_APPLY
         transition(LogReplicationEventType.SYNC_CANCEL, LogReplicationStateType.WAIT_SNAPSHOT_APPLY, UUID.randomUUID(), false);
 
         assertThat(fsm.getState().getTransitionSyncId()).isEqualTo(snapshotSync);


### PR DESCRIPTION
## Overview

Description:

Using `ReaderImplementation.STREAMS` can cause flakyness in the fsm tests where we just want to verify FSM transitions. Since a mock implementation for the data sender is used it is possible to get NPEs that can cause additional transitions that can throw off the checks in the test.  `ReaderImplementation.EMPTY` avoids this so just the transitions made in the test occur.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
