### PR TITLE
Default constructor for instantiating empty Table objects

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -16,6 +16,7 @@ import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.runtime.view.ObjectsView.ObjectID;
 import org.corfudb.runtime.view.SMRObject;
+import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.SafeProtobufSerializer;
 
@@ -106,6 +107,21 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
 
     @Getter
     private final ISerializer serializer;
+
+    public Table(String namespace, String tableName, Class<K> keyClass, Class<V> valueClass, Class<M> metadataClass) {
+        this.fullyQualifiedTableName = TableRegistry.getFullyQualifiedTableName(namespace, tableName);
+        this.keyClass = keyClass;
+        this.valueClass = valueClass;
+        this.metadataClass = metadataClass;
+
+        this.namespace = null;
+        this.streamTags = null;
+        this.streamUUID = null;
+        this.metadataOptions = null;
+        this.tableParameters = null;
+        this.guidGenerator = null;
+        this.serializer = null;
+    }
 
     /**
      * Returns a Table instance backed by a CorfuTable.


### PR DESCRIPTION
## Overview

Description:
Not all callers of Table have all the parameters setup. So this default constructor allows instantiating empty Table objects only for the purposes of extracting tableName and Namespace

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
