### PR TITLE
PG Utils Fixes

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/PgUtils/PostgresUtils.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/PgUtils/PostgresUtils.java
@@ -348,11 +348,11 @@ public class PostgresUtils {
         }
     }
 
-    public static void truncateTables(List<String> tablesToTruncate, PostgresConnector connector) {
-        String truncatePrefix = "TRUNCATE TABLE ";
+    public static void clearTables(List<String> tablesToTruncate, PostgresConnector connector) {
+        String truncatePrefix = "DELETE FROM ";
         for (String table : tablesToTruncate) {
             retryIndefinitely(() -> tryExecuteCommand(truncatePrefix + table + ";", connector),
-                    String.format("Truncate table for table [%s]", table));
+                    String.format("Delete from table for table [%s]", table));
         }
     }
 
@@ -390,7 +390,10 @@ public class PostgresUtils {
 
         for (Map<String, Object> row : executeQuery(getSubQuery, connector)) {
             String pubname = row.get("pubname").toString();
-            if (pubname != null && !pubname.isEmpty()) {
+
+            // TODO (Postgres): filtering out non replication pubs manually, can filter for just replication
+            // pubs once naming is standardized.
+            if (pubname != null && !pubname.isEmpty() && !pubname.contains("dbz")) {
                 publicationNames.add(pubname);
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -81,7 +81,7 @@ import static org.corfudb.infrastructure.logreplication.PgUtils.PostgresUtils.ge
 import static org.corfudb.infrastructure.logreplication.PgUtils.PostgresUtils.makeTablesReadOnly;
 import static org.corfudb.infrastructure.logreplication.PgUtils.PostgresUtils.makeTablesWriteable;
 import static org.corfudb.infrastructure.logreplication.PgUtils.PostgresUtils.retryIndefinitely;
-import static org.corfudb.infrastructure.logreplication.PgUtils.PostgresUtils.truncateTables;
+import static org.corfudb.infrastructure.logreplication.PgUtils.PostgresUtils.clearTables;
 import static org.corfudb.infrastructure.logreplication.PgUtils.PostgresUtils.tryExecuteCommand;
 import static org.corfudb.infrastructure.logreplication.PostgresReplicationConnectionConfig.isPostgres;
 import static org.corfudb.infrastructure.logreplication.infrastructure.plugins.PgClusterManager.PG_CONTAINER_PHYSICAL_HOST;
@@ -400,7 +400,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 log.info("Publications successfully created on active postgres!");
             } else if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
                 dropAllSubscriptions(connector);
-                truncateTables(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
+                clearTables(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
                 makeTablesReadOnly(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
                 log.info("Cleared tables to be replicated!");
 
@@ -774,7 +774,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     dropPublications(getAllPublications(connector), connector);
 
                     // Clear tables
-                    truncateTables(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
+                    clearTables(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
                     makeTablesReadOnly(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
 
                     publicationsNotAvailable = true;
@@ -796,7 +796,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     // Drop all publications if any
                     dropPublications(getAllPublications(connector), connector);
 
-                    truncateTables(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
+                    clearTables(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
                     makeTablesReadOnly(new ArrayList<>(logReplicationConfig.getStreamsToReplicate()), connector);
 
                     publicationsNotAvailable = true;

--- a/test/src/test/java/org/corfudb/integration/pg/PostgresUtilsTest.java
+++ b/test/src/test/java/org/corfudb/integration/pg/PostgresUtilsTest.java
@@ -158,7 +158,7 @@ public class PostgresUtilsTest {
             PostgresUtils.dropAllPublications(primary);
 
             // "Clear" tables on the primary
-            PostgresUtils.truncateTables(new ArrayList<>(tablesToReplicate), primary);
+            PostgresUtils.clearTables(new ArrayList<>(tablesToReplicate), primary);
 
             // Create subscription on primary, "full sync" and start streaming from the replica
             tryExecuteCommand(PostgresUtils.createSubscriptionCmd(replicaContainer, primaryContainer, replica), primary);


### PR DESCRIPTION
## Overview

Description:

Ignore publications not created by LR + use DELETE instead of TRUNCATE since DDL statements are not replicated.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
