### PR TITLE
Update logback to 1.5.12 and clojure to 1.12.0

### DIFF
--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>1.8.0</version>
+            <version>1.12.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jline</groupId>
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>com.theoryinpractise</groupId>
                 <artifactId>clojure-maven-plugin</artifactId>
-                <version>1.8.1</version>
+                <version>1.9.3</version>
                 <extensions>true</extensions>
                 <configuration>
                     <temporaryOutputDirectory>true</temporaryOutputDirectory>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,13 @@
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>sizeof</artifactId>
-            <version>0.4.3</version>
+            <version>0.4.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,10 @@
         <revision>0.4.2.1-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <logback.classic.version>1.2.11</logback.classic.version>
+        <logback.classic.version>1.5.12</logback.classic.version>
 
         <!-- Dependency versions -->
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
         <netty.version>4.1.111.Final</netty.version>
         <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
         <protobuf.version>3.21.12</protobuf.version>


### PR DESCRIPTION

## Overview


Description:
Fixes CVE-2023-6378 for logback
, and CVE-2017-20189 for clojure.


Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
