### PR TITLE
Bound receiver RPC queue + fix max msg batch size

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -20,6 +20,7 @@ import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
 import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLeadershipLoss;
@@ -45,6 +46,10 @@ public class LogReplicationServer extends AbstractServer {
     // node id should be the only identifier for a node in the topology
     private String localNodeId;
 
+    /* Size bounding LRs client RPC queue, set to be at least that of the sender buffer window
+     * with some padding.
+     */
+    private static final int MAX_EXECUTOR_QUEUE_SIZE = 10;
     private final ExecutorService executor;
 
     @Getter
@@ -87,7 +92,12 @@ public class LogReplicationServer extends AbstractServer {
 
     @Override
     protected void processRequest(RequestMsg req, ChannelHandlerContext ctx, IServerRouter r) {
-        executor.submit(() -> getHandlerMethods().handle(req, ctx, r));
+        if (((ThreadPoolExecutor)executor).getQueue().size() < MAX_EXECUTOR_QUEUE_SIZE) {
+            executor.submit(() -> getHandlerMethods().handle(req, ctx, r));
+        } else {
+            log.warn("Server request queue at capacity ({}), dropping message {}",
+                    MAX_EXECUTOR_QUEUE_SIZE, req.getHeader().getRequestId());
+        }
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -46,8 +46,8 @@ public class LogReplicationServer extends AbstractServer {
     // node id should be the only identifier for a node in the topology
     private String localNodeId;
 
-    /* Size bounding LRs client RPC queue, set to be at least that of the sender buffer window
-     * with some padding.
+    /*
+     * Size bounding LRs client RPC queue, set to be at least that of the sender buffer window.
      */
     private static final int MAX_EXECUTOR_QUEUE_SIZE = 10;
     private final ExecutorService executor;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -45,11 +45,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.corfudb.common.util.URLUtils.getVersionFormattedHostAddress;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_NUM_MSG_PER_BATCH;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_CACHE_NUM_ENTRIES;
-import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_DATA_MSG_SIZE_SUPPORTED;
+import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_MSG_BATCH_SIZE;
 
 
 /**
@@ -282,7 +281,7 @@ public class ServerContext implements AutoCloseable {
      */
     public int getLogReplicationMaxDataMessageSize() {
         String val = getServerConfig(String.class, "--max-replication-data-message-size");
-        return val == null ? MAX_DATA_MSG_SIZE_SUPPORTED : Integer.parseInt(val);
+        return val == null ? DEFAULT_MAX_MSG_BATCH_SIZE : Integer.parseInt(val);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -38,7 +38,7 @@ public class LogReplicationConfig {
     public static final int DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED = 50;
 
     // Log Replication uses 25MB limit as the default max message size to batch and
-    // send data across over to the other side.
+    // send data across over to the other side. (Arbitrary limit, can be changed)
     public static final int DEFAULT_MAX_MSG_BATCH_SIZE = (25 << 20);
 
     // Log Replication default max cache number of entries

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -37,9 +37,9 @@ public class LogReplicationConfig {
     // Default value for the max number of entries applied in a single transaction on Sink during snapshot sync
     public static final int DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED = 50;
 
-    // Max message size supported by protocol buffers is 64MB. Log Replication uses this limit as the default message
-    // size to batch and send data across over to the other side.
-    public static final int MAX_DATA_MSG_SIZE_SUPPORTED = (64 << 20);
+    // Log Replication uses 25MB limit as the default max message size to batch and
+    // send data across over to the other side.
+    public static final int DEFAULT_MAX_MSG_BATCH_SIZE = (25 << 20);
 
     // Log Replication default max cache number of entries
     // Note: if we want to improve performance for large scale this value should be tuned as it
@@ -48,7 +48,7 @@ public class LogReplicationConfig {
     public static final int MAX_CACHE_NUM_ENTRIES = 200;
 
     // Percentage of log data per log replication message
-    public static final int DATA_FRACTION_PER_MSG = 90;
+    public static final long DATA_FRACTION_PER_MSG = 90L;
 
     public static final UUID REGISTRY_TABLE_ID = CorfuRuntime.getStreamID(
             getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, TableRegistry.REGISTRY_TABLE_NAME));
@@ -105,9 +105,9 @@ public class LogReplicationConfig {
                                 int maxNumMsgPerBatch, int maxMsgSize, int cacheSize, int maxSnapshotEntriesApplied) {
         this.configManager = configManager;
         this.maxNumMsgPerBatch = maxNumMsgPerBatch;
-        this.maxMsgSize = maxMsgSize;
         this.maxCacheSize = cacheSize;
-        this.maxDataSizePerMsg = maxMsgSize * DATA_FRACTION_PER_MSG / 100;
+        this.maxMsgSize = maxMsgSize;
+        this.maxDataSizePerMsg = (int) ((maxMsgSize * DATA_FRACTION_PER_MSG) / 100L);
         this.maxSnapshotEntriesApplied = maxSnapshotEntriesApplied;
         syncWithRegistry();
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -33,7 +33,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.google.protobuf.UnsafeByteOperations.unsafeWrap;
-import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_DATA_MSG_SIZE_SUPPORTED;
 import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.generatePayload;
 import static org.corfudb.protocols.service.CorfuProtocolLogReplication.getLrEntryMsg;
@@ -185,7 +184,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
         // For interested entry, if its size is too big we should skip and report error
         if (currentEntrySize > maxDataSizePerMsg) {
             log.error("The current entry size {} is bigger than the maxDataSizePerMsg {} supported.",
-                    currentEntrySize, MAX_DATA_MSG_SIZE_SUPPORTED);
+                    currentEntrySize, maxDataSizePerMsg);
             // If a message cannot be sent due to its size exceeding the maximum boundary, the replication will be stopped.
             messageExceededSize = true;
             return false;

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -71,7 +71,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_NUM_MSG_PER_BATCH;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_CACHE_NUM_ENTRIES;
-import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_DATA_MSG_SIZE_SUPPORTED;
+import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_MSG_BATCH_SIZE;
 import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STATUS_STREAM_TAG;
 import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.NAMESPACE;
 import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_STATUS_TABLE;
@@ -986,7 +986,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         CorfuRuntime newRT = getNewRuntime(getDefaultNode()).connect();
         LogReplicationConfigManager tableManagerPlugin = new LogReplicationConfigManager(newRT);
         LogReplicationConfig config = new LogReplicationConfig(tableManagerPlugin, DEFAULT_MAX_NUM_MSG_PER_BATCH,
-                MAX_DATA_MSG_SIZE_SUPPORTED, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
+                DEFAULT_MAX_MSG_BATCH_SIZE, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
 
         switch(readerImpl) {
             case EMPTY:

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -56,7 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_NUM_MSG_PER_BATCH;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED;
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_CACHE_NUM_ENTRIES;
-import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_DATA_MSG_SIZE_SUPPORTED;
+import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_MSG_BATCH_SIZE;
 
 @Slf4j
 public class LogReplicationReaderWriterIT extends AbstractIT {
@@ -240,7 +240,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         int cnt = 0;
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
         LogReplicationConfig config = new LogReplicationConfig(configManager, DEFAULT_MAX_NUM_MSG_PER_BATCH,
-                MAX_DATA_MSG_SIZE_SUPPORTED, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
+                DEFAULT_MAX_MSG_BATCH_SIZE, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
         StreamsSnapshotReader reader = new StreamsSnapshotReader(rt, config);
 
         reader.reset(rt.getAddressSpaceView().getLogTail());
@@ -271,7 +271,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public static void writeSnapLogMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
         LogReplicationConfig config = new LogReplicationConfig(configManager, DEFAULT_MAX_NUM_MSG_PER_BATCH,
-                MAX_DATA_MSG_SIZE_SUPPORTED, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
+                DEFAULT_MAX_MSG_BATCH_SIZE, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt, 0, PRIMARY_SITE_ID);
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, config, logReplicationMetadataManager);
 
@@ -294,7 +294,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public static void readLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt, boolean blockOnce) throws TrimmedException {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
         LogReplicationConfig config = new LogReplicationConfig(configManager, DEFAULT_MAX_NUM_MSG_PER_BATCH,
-                MAX_DATA_MSG_SIZE_SUPPORTED, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
+                DEFAULT_MAX_MSG_BATCH_SIZE, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
         StreamsLogEntryReader reader = new StreamsLogEntryReader(rt, config);
         reader.setGlobalBaseSnapshot(Address.NON_ADDRESS, Address.NON_ADDRESS);
 
@@ -326,7 +326,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     public static void writeLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, Set<String> streams, CorfuRuntime rt) {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
         LogReplicationConfig config = new LogReplicationConfig(configManager, DEFAULT_MAX_NUM_MSG_PER_BATCH,
-                MAX_DATA_MSG_SIZE_SUPPORTED, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
+                DEFAULT_MAX_MSG_BATCH_SIZE, MAX_CACHE_NUM_ENTRIES, DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED);
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt, 0, PRIMARY_SITE_ID);
         LogEntryWriter writer = new LogEntryWriter(config, logReplicationMetadataManager);
 


### PR DESCRIPTION
## Overview

Description:

- Added bounding for RPC queue on receiver
- Fix integer overflow when calculating max size for a log entry message, and usage of value

Why should this be merged: 

This PR attempts to fix the following problem:

The source has a set timeout period within the completable future for sent log entries.
In cases with larger batch sizes being sent to the sink, this timeout can repeatedly expire before an ack is received to complete the future.
This prompts the source to resend the entires that timed out which will then keep accumulating on the sink, in some cases resulting in an OOM.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
