### PR TITLE
Allow Apply of LogEntry Message Batch with New Entries In the Same Batch.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -110,7 +110,7 @@ public class LogEntryWriter extends SinkWriter {
 
                         // Validate the message metadata with the local metadata table
                         if (topologyConfigId != persistedTopologyConfigId || baseSnapshotTs != persistedSnapshotStart ||
-                            baseSnapshotTs != persistedSnapshotDone || prevTs != persistedBatchTs) {
+                            baseSnapshotTs != persistedSnapshotDone || prevTs > persistedBatchTs) {
                             log.warn("Message metadata mismatch. Skip applying message {}, persistedTopologyConfigId={}," +
                                     "persistedSnapshotStart={}, persistedSnapshotDone={}, persistedBatchTs={}",
                                 txMessage.getMetadata(), persistedTopologyConfigId, persistedSnapshotStart,
@@ -230,8 +230,7 @@ public class LogEntryWriter extends SinkWriter {
             lastMsgTs = srcGlobalSnapshot;
         }
 
-        // If the entry is the expected entry, process it and process the messages in the queue.
-        if (msg.getMetadata().getPreviousTimestamp() == lastMsgTs) {
+        if (msg.getMetadata().getPreviousTimestamp() <= lastMsgTs && msg.getMetadata().getTimestamp() > lastMsgTs) {
             return applyMsg(msg);
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -230,7 +230,7 @@ public class LogEntryWriter extends SinkWriter {
             lastMsgTs = srcGlobalSnapshot;
         }
 
-        if (msg.getMetadata().getPreviousTimestamp() <= lastMsgTs && msg.getMetadata().getTimestamp() > lastMsgTs) {
+        if (msg.getMetadata().getPreviousTimestamp() <= lastMsgTs && lastMsgTs < msg.getMetadata().getTimestamp()) {
             return applyMsg(msg);
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
@@ -132,7 +132,7 @@ public abstract class SinkBufferManager {
         long currentTs = getCurrentSeq(dataMessage);
 
         // This message contains entries that haven't been applied yet
-        if (preTs <= lastProcessedSeq && currentTs > lastProcessedSeq) {
+        if (preTs <= lastProcessedSeq && lastProcessedSeq < currentTs) {
             // The received message is either the next in sequence OR the same message as the last one with a few
             // more opaque entries.
             log.debug("Received in order message={}, lastProcessed={}", currentTs, lastProcessedSeq);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
@@ -133,6 +133,8 @@ public abstract class SinkBufferManager {
 
         // This message contains entries that haven't been applied yet
         if (preTs <= lastProcessedSeq && currentTs > lastProcessedSeq) {
+            // The received message is either the next in sequence OR the same message as the last one with a few
+            // more opaque entries.
             log.debug("Received in order message={}, lastProcessed={}", currentTs, lastProcessedSeq);
             if (sinkManager.processMessage(dataMessage)) {
                 ackCnt++;

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -309,23 +309,23 @@ public class SourceForwardingDataSender implements DataSender {
         return false;
     }
 
-    /** Change the msg such that Sink ignores the msg. Used to test that the ACK received is not for this msg,
+    /** Change the msg such that Sink ignores the msg (previousTimestamp is decremented by 1, which means no new
+     * messages to apply). Used to test that the ACK received is not for this msg,
      * i.e., the lastProcessedTs on Sink doesn't change when the msg is ignored.
      **/
     private LogReplicationEntryMsg changeMsgMetadata(LogReplicationEntryMsg message) {
         LogReplicationEntryMsg newMessage = LogReplicationEntryMsg.newBuilder().mergeFrom(message)
                 .setMetadata(LogReplication.LogReplicationEntryMetadataMsg.newBuilder().mergeFrom(message.getMetadata())
-                        .setTimestamp(message.getMetadata().getTimestamp() + 1)
                         .setPreviousTimestamp(message.getMetadata().getPreviousTimestamp() - 1)
                         .build())
                 .build();
 
         assertThat(destinationLogReplicationManager.getLogReplicationMetadataManager()
                 .getLastProcessedLogEntryBatchTimestamp())
-                .isGreaterThanOrEqualTo(newMessage.getMetadata().getPreviousTimestamp());
+                .isGreaterThan(newMessage.getMetadata().getPreviousTimestamp());
         assertThat(destinationLogReplicationManager.getLogReplicationMetadataManager()
                 .getLastProcessedLogEntryBatchTimestamp())
-                .isLessThan(newMessage.getMetadata().getTimestamp());
+                .isEqualTo(newMessage.getMetadata().getTimestamp());
 
         lastAckDropped = Long.MAX_VALUE;
 


### PR DESCRIPTION
Validation logic in LogEntry writer is incorrect in the following scenario:
1. Source sends a batch with timestamp range [1, n]
2. This batch is applied on Sink
3. Before an ACK is received, Replication FSM on the Source stops due to
   leadership loss, network blip or any such intermittent failure.
4. New data gets written to replicated streams.
5. Replication starts again.  As ACK from 1) was not received, a new
   batch with timestamps [1, n+m] is constructed and sent.

The new 'm' entries must be applied on the Sink.  Instead, it currently
rejects the message.


Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
