### PR TITLE
Fix the sequencer health monitor bug

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -37,6 +37,7 @@ import org.corfudb.runtime.proto.service.Sequencer.TokenRequestMsg;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.LambdaUtils;
 import org.corfudb.util.Utils;
 
 import javax.annotation.Nonnull;
@@ -214,7 +215,7 @@ public class SequencerServer extends AbstractServer {
         streamTailToGlobalTailMap = sequencerFactoryHelper.getStreamTailToGlobalTailMap();
         healthReportScheduler = sequencerFactoryHelper.getHealthReportScheduler("sequencer-health");
         HealthMonitor.reportIssue(Issue.createInitIssue(Component.SEQUENCER));
-        healthReportScheduler.scheduleAtFixedRate(this::reportSequencerHealth, INIT_DELAY, DELAY_NUM, DELAY_UNITS);
+        healthReportScheduler.scheduleAtFixedRate(() -> LambdaUtils.runSansThrow(this::reportSequencerHealth), INIT_DELAY, DELAY_NUM, DELAY_UNITS);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/health/HealthStatus.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/health/HealthStatus.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.health;
 
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -14,6 +15,7 @@ import java.util.Set;
  * runtimeHealthIssues can appear.
  */
 @ToString
+@Slf4j
 public class HealthStatus {
     
     @Getter
@@ -40,6 +42,7 @@ public class HealthStatus {
     public void addInitHealthIssue(Issue issue) {
         verifyComponent(issue);
         if (!issue.isInitIssue()) {
+            log.warn("addInitHealthIssue: trying to add a non-init issue - {}", issue);
             throw new IllegalArgumentException("Only issues of type INIT are allowed");
         }
         if (initStatus == InitStatus.UNKNOWN || initStatus == InitStatus.INITIALIZED) {
@@ -72,6 +75,7 @@ public class HealthStatus {
     public void addRuntimeHealthIssue(Issue issue) {
         verifyComponent(issue);
         if (initStatus != InitStatus.INITIALIZED) {
+            log.warn("addRuntimeHealthIssue: trying to add a runtime health issue to NOT_INITIALIZED component - {}", issue);
             throw new IllegalStateException("Runtime health issue can only be reported if the component is initialized");
         }
         runtimeHealthIssues.add(issue);
@@ -96,6 +100,7 @@ public class HealthStatus {
 
     private void verifyComponent(Issue issue) {
         if (issue.getComponent() != this.component) {
+            log.warn("verifyComponent: this issue: {} is for the wrong component: {}", issue, this.component);
             String msg = String.format("Only the issues belonging to %s are allowed but got: %s", this.component,
                     issue.getComponent());
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/health/HealthMonitorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/health/HealthMonitorTest.java
@@ -569,7 +569,7 @@ public class HealthMonitorTest {
             // Check that the issue persists
             assertTrue(issuePersists.get());
             // Now resolve the init issue, so the runtime issues can be reported
-            HealthMonitor.resolveIssue(Issue.createInitIssue(Component.SEQUENCER));
+            HealthMonitor.resolveIssue(Issue.createInitIssue(SEQUENCER));
 
             if (!resolutionLatch.await(3, SECONDS)) {
                 throw new IllegalStateException("Second Condition was not " +

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/health/HealthMonitorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/health/HealthMonitorTest.java
@@ -2,17 +2,26 @@ package org.corfudb.infrastructure.health;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.health.HealthReport.ComponentReportedHealthStatus;
 import org.corfudb.infrastructure.health.HealthReport.ReportedLivenessStatus;
+import org.corfudb.util.LambdaUtils;
 import org.corfudb.util.Sleep;
 import org.junit.jupiter.api.Test;
-
+import java.util.concurrent.CountDownLatch;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.corfudb.infrastructure.health.Component.COMPACTOR;
@@ -34,7 +43,11 @@ import static org.corfudb.infrastructure.health.HealthReport.OVERALL_STATUS_UNKN
 import static org.corfudb.infrastructure.health.HealthReport.OVERALL_STATUS_UP;
 import static org.corfudb.infrastructure.health.Issue.IssueId.COMPACTION_CYCLE_FAILED;
 import static org.corfudb.infrastructure.health.Issue.IssueId.FAILURE_DETECTOR_TASK_FAILED;
+import static org.corfudb.infrastructure.health.Issue.IssueId.SEQUENCER_REQUIRES_FULL_BOOTSTRAP;
 import static org.corfudb.infrastructure.health.Issue.IssueId.SOME_NODES_ARE_UNRESPONSIVE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class HealthMonitorTest {
 
@@ -510,4 +523,77 @@ public class HealthMonitorTest {
         HealthMonitor.shutdown();
     }
 
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    void testRuntimeIssueReportIsResolvedInRescheduledContext() {
+        // Schedule a thread that reports the runtime issue
+        // but wrap the runnable in runSansThrow, so it's rescheduled
+        final ScheduledExecutorService scheduledExecutorService =
+                Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder()
+                        .setDaemon(true)
+                        .setNameFormat("sequencer-health")
+                        .build());
+        AtomicBoolean issuePersists = new AtomicBoolean(false);
+        CountDownLatch errorLatch = new CountDownLatch(1);
+        CountDownLatch resolutionLatch = new CountDownLatch(1);
+
+        try {
+            Runnable run = () -> {
+                try {
+                    Issue issue = Issue.createIssue(Component.SEQUENCER,
+                            SEQUENCER_REQUIRES_FULL_BOOTSTRAP, "Sequencer " +
+                                    "requires bootstrap");
+                    HealthMonitor.reportIssue(issue);
+                    issuePersists.set(false);
+                    resolutionLatch.countDown();
+                }
+                catch (IllegalStateException ie) {
+                    issuePersists.set(true);
+                    errorLatch.countDown();
+                    throw ie;
+                }
+            };
+
+            HealthMonitor.init();
+            HealthMonitor.reportIssue(Issue.createInitIssue(Component.SEQUENCER));
+            scheduledExecutorService
+                    .scheduleAtFixedRate(
+                            () -> LambdaUtils.runSansThrow(run),0,  1, SECONDS);
+
+            if (!errorLatch.await(3, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("First Condition was not " +
+                        "met within the timeout period");
+            }
+
+            // Check that the issue persists
+            assertTrue(issuePersists.get());
+            // Now resolve the init issue, so the runtime issues can be reported
+            HealthMonitor.resolveIssue(Issue.createInitIssue(Component.SEQUENCER));
+
+            if (!resolutionLatch.await(3, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Second Condition was not " +
+                        "met within the timeout period");
+            }
+
+            assertFalse(issuePersists.get());
+        }
+
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Test interrupted while waiting for conditions.", e);
+        }
+
+        finally {
+            scheduledExecutorService.shutdown();
+            try {
+                if (!scheduledExecutorService.awaitTermination(1, TimeUnit.SECONDS)) {
+                    scheduledExecutorService.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduledExecutorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/health/HealthMonitorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/health/HealthMonitorTest.java
@@ -541,7 +541,7 @@ public class HealthMonitorTest {
         try {
             Runnable run = () -> {
                 try {
-                    Issue issue = Issue.createIssue(Component.SEQUENCER,
+                    Issue issue = Issue.createIssue(SEQUENCER,
                             SEQUENCER_REQUIRES_FULL_BOOTSTRAP, "Sequencer " +
                                     "requires bootstrap");
                     HealthMonitor.reportIssue(issue);
@@ -556,12 +556,12 @@ public class HealthMonitorTest {
             };
 
             HealthMonitor.init();
-            HealthMonitor.reportIssue(Issue.createInitIssue(Component.SEQUENCER));
+            HealthMonitor.reportIssue(Issue.createInitIssue(SEQUENCER));
             scheduledExecutorService
                     .scheduleAtFixedRate(
                             () -> LambdaUtils.runSansThrow(run),0,  1, SECONDS);
 
-            if (!errorLatch.await(3, TimeUnit.SECONDS)) {
+            if (!errorLatch.await(3, SECONDS)) {
                 throw new IllegalStateException("First Condition was not " +
                         "met within the timeout period");
             }
@@ -571,7 +571,7 @@ public class HealthMonitorTest {
             // Now resolve the init issue, so the runtime issues can be reported
             HealthMonitor.resolveIssue(Issue.createInitIssue(Component.SEQUENCER));
 
-            if (!resolutionLatch.await(3, TimeUnit.SECONDS)) {
+            if (!resolutionLatch.await(3, SECONDS)) {
                 throw new IllegalStateException("Second Condition was not " +
                         "met within the timeout period");
             }
@@ -581,13 +581,14 @@ public class HealthMonitorTest {
 
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException("Test interrupted while waiting for conditions.", e);
+            throw new IllegalStateException("Test interrupted while waiting for conditions.", e);
         }
 
         finally {
+            HealthMonitor.shutdown();
             scheduledExecutorService.shutdown();
             try {
-                if (!scheduledExecutorService.awaitTermination(1, TimeUnit.SECONDS)) {
+                if (!scheduledExecutorService.awaitTermination(1, SECONDS)) {
                     scheduledExecutorService.shutdownNow();
                 }
             } catch (InterruptedException e) {


### PR DESCRIPTION
## Overview

Description:

There could be cases where the runtime issue for the sequencer health thread is reported before the init issue, which will result in the scheduled thread dying and not reporting the sequencer health correctly.

This patch wraps the scheduled thread in runSansThrow, rescheduling the thread and preventing this from happening. 