### PR TITLE
Fix Dockerfile to run Corfu Server from image.

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -24,6 +24,11 @@ COPY target/logback.prod.xml /usr/share/corfu/conf/logback.prod.xml
 COPY target/corfu-compactor-config.yml /usr/share/corfu/conf/corfu-compactor-config.yml
 COPY target/compactor-logback.prod.xml /usr/share/corfu/conf/compactor-logback.prod.xml
 
+# Create directories and files required for running Corfu Server
+RUN mkdir -p /config
+RUN mkdir -p /var/log/corfu/
+RUN touch /var/log/corfu/corfu.jvm.gc.9000.log
+
 # For integration testing purposes
 COPY target/${CORFU_JAR} /app/corfu.jar
 
@@ -44,4 +49,6 @@ CMD java -cp *.jar \
     org.corfudb.infrastructure.CorfuServer \
     --compactor-script /usr/share/corfu/scripts/compactor_runner.py \
     --compactor-config=/usr/share/corfu/conf/corfu-compactor-config.yml \
-    --compaction-trigger-freq-ms=900000
+    --compaction-trigger-freq-ms=900000 \
+    --log-path /config \
+    9000

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -27,7 +27,6 @@ COPY target/compactor-logback.prod.xml /usr/share/corfu/conf/compactor-logback.p
 # Create directories and files required for running Corfu Server
 RUN mkdir -p /config
 RUN mkdir -p /var/log/corfu/
-RUN touch /var/log/corfu/corfu.jvm.gc.9000.log
 
 # For integration testing purposes
 COPY target/${CORFU_JAR} /app/corfu.jar


### PR DESCRIPTION
## Overview

Description:
Create necessary directories and files -
/config
/var/log/corfu/
/var/log/corfu/corfu.jvm.gc.9000.log

Add the required args of the log path and port -
    --log-path /config \
    9000

Testing Done:
Verified that corfu servers runs with a docker image
 ```
 .ci/infrastructure-docker-build.sh docker
 docker run -ti --rm docker.io/corfudb-universe/corfu-server:0.4.0-SNAPSHOT
 ```

Why should this be merged: 
The current corfu server images fail to run a corfu server container due to runtime errors. This CL fixes these errors.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
