### PR TITLE
[PG] Remote status clusterId fix

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -1171,7 +1171,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                                 nodeDescriptor -> {
                                     // TODO (Postgres): Will need leadership check after clustering implemented
                                     String standbyNodeIp = nodeDescriptor.getHost().split(":")[0];
-                                    mapToSend.put(localClusterDescriptor.clusterId, getPgReplicationStatus(connector, standbyNodeIp));
+                                    mapToSend.put(nodeDescriptor.getClusterId(), getPgReplicationStatus(connector, standbyNodeIp));
                                 })
                 );
             }


### PR DESCRIPTION
## Overview

Description:

Fix: maps replication status to remote clusterId as opposed local. 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
