### PR TITLE
Upgrade grpc from 1.65.1 to 1.68.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <!-- Dependency versions -->
         <slf4j.version>2.0.16</slf4j.version>
         <netty.version>4.1.111.Final</netty.version>
-        <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
-        <protobuf.version>3.21.12</protobuf.version>
+        <netty.tcnative.version>2.0.65.Final</netty.tcnative.version>
+        <protobuf.version>3.25.5</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.30</lombok.version>
         <guava.version>32.1.2-jre</guava.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -24,7 +24,7 @@
         <annotations.api.version>6.0.53</annotations.api.version>
         <ehcahce.sizeOf.version>0.4.0</ehcahce.sizeOf.version>
 
-        <grpc.version>1.65.1</grpc.version>
+        <grpc.version>1.68.2</grpc.version>
     </properties>
 
     <build>


### PR DESCRIPTION
- Also upgrade protobuf and netty-tcnative. grpc.version 1.68.2
netty.version 4.1.111.Final (unchanged)
netty.tcnative.version 2.0.65.Final
protobuf.version 3.25.5

- Fixes CVE-2024-7254 (protobuf)

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
