### PR TITLE
Bump corfu version to 0.4.2.0

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'CorfuDB/corfudb-cloud'
+          ref: corfu-0.4.2.0
 
       - name: install helm package manager
         working-directory: ./cloud/corfu
@@ -55,7 +56,7 @@ jobs:
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
           chmod 700 get_helm.sh
           ./get_helm.sh
-          
+
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
 
@@ -72,9 +73,9 @@ jobs:
         working-directory: ./cloud/corfu
         run: |
           helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.8.0 --set installCRDs=true
-          
+
           helm install corfu corfu --set persistence.enabled=true --set global.replicas=3 --set image.pullPolicy=IfNotPresent --set image.registry=""
-          
+
           sleep 120
 
       - name: check deployment status

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'CorfuDB/corfudb-cloud'
+          ref: corfu-0.4.2.0
 
       - name: Build universe-core
         working-directory: ./universe

--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: 'CorfuDB/corfudb-cloud'
+          ref: corfu-0.4.2.0
 
       - name: Build universe-core
         working-directory: ./universe

--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -1,4 +1,4 @@
-name: CorfuDB Artifacts
+name: Publish CorfuDB Artifacts
 
 on:
   push:

--- a/corfudb-tools/README
+++ b/corfudb-tools/README
@@ -15,7 +15,7 @@ stream tags for a table, display all known stream tags, etc.
 
 1. showTable to read and output all entries in a given table and namespace.
 It can be invoked like the below example-
-java -cp "/path/to/corfudb-tools-0.4.0-SNAPSHOT-shaded.jar"
+java -cp "/path/to/corfudb-tools-0.4.2.0-SNAPSHOT-shaded.jar"
 org.corfudb.browser.CorfuStoreBrowserMain
 --host=10.160.29.112
 --port=9000
@@ -30,7 +30,7 @@ org.corfudb.browser.CorfuStoreBrowserMain
 
 2. listTables to list all table names in a given namespace(all namespaces if the
 namespace param is null)-
-java -cp "corfudb-tools-0.4.0-SNAPSHOT-shaded.jar" --Dlogback.configurationFile=logback.prod.xml
+java -cp "corfudb-tools-0.4.2.0-SNAPSHOT-shaded.jar" --Dlogback.configurationFile=logback.prod.xml
 org.corfudb.browser.CorfuBrowserMain
 --host=10.160.29.112
 --port=9000
@@ -45,7 +45,7 @@ org.corfudb.browser.CorfuBrowserMain
 Keystore and truststore parameters are not required if tls is disabled.
 
 For usage help,
-java -cp "corfudb-tools-0.4.0-SNAPSHOT-shaded.jar" org.corfudb.browser.CorfuStoreBrowserMain <--help|-h>
+java -cp "corfudb-tools-0.4.2.0-SNAPSHOT-shaded.jar" org.corfudb.browser.CorfuStoreBrowserMain <--help|-h>
 
 
 -------
@@ -53,7 +53,7 @@ Editor
 -------
 editTable to edit the value associated with a key in a given table and
 namespace-
-java -cp "corfudb-tools-0.4.0-SNAPSHOT-shaded.jar" --Dlogback.configurationFile=logback.prod.xml
+java -cp "corfudb-tools-0.4.2.0-SNAPSHOT-shaded.jar" --Dlogback.configurationFile=logback.prod.xml
 org.corfudb.browser.CorfuBrowserMain
 --host=10.160.29.112
 --port=9000

--- a/infrastructure/src/main/resources/corfu_plugin_config.properties
+++ b/infrastructure/src/main/resources/corfu_plugin_config.properties
@@ -1,16 +1,16 @@
 # Transport Plugin Configuration (Plugin)
-transport_adapter_JAR_path=/infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+transport_adapter_JAR_path=/infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationClientChannelAdapter
 
 # Stream Fetcher Configuration (Plugin)
-stream_fetcher_plugin_JAR_path=/infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+stream_fetcher_plugin_JAR_path=/infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultStreamFetcherPlugin
 
 # Topology Manager Configuration (Plugin)
-topology_manager_adapter_JAR_path=/infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=/infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
 
 # Snapshot Sync Configuration (Plugin)
-snapshot_sync_plugin_JAR_path=/infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+snapshot_sync_plugin_JAR_path=/infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin

--- a/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
@@ -42,7 +42,7 @@ public class CorfuClusterParams<T extends CorfuServerParams> implements GroupPar
             ContainerResources.builder().build();
 
     /**
-     * Corfu server version, for instance: 0.4.0-SNAPSHOT
+     * Corfu server version, for instance: 0.0.0.0-SNAPSHOT
      */
     @NonNull
     @Getter

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
@@ -69,7 +69,7 @@ public class CorfuServerParams implements NodeParams {
     private final ContainerResources containerResources;
 
     /**
-     * Corfu server version, for instance: 0.4.0-SNAPSHOT
+     * Corfu server version, for instance: 0.0.0.0-SNAPSHOT
      */
     @NonNull
     private final String serverVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
-        <revision>0.4.0-SNAPSHOT</revision>
+        <revision>0.4.2.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <logback.classic.version>1.2.11</logback.classic.version>

--- a/test/src/test/resources/transport/grpcConfig.properties
+++ b/test/src/test/resources/transport/grpcConfig.properties
@@ -1,5 +1,5 @@
 # Transport Plugin Configuration
-transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationClientChannelAdapter
 
@@ -8,7 +8,7 @@ stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.1-SNA
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter
 
 # Topology Manager Plugin Configuration
-topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
 
 # Snapshot Sync Configuration (Plugin)

--- a/test/src/test/resources/transport/nettyConfig.properties
+++ b/test/src/test/resources/transport/nettyConfig.properties
@@ -1,16 +1,16 @@
 # Transport Plugin Configuration
-transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter
 
 # Stream Fetcher Plugin Configuration
-stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter
 
 # Topology Manager Configuration
-topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
 
 # Snapshot Sync Configuration (Plugin)
-snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin

--- a/test/src/test/resources/transport/nettyConfigUpgradeActive.properties
+++ b/test/src/test/resources/transport/nettyConfigUpgradeActive.properties
@@ -1,16 +1,16 @@
 # Transport Plugin Configuration
-transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter
 
 # Stream Fetcher Plugin Configuration
-stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultAdapterForUpgradeActive
 
 # Topology Manager Configuration
-topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
 
 # Snapshot Sync Configuration (Plugin)
-snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin

--- a/test/src/test/resources/transport/nettyConfigUpgradeStandby.properties
+++ b/test/src/test/resources/transport/nettyConfigUpgradeStandby.properties
@@ -1,16 +1,16 @@
 # Transport Plugin Configuration
-transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter
 
 # Stream Fetcher Plugin Configuration
-stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultAdapterForUpgradeStandby
 
 # Topology Manager Configuration
-topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
 
 # Snapshot Sync Configuration (Plugin)
-snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
+snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.2.0-SNAPSHOT.jar
 snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin


### PR DESCRIPTION
Description:
Increase the corfu version to 0.4.2.0-SNAPSHOT for the 420 release.

Why should this be merged: Currently it has an outdated value - 0.4.0-SNAPSHOT. This CL updates it.

Related issue(s) (if applicable): #


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
