### PR TITLE
Pin Docker to 24.0.9

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -38,8 +38,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: build docker image
         run: .ci/infrastructure-docker-build.sh docker ${{ matrix.jdk_base_image }}

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -37,8 +37,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare top of trunk docker image
         run: .ci/infrastructure-docker-build.sh compatibility

--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -37,8 +37,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare top of trunk docker image
         run: |

--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -43,8 +43,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare Corfu
         run: |

--- a/.github/workflows/universe-test.yml
+++ b/.github/workflows/universe-test.yml
@@ -33,8 +33,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare Corfu
         run: .ci/infrastructure-docker-build.sh docker

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -31,7 +31,7 @@
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
             <classifier>shaded</classifier>
-            <version>8.11.7</version>
+            <version>8.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
## Overview
Spotify client doesn't work with the latest docker
as it gives an error -
 Cannot construct instance of
 `com.spotify.docker.client.messages.Image`,
 problem: Null virtualSize

This commit pins the docker version to 24.0.9
temporarily until a permanent solution is in place
and also updates the Spotify docker client version to 8.16.0.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
