### PR TITLE
Remove GC Log Syncing

### DIFF
--- a/infrastructure/src/main/resources/corfu-compactor-config.yml
+++ b/infrastructure/src/main/resources/corfu-compactor-config.yml
@@ -15,8 +15,6 @@ ConfigFiles:
 
 CorfuPaths:
   CompactorLogfile: /var/log/corfu/corfu-compactor-audit.log
-  CorfuMemLogPrefix: /dev/shm/corfu.jvm.gc.
-  CorfuDiskLogDir: /var/log/corfu/jvm
 
 MemoryOptions:
   DiskBacked: yes


### PR DESCRIPTION
## Overview
JRE17 introduced -Xlog:async which will write GC logs asynchronously and not pause the JVM during STW events if secondary storage is slow. This patch removes the previous process that copied and synced log files from /dev/shm to /var/log.

Why should this be merged: Simplifies logging

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
