### PR TITLE
Metric registry provider metadata

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -141,6 +141,9 @@ public class MeterRegistryProvider {
                     log.info("Registering provider: {}", registryProvider);
                     provider = Optional.of(registryProvider);
                     final Map<String, String> registryMetadata = loadRegistryData();
+                    String classPath = System.getProperty("java.class.path");
+                    log.info("Classpath: {}", classPath);
+                    log.info("Registry metadata: {}", registryMetadata);
                     MeterRegistry registry = registryProvider.provideRegistry(registryMetadata);
                     addToCompositeRegistry(() -> Optional.of(registry));
                 } catch (Throwable exception) {

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -98,6 +98,7 @@ public class MeterRegistryProvider {
                 LoggingMeterRegistryWithHistogramSupport registry =
                         new LoggingMeterRegistryWithHistogramSupport(config, logger::debug, externalMetricsSuppliers);
                 registry.config().commonTags("id", identifier);
+                registry.config().clock()
                 Optional<MeterRegistry> ret = Optional.of(registry);
                 JVMMetrics.register(ret);
                 return ret;
@@ -141,10 +142,9 @@ public class MeterRegistryProvider {
                     log.info("Registering provider: {}", registryProvider);
                     provider = Optional.of(registryProvider);
                     final Map<String, String> registryMetadata = loadRegistryData();
-                    String classPath = System.getProperty("java.class.path");
-                    log.info("Classpath: {}", classPath);
                     log.info("Registry metadata: {}", registryMetadata);
                     MeterRegistry registry = registryProvider.provideRegistry(registryMetadata);
+                    id.ifPresent(s -> registry.config().commonTags("id", s));
                     addToCompositeRegistry(() -> Optional.of(registry));
                 } catch (Throwable exception) {
                     log.error("Problems registering a registry", exception);

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -98,7 +98,6 @@ public class MeterRegistryProvider {
                 LoggingMeterRegistryWithHistogramSupport registry =
                         new LoggingMeterRegistryWithHistogramSupport(config, logger::debug, externalMetricsSuppliers);
                 registry.config().commonTags("id", identifier);
-                registry.config().clock()
                 Optional<MeterRegistry> ret = Optional.of(registry);
                 JVMMetrics.register(ret);
                 return ret;

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/RegistryLoader.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/RegistryLoader.java
@@ -1,15 +1,16 @@
 package org.corfudb.common.metrics.micrometer.registries;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 
 /**
  * Lazily loads the registry providers.
  */
 public class RegistryLoader {
 
-    private final ServiceLoader<RegistryProvider> loader = ServiceLoader.load(RegistryProvider.class,
-            ClassLoader.getSystemClassLoader());
+    private final ServiceLoader<RegistryProvider> loader = ServiceLoader.load(RegistryProvider.class);
 
     public Iterator<RegistryProvider> getRegistries() {
         return loader.iterator();

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/RegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/RegistryProvider.java
@@ -2,13 +2,15 @@ package org.corfudb.common.metrics.micrometer.registries;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
+import java.util.Map;
+
 /**
  * Clients who are willing to integrate their registries into Corfu metrics composite registry
  * must implement this interface.
  */
 public interface RegistryProvider {
 
-    MeterRegistry provideRegistry();
+    MeterRegistry provideRegistry(Map<String, String> registryMetadata);
 
     void close();
 


### PR DESCRIPTION
## Overview

Description:

1. Create an ability to provide custom metadata for the provided registries loaded by ServiceLoader. 
2. Set common tags like id for the provided registries. 
3. Fix the CompositeRegistry cleanup bug (ConcurrentModificationException).  
