### PR TITLE
Allow only these metrics to export to sha

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -1,9 +1,11 @@
 package org.corfudb.common.metrics.micrometer;
 
+import com.google.common.collect.ImmutableSet;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -46,6 +49,15 @@ public class MeterRegistryProvider {
         SERVER,
         CLIENT
     }
+
+    public static final Set<String> systemHealthMetrics = ImmutableSet.of(
+            "address_space.write.latency",
+            "transaction.duration",
+            "logunit.fsync.timer",
+            "logunit.read.timer",
+            "failure-detector.ping-latency",
+            "overall.status"
+    );
 
     /**
      * Class that initializes the Meter Registry.
@@ -147,6 +159,11 @@ public class MeterRegistryProvider {
                         if (registry.isPresent()) {
                             MeterRegistry providedRegistry = registry.get();
                             id.ifPresent(s -> providedRegistry.config().commonTags("id", s));
+                            // Apply a MeterFilter to allow only allowed metrics
+                            providedRegistry.config().meterFilter(MeterFilter.denyUnless(id ->
+                                    systemHealthMetrics.contains(id.getName())
+                            ));
+
                             addToCompositeRegistry(() -> registry);
                         }
                         else {


### PR DESCRIPTION
## Overview

Description:

Try to reduce the memory bloat by filtering out unnecessary meters before they are registered.
