### PR TITLE
Move Docker Login to Actions

### DIFF
--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -1,7 +1,9 @@
 name: Publish CorfuDB Artifacts
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
 
 # Cancel Previous Runs
 concurrency:
@@ -12,6 +14,7 @@ jobs:
   publish_corfu_db_artifacts:
 
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
     env:
       PKG_USERNAME: ${{ secrets.pkg_username }}

--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -1,6 +1,7 @@
 name: Publish CorfuDB Artifacts
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -19,8 +20,6 @@ jobs:
     env:
       PKG_USERNAME: ${{ secrets.pkg_username }}
       PUBLISH_TOKEN: ${{ secrets.publish_token }}
-      DOCKER_USERNAME: ${{ secrets.docker_username }}
-      DOCKER_PASSWORD: ${{ secrets.docker_password }}
 
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +31,9 @@ jobs:
           java-version: '11'
           check-latest: true
           cache-dependency-path: '**/pom.xml'
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.docker_password }}" | docker login -u "${{ secrets.docker_username }}" --password-stdin
 
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -1,10 +1,7 @@
 name: Publish CorfuDB Artifacts
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - master
+  pull_request:
 
 # Cancel Previous Runs
 concurrency:
@@ -15,7 +12,6 @@ jobs:
   publish_corfu_db_artifacts:
 
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     env:
       PKG_USERNAME: ${{ secrets.pkg_username }}

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -81,22 +81,6 @@
                 <version>3.0.0</version>
                 <executions>
                     <execution>
-                        <id>Docker login</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>docker</executable>
-                            <arguments>
-                                <argument>login</argument>
-                                <argument>--username=${env.DOCKER_USERNAME}</argument>
-                                <argument>--password=${env.DOCKER_PASSWORD}</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-
-                    <execution>
                         <id>Docker push</id>
                         <phase>deploy</phase>
                         <goals>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -97,22 +97,6 @@
                 <version>1.6.0</version>
                 <executions>
                     <execution>
-                        <id>Docker login</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>docker</executable>
-                            <arguments>
-                                <argument>login</argument>
-                                <argument>--username=${env.DOCKER_USERNAME}</argument>
-                                <argument>--password=${env.DOCKER_PASSWORD}</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-
-                    <execution>
                         <id>Docker push corfu server</id>
                         <phase>deploy</phase>
                         <goals>


### PR DESCRIPTION
Docker login params are currently sourced from Actions and are passed into pom.xml.

They are useless in pom.xml as they cannot be individually run without the Actions. 
For someone to publish artifacts without Actions, they could do so with the command (as is the case currently)-
 `docker login -u <username>` followed by a prompt for the password, and then 
execute prepare and publish commands -
```
.ci/infrastructure-docker-build.sh docker
.ci/generator-docker-build.sh
./mvnw clean deploy -s ./.mvn/settings.xml -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip -T 1C
```

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
