### PR TITLE
A New Snapshot Sync is rejected on the Standby During Apply Phase of Current Sync

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerCmdLine.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerCmdLine.java
@@ -49,6 +49,7 @@ public class CorfuServerCmdLine {
                     + "[" + HEALTH_PORT_PARAM + "=<health_port>]"
                     + "[--snapshot-batch=<batch-size>] [--lock-lease=<lease-duration>]"
                     + "[--max-snapshot-entries-applied=<max-snapshot-entries-applied>]"
+                    + "[--wait-before-apply-ms=<wait_before_apply_ms>]"
                     + "[-P <prefix>] [-R <retention>] <port>"
                     + "[--compaction-trigger-freq-ms=<compaction_trigger_freq_ms>]"
                     + "[--compactor-script=<compactor_script_path>]"

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -309,6 +309,11 @@ public class ServerContext implements AutoCloseable {
         return val == null ? DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED : Integer.parseInt(val);
     }
 
+    public int getSnapshotApplyWaitTime() {
+        String val = getServerConfig(String.class, "--wait-before-apply-ms");
+        return val == null ? 0 : Integer.parseInt(val);
+    }
+
     /**
      * Cleanup the DataStore files with names that are prefixes of the specified
      * fileName when so that the number of these files don't exceed the user-defined

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -65,7 +65,7 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                     + "[-b] [-g -o <username_file> -j <password_file>] "
                     + "[-k <seqcache>] [-T <threads>] [-B <size>] [-i <channel-implementation>] "
                     + "[-H <seconds>] [-I <cluster-id>] [-x <ciphers>] [-z <tls-protocols>]] "
-                    + "[--disable-cert-expiry-check-file=<file_path>]"
+                    + "[--disable-cert-expiry-check-file=<file_path>] [--wait-before-apply-ms=<wait_before_apply_ms>]"
                     + "[--metrics]"
                     + "[-P <prefix>] [-R <retention>] <port>\n"
                     + "\n"
@@ -195,7 +195,9 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                     + " -h, --help                                                               "
                     + "              Show this screen\n"
                     + " --version                                                                "
-                    + "              Show version\n";
+                    + "              Show version\n"
+                    + " --wait-before-apply-ms=<wait_before_apply_ms>                                  "
+                    + "             Duration in ms to wait before before starting the apply phase [default: 0] \n";
 
     // Active Corfu Server Node.
     private volatile CorfuInterClusterReplicationServerNode activeServer;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -268,7 +268,7 @@ public class LogReplicationSinkManager implements DataReceiver {
 
         if (isMessageFromNewSnapshotSync(message) && ongoingApply.get()) {
             log.warn("Drop message {}.  A Snapshot Apply is already ongoing.  Not accepting messages from a new " +
-                "Snapshot Sync Cycle");
+                "Snapshot Sync Cycle", message);
             return null;
         }
 
@@ -312,14 +312,10 @@ public class LogReplicationSinkManager implements DataReceiver {
     }
 
     private boolean isMessageFromNewSnapshotSync(LogReplication.LogReplicationEntryMsg message) {
-        if ((message.getMetadata().getEntryType() == LogReplicationEntryType.SNAPSHOT_START ||
+        return ((message.getMetadata().getEntryType() == LogReplicationEntryType.SNAPSHOT_START ||
             message.getMetadata().getEntryType() == LogReplicationEntryType.SNAPSHOT_MESSAGE ||
             message.getMetadata().getEntryType() == LogReplicationEntryType.SNAPSHOT_END) &&
-            !Objects.equals(getUUID(message.getMetadata().getSyncRequestId()), lastSnapshotSyncId))
-        {
-           return true;
-        }
-        return false;
+            !Objects.equals(getUUID(message.getMetadata().getSyncRequestId()), lastSnapshotSyncId));
     }
 
     /**

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -407,6 +407,19 @@ public class AbstractIT extends AbstractCorfuTest {
                 .runServer();
     }
 
+    public Process runReplicationServerWaitInSnapshotApply(int port, String pluginConfigFilePath,
+                                                           int lockLeaseDuration, int waitInSnapshotApplyMs)
+                                                        throws IOException {
+        return new CorfuReplicationServerRunner()
+            .setHost(DEFAULT_HOST)
+            .setPort(port)
+            .setLockLeaseDuration(lockLeaseDuration)
+            .setPluginConfigFilePath(pluginConfigFilePath)
+            .setMsg_size(MSG_SIZE)
+            .setWaitSnapshotApplyMs(waitInSnapshotApplyMs)
+            .runServer();
+    }
+
     public Process runReplicationServerCustomMaxWriteSize(int port,
                                                           String pluginConfigFilePath, int maxWriteSize,
                                                           int maxEntriesApplied) throws IOException {
@@ -719,6 +732,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private Integer lockLeaseDuration;
         private int maxWriteSize = 0;
         private int maxSnapshotEntriesApplied;
+        private int waitSnapshotApplyMs;
 
         /**
          * Create a command line string according to the properties set for a Corfu Server
@@ -780,6 +794,10 @@ public class AbstractIT extends AbstractCorfuTest {
 
             if (maxSnapshotEntriesApplied != 0) {
                 command.append(" --max-snapshot-entries-applied=").append(maxSnapshotEntriesApplied);
+            }
+
+            if (waitSnapshotApplyMs != 0) {
+                command.append(" --wait-before-apply-ms=").append(waitSnapshotApplyMs);
             }
 
             command.append(" -d ").append(logLevel).append(" ")

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -340,7 +340,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
                         DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC);
                     txn.commit();
                 }
-                TimeUnit.SECONDS.sleep(waitTimeBetweenSyncRequestsMs);
+                TimeUnit.MILLISECONDS.sleep(waitTimeBetweenSyncRequestsMs);
             }
 
             // Wait for the forced sync events to be added to the event table

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -807,6 +807,24 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
+    public void startStandbyLogReplicator(int waitSnapshotApplyMs) {
+        try {
+            if (runProcess) {
+                // Start Log Replication Server on Active Site
+                standbyReplicationServer = runReplicationServerWaitInSnapshotApply(standbyReplicationServerPort, pluginConfigFilePath,
+                    lockLeaseDuration, waitSnapshotApplyMs);
+            } else {
+                executorService.submit(() -> {
+                    CorfuInterClusterReplicationServer.main(new String[]{"-m", "--plugin=" + pluginConfigFilePath,
+                        "--wait-before-apply-ms=" + waitSnapshotApplyMs, "--address=localhost",
+                        String.valueOf(standbyReplicationServerPort)});
+                });
+            }
+        } catch (Exception e) {
+            log.debug("Error caught while running Log Replication Server");
+        }
+    }
+
     public void verifyDataOnStandbyNonUFO(int expectedConsecutiveWrites) {
         // Wait until data is fully replicated
         while (mapAStandby.count() != expectedConsecutiveWrites) {


### PR DESCRIPTION
Description:
If an existing snapshot sync is in the apply phase, a new incoming snapshot sync is rejected until the apply phase has completed.  This is because the 2 syncs can race when updating metadata and the shared shadow streams.

Background on Alternate Solution Considered:
An alternate solution is to halt the apply phase when a conflict is detected.  This is not ideal as data is already inconsistent during this phase, user APIs are blocked and there is no straightforward way to 'roll-back' a partial apply.  Besides, the apply phase was added by design to minimize keeping the state inconsistent(apply phase starts after all data is transferred so that network or infra glitches do not impact user apis).

Why should this be merged:

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc


Race Handling Workflow After the Fix
===============================
1st Snapshot Sync Starts
```
2024-07-19T00:14:15.016Z | INFO  |              discovery-service | .r.LogReplicationSourceManager | Start Snapshot Sync, requestId=ec240c8d-e438-466c-82ba-ffc551209978, forced=true
``` 

Transfer Complete.  Receiver will now be in the apply phase of this sync.
```
2024-07-19T00:14:15.090Z | INFO  |           state-machine-worker |  o.c.i.l.r.send.SnapshotSender | Snapshot sync transfer completed for ec240c8d-e438-466c-82ba-ffc551209978 on timestamp=37, ack=entry_type: SNAPSHOT_TRANSFER_COMPLETE timestamp: -1 previousTimestamp: -1 syncRequestId { lsb: -9026621280176006792 msb: -1431004978038159764 } snapshotTimestamp: 37 snapshotSyncSeqNum: 3
``` 

2nd Switchover Received
```
2024-07-19T00:14:18.019Z | INFO  |              discovery-service | .r.LogReplicationSourceManager | Start Snapshot Sync, requestId=029a8016-1428-404c-968a-234d9085e673, forced=true
``` 

Receiver ignores incoming messages from the new sync.  No ACKs will be received on the Sender and it continues to resend the messages
```
2024-07-19T00:14:18.036Z | WARN  |         LogReplicationServer-0 | .r.r.LogReplicationSinkManager | Snapshot Apply for sync id ec240c8d-e438-466c-82ba-ffc551209978 is already ongoing.  Not accepting messages from a new Snapshot Sync Cycle.  Dropping message
``` 

Finally, the 1st snapshot sync is applied on the receiver and it accepts the new snapshot sync.
```
2024-07-19T00:14:38.098Z | INFO  |           state-machine-worker |  o.c.i.l.r.send.SnapshotSender | Snapshot sync transfer completed for 029a8016-1428-404c-968a-234d9085e673 on timestamp=43, ack=entry_type: SNAPSHOT_TRANSFER_COMPLETE timestamp: -1 previousTimestamp: -1 syncRequestId { lsb: -7599222605190142349 msb: 187603166805114956 } snapshotTimestamp: 43 snapshotSyncSeqNum: 3
``` 

The new sync is successfully applied
```
2024-07-19T00:14:58.167Z | INFO  |           state-machine-worker | i.l.r.f.WaitSnapshotApplyState | Snapshot sync apply is complete appliedTs=43, baseTs=43
``` 

All other forced snapshot sync requests are deleted from the event table
```
2024-07-19T00:14:58.172Z | INFO  |       replication-fsm-consumer | i.l.r.f.WaitSnapshotApplyState | Finished processing event 029a8016-1428-404c-968a-234d9085e673. Flushing all events from the event table
``` 