### PR TITLE
Install python packages with apt

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -8,8 +8,8 @@ ARG CORFU_TOOLS_JAR
 WORKDIR /app
 
 RUN apt update && apt -y install iptables bash jq python3 sudo iproute2 python3-pip curl
-RUN apt-get install -y python3-yaml
-RUN apt-get install -y python3-netifaces
+RUN apt-get install -y --no-install-recommends python3-yaml=6.0.1-2build2
+RUN apt-get install -y --no-install-recommends python3-netifaces=0.11.0-2build3
 
 RUN echo "$BASE_IMAGE" > docker.container.info.txt
 

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -8,8 +8,8 @@ ARG CORFU_TOOLS_JAR
 WORKDIR /app
 
 RUN apt update && apt -y install iptables bash jq python3 sudo iproute2 python3-pip curl
-RUN apt-get install -y --no-install-recommends python3-yaml=6.0.1-2build2
-RUN apt-get install -y --no-install-recommends python3-netifaces=0.11.0-2build3
+RUN apt-get install -y --no-install-recommends python3-yaml
+RUN apt-get install -y --no-install-recommends python3-netifaces
 
 RUN echo "$BASE_IMAGE" > docker.container.info.txt
 

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -8,8 +8,8 @@ ARG CORFU_TOOLS_JAR
 WORKDIR /app
 
 RUN apt update && apt -y install iptables bash jq python3 sudo iproute2 python3-pip curl
-RUN python3 -m pip install pyyaml==6.0.1
-RUN python3 -m pip install netifaces==0.11.0
+RUN apt-get install -y python3-yaml
+RUN apt-get install -y python3-netifaces
 
 RUN echo "$BASE_IMAGE" > docker.container.info.txt
 


### PR DESCRIPTION
Avoid installation error enforced by PEP 668.

------
 > [ 4/18] RUN python3 -m pip install pyyaml==6.0.1:
0.442 error: externally-managed-environment
0.442
0.442 × This environment is externally managed
0.442 ╰─> To install Python packages system-wide, try apt install
0.442     python3-xyz, where xyz is the package you are trying to
0.442     install.
0.442
0.442     If you wish to install a non-Debian-packaged Python package,
0.442     create a virtual environment using python3 -m venv path/to/venv.
0.442     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.442     sure you have python3-full installed.
0.442
0.442     If you wish to install a non-Debian packaged Python application,
0.442     it may be easiest to use pipx install xyz, which will manage a
0.442     virtual environment for you. Make sure you have pipx installed.
0.442
0.442     See /usr/share/doc/python3.12/README.venv for more information.
0.442
0.442 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider.
 You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.442 hint: See PEP 668 for the detailed specification.
------
Dockerfile:11

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
