### PR TITLE
Upgrade GitHub Workflow to use latest Ubuntu (#3527)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_and_analysis:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -31,8 +31,13 @@ jobs:
         with:
           java-version: 1.8
 
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare top of trunk docker image
         run: ./mvnw clean install -DskipTests -Pcompatibility -Dmaven.javadoc.skip=true -T 1C

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -4,7 +4,7 @@ name: Compatibility Test
 jobs:
   compatibility_test:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       PKG_USERNAME: ${{ secrets.pkg_username }}

--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -4,7 +4,7 @@ name: Injection Framework Test
 jobs:
   injection_framework_test:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       PKG_USERNAME: ${{ secrets.pkg_username }}

--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -31,8 +31,13 @@ jobs:
         with:
           java-version: 1.8
 
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare top of trunk docker image
         run: ./mvnw clean package -DskipTests -Pdocker -Dmaven.javadoc.skip=true -T 1C
@@ -43,6 +48,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: 'CorfuDB/corfudb-cloud'
+          ref: "corfudb-cloud-0.3.2"
 
       - name: Build universe-core
         working-directory: ./universe

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,7 +4,7 @@ name: Integration Test
 jobs:
   integration_test:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -38,8 +38,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare Corfu
         run: ./mvnw clean install -Pdocker -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip -T 1C

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,7 @@ name: Unit Test
 jobs:
   unit_test:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/universe-test.yml
+++ b/.github/workflows/universe-test.yml
@@ -4,7 +4,7 @@ name: Universe Test
 jobs:
   universe_test:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/universe-test.yml
+++ b/.github/workflows/universe-test.yml
@@ -27,8 +27,13 @@ jobs:
         with:
           java-version: 1.8
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - name: Install Docker
+        run: |
+          for pkg in docker.io docker-ce docker-ce-cli docker-ce-rootless-extras docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh ./get-docker.sh --version 24.0.9
+          /usr/bin/docker version
+          /usr/bin/docker info
 
       - name: Prepare Corfu
         run: ./mvnw clean install -Pdocker -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip -T 1C

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -31,7 +31,7 @@
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
             <classifier>shaded</classifier>
-            <version>8.11.7</version>
+            <version>8.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
Update image label to ubuntu-latest.
Fix https://github.com/actions/runner-images/issues/6002 to ensure continued support.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
