### PR TITLE
Upgrade Netty from 4.1.89 to 4.1.111

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -1,9 +1,11 @@
 package org.corfudb.infrastructure.logreplication.transport.sample;
 
+import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import io.grpc.internal.PickFirstLoadBalancerProvider;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationChannelGrpc;
@@ -70,6 +72,8 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         this.connectionFuture = new CompletableFuture<>();
         this.requestObserverMap = new ConcurrentHashMap<>();
         this.responseObserverMap = new ConcurrentHashMap<>();
+
+        LoadBalancerRegistry.getDefaultRegistry().register(new PickFirstLoadBalancerProvider());
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
@@ -1,7 +1,9 @@
 package org.corfudb.infrastructure.logreplication.transport.sample;
 
+import io.grpc.LoadBalancerRegistry;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.internal.PickFirstLoadBalancerProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
@@ -42,6 +44,8 @@ public class GRPCLogReplicationServerChannelAdapter extends IServerChannelAdapte
         // a single-threaded executor here.
         this.server = ServerBuilder.forPort(port).addService(service)
                 .executor(Executors.newSingleThreadScheduledExecutor()).build();
+
+        LoadBalancerRegistry.getDefaultRegistry().register(new PickFirstLoadBalancerProvider());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
 
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
-        <netty.version>4.1.89.Final</netty.version>
-        <netty.tcnative.version>2.0.60.Final</netty.tcnative.version>
-        <protobuf.version>3.21.7</protobuf.version>
+        <netty.version>4.1.111.Final</netty.version>
+        <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
+        <protobuf.version>3.21.12</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.30</lombok.version>
         <guava.version>32.1.2-jre</guava.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -24,7 +24,7 @@
         <annotations.api.version>6.0.53</annotations.api.version>
         <ehcahce.sizeOf.version>0.4.0</ehcahce.sizeOf.version>
 
-        <grpc.version>1.54.0</grpc.version>
+        <grpc.version>1.65.1</grpc.version>
     </properties>
 
     <build>


### PR DESCRIPTION
- Also upgrade grpc, protobuf and netty-tcnative. 

```
grpc.version 1.65.1
netty.version 4.1.111.Final
netty.tcnative.version 2.0.61.Final
protobuf.version 3.21.12
```

Compatibility: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty

- Fixes OSS-TP vulnerabilities - [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487), [CVE-2023-34462](https://nvd.nist.gov/vuln/detail/CVE-2023-34462), [CVE-2024-29025](https://nvd.nist.gov/vuln/detail/CVE-2024-29025)

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
