### PR TITLE
LR Batch+Queue Size Tuning

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -47,9 +47,12 @@ public class LogReplicationServer extends AbstractServer {
     private String localNodeId;
 
     /*
-     * Size bounding LRs client RPC queue, set to be at least that of the sender buffer window.
+     * Size bounding LRs client RPC queue, set to be at least that of the sender buffer window
+     * (LogReplicationConfig.DEFAULT_MAX_NUM_MSG_PER_BATCH).
+     * Consider optimizations like de-duplication of resent messages and/or disk-backed receiver queue to avoid tuning
+     * this parameter for higher scale.
      */
-    private static final int MAX_EXECUTOR_QUEUE_SIZE = 10;
+    private static final int MAX_EXECUTOR_QUEUE_SIZE = 5;
     private final ExecutorService executor;
 
     @Getter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -32,14 +32,14 @@ public class LogReplicationConfig {
     public static final int DEFAULT_TIMEOUT_MS = 5000;
 
     // Log Replication default max number of messages generated at the active cluster for each batch
-    public static final int DEFAULT_MAX_NUM_MSG_PER_BATCH = 10;
+    public static final int DEFAULT_MAX_NUM_MSG_PER_BATCH = 5;
 
     // Default value for the max number of entries applied in a single transaction on Sink during snapshot sync
     public static final int DEFAULT_MAX_SNAPSHOT_ENTRIES_APPLIED = 50;
 
-    // Log Replication uses 25MB limit as the default max message size to batch and
+    // Log Replication uses 15MB limit as the default max message size to batch and
     // send data across over to the other side. (Arbitrary limit, can be changed)
-    public static final int DEFAULT_MAX_MSG_BATCH_SIZE = (25 << 20);
+    public static final int DEFAULT_MAX_MSG_BATCH_SIZE = (15 << 20);
 
     // Log Replication default max cache number of entries
     // Note: if we want to improve performance for large scale this value should be tuned as it


### PR DESCRIPTION
Description:
Reduce the batch and queue sizes for incoming and outgoing LR payload.  It was observed during scale testing that 10 messages of ~25MB of each(may include messages resent due to timeout) can cause certain configuration JVMs to go out-of-memory.  Tune these parameters to accommodate such scale.

In future, consider optimizations such as de-duplication of resent messages and/or using disk-backed receiver queue to avoid tuning for specific JVM sizes.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
