### PR TITLE
Upgrade upload-artifact-v4 from v2

### DIFF
--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -68,7 +68,7 @@ jobs:
         run: ./gradlew clean test -Dtags=version-compatibility
 
       - name: Upload compatibility test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: compatibility-test-logs
           retention-days: 3

--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -72,7 +72,7 @@ jobs:
         run: ./gradlew clean test -Dtags=longevity-docker
 
       - name: upload longevity logs artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: injection-framework-logs
           retention-days: 3


### PR DESCRIPTION
GitHub Actions fail with deprecated upload-artifact-v2. 
Upgrading this version fixes it.

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
