### PR TITLE
Allow caller to specify a source version number

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -436,6 +436,11 @@ public class CorfuRuntime {
          */
         private int streamingSchedulerPollThreshold = 5;
 
+        /**
+         * Allow the caller to specify a different source/build number to identify protobuf upgrades
+         */
+        long sourceCodeVersion = GitRepositoryState.getCorfuSourceCodeVersion();
+
         public static CorfuRuntimeParametersBuilder builder() {
             return new CorfuRuntimeParametersBuilder();
         }
@@ -476,6 +481,7 @@ public class CorfuRuntime {
             private Duration streamingPollPeriod = Duration.ofMillis(50);
             private int streamingSchedulerPollBatchSize = 25;
             private int streamingSchedulerPollThreshold = 5;
+            private long sourceCodeVersion = GitRepositoryState.getCorfuSourceCodeVersion();
             private boolean cacheWrites = true;
             private String clientName = "CorfuClient";
             private long checkpointTriggerFreqMillis = 0;
@@ -497,6 +503,11 @@ public class CorfuRuntime {
 
             public CorfuRuntimeParametersBuilder streamingSchedulerPollThreshold(int streamingSchedulerPollThreshold) {
                 this.streamingSchedulerPollThreshold = streamingSchedulerPollThreshold;
+                return this;
+            }
+
+            public CorfuRuntimeParametersBuilder sourceCodeVersion(long sourceCodeVersion) {
+                this.sourceCodeVersion = sourceCodeVersion;
                 return this;
             }
 
@@ -859,6 +870,7 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setStreamingPollPeriod(streamingPollPeriod);
                 corfuRuntimeParameters.setStreamingSchedulerPollBatchSize(streamingSchedulerPollBatchSize);
                 corfuRuntimeParameters.setStreamingSchedulerPollThreshold(streamingSchedulerPollThreshold);
+                corfuRuntimeParameters.setSourceCodeVersion(sourceCodeVersion);
                 corfuRuntimeParameters.setCacheWrites(cacheWrites);
                 corfuRuntimeParameters.setClientName(clientName);
                 corfuRuntimeParameters.setCheckpointTriggerFreqMillis(checkpointTriggerFreqMillis);

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -460,7 +460,7 @@ public class TableRegistry {
      * @param tableDescriptorsBuilder Builder instance.
      * @param rootFileDescriptor      File descriptor to be added.
      */
-    public static void insertAllDependingFileDescriptorProtos(TableDescriptors.Builder tableDescriptorsBuilder,
+    public void insertAllDependingFileDescriptorProtos(TableDescriptors.Builder tableDescriptorsBuilder,
                                                               FileDescriptor rootFileDescriptor,
                                                               Map<ProtobufFileName, CorfuRecord<ProtobufFileDescriptor, TableMetadata>>
                                                                       allDescriptors) {
@@ -485,12 +485,12 @@ public class TableRegistry {
             // are not deterministically constructed. So we can tell if we are coming up after
             // a fresh upgrade, we conservatively record the git repo version in each proto file
             // and update it if this version were to be different.
-            long corfuCodeVersion = GitRepositoryState.getCorfuSourceCodeVersion();
+            long sourceCodeVersion = runtime.getParameters().getSourceCodeVersion();
             ProtobufFileName protoFileName = ProtobufFileName.newBuilder()
                     .setFileName(fileDescriptorProto.getName()).build();
             ProtobufFileDescriptor protoFd = ProtobufFileDescriptor.newBuilder()
                     .setFileDescriptor(fileDescriptorProto)
-                    .setVersion(corfuCodeVersion)
+                    .setVersion(sourceCodeVersion)
                     .build();
             // Add the actual descriptor into a common pool of descriptors to avoid duplication
             allDescriptors.putIfAbsent(protoFileName, new CorfuRecord<>(protoFd, null));


### PR DESCRIPTION
Some protobufs used by Corfu clients may change even when there is no change in corfu's source code itself.
To help identify these cases, let the caller supply their own source code version number to help identify if the protobuf files on Table opens need to be re-indexed.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
