### PR TITLE
Make provided registry optional

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -143,9 +143,16 @@ public class MeterRegistryProvider {
                         RegistryProvider registryProvider = registries.next();
                         log.info("Registering provider: {}", registryProvider);
                         provider = Optional.of(registryProvider);
-                        MeterRegistry registry = registryProvider.provideRegistry(registryMetadata);
-                        id.ifPresent(s -> registry.config().commonTags("id", s));
-                        addToCompositeRegistry(() -> Optional.of(registry));
+                        Optional<MeterRegistry> registry = registryProvider.provideRegistry(registryMetadata);
+                        if (registry.isPresent()) {
+                            MeterRegistry providedRegistry = registry.get();
+                            id.ifPresent(s -> providedRegistry.config().commonTags("id", s));
+                            addToCompositeRegistry(() -> registry);
+                        }
+                        else {
+                            log.warn("Registry was not configured");
+                        }
+
                     }
                     catch (Throwable exception) {
                         log.error("Problems registering a registry", exception);

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/RegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/RegistryProvider.java
@@ -3,6 +3,7 @@ package org.corfudb.common.metrics.micrometer.registries;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Clients who are willing to integrate their registries into Corfu metrics composite registry
@@ -10,7 +11,7 @@ import java.util.Map;
  */
 public interface RegistryProvider {
 
-    MeterRegistry provideRegistry(Map<String, String> registryMetadata);
+    Optional<MeterRegistry> provideRegistry(Map<String, String> registryMetadata);
 
     void close();
 


### PR DESCRIPTION
## Overview

Description:

This CL does not change any existing functionality, it only makes the provided registry optional. Current mechanism of throwing the exception in the expected cases, introduces the harmless exception into logs, which potentially can redirect a lot of bugs towards our team. 