### PR TITLE
LR bugfix: set LAST_LOG_ENTRY_APPLIED on snapshot completion

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerBaseAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerBaseAdapter.java
@@ -39,7 +39,7 @@ public abstract class CorfuReplicationClusterManagerBaseAdapter implements Corfu
      * @param newTopologyConfigMsg
      */
     public synchronized void updateTopologyConfig(TopologyConfigurationMsg newTopologyConfigMsg) {
-        if (newTopologyConfigMsg.getTopologyConfigID() > topologyConfig.getTopologyConfigID()) {
+        if (newTopologyConfigMsg.getTopologyConfigID() >= topologyConfig.getTopologyConfigID()) {
             topologyConfig = newTopologyConfigMsg;
             corfuReplicationDiscoveryService.updateTopology(topologyConfig);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -345,7 +345,7 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         newActiveClusters.get(0).getNodesDescriptors().add(backupNode);
         List<ClusterDescriptor> standbyClusters = new ArrayList<>(currentConfig.getStandbyClusters().values());
 
-        return new TopologyDescriptor(++configId, newActiveClusters, standbyClusters);
+        return new TopologyDescriptor(configId, newActiveClusters, standbyClusters);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -70,7 +70,8 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
     public static final ClusterUuidMsg OP_ALL_STANDBY = ClusterUuidMsg.newBuilder().setLsb(3L).setMsb(3L).build();
     public static final ClusterUuidMsg OP_INVALID = ClusterUuidMsg.newBuilder().setLsb(4L).setMsb(4L).build();
     public static final ClusterUuidMsg OP_ENFORCE_SNAPSHOT_FULL_SYNC = ClusterUuidMsg.newBuilder().setLsb(5L).setMsb(5L).build();
-    public static final ClusterUuidMsg OP_BACKUP = ClusterUuidMsg.newBuilder().setLsb(6L).setMsb(6L).build();
+    public static final ClusterUuidMsg OP_BACKUP_WITH_INC_ID = ClusterUuidMsg.newBuilder().setLsb(6L).setMsb(6L).build();
+    public static final ClusterUuidMsg OP_BACKUP_WITHOUT_INC_ID = ClusterUuidMsg.newBuilder().setLsb(7L).setMsb(7L).build();
 
     @Getter
     private long configId;
@@ -326,8 +327,11 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
 
     /**
      * Create a new topology config, which replaces the active cluster with a backup cluster.
+     *
+     * Since it has been observed that the configID is not guaranteed to be incremented on every topology update,
+     * there are 2 flavours - increment the configId or have the same configId.
      **/
-    public TopologyDescriptor generateConfigWithBackup() {
+    public TopologyDescriptor generateConfigWithBackup(boolean incrTopologyId) {
         TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
         ClusterDescriptor currentActive = currentConfig.getActiveClusters().values().iterator().next();
 
@@ -345,7 +349,7 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         newActiveClusters.get(0).getNodesDescriptors().add(backupNode);
         List<ClusterDescriptor> standbyClusters = new ArrayList<>(currentConfig.getStandbyClusters().values());
 
-        return new TopologyDescriptor(configId, newActiveClusters, standbyClusters);
+        return new TopologyDescriptor(incrTopologyId ? ++configId : configId, newActiveClusters, standbyClusters);
     }
 
     /**
@@ -428,10 +432,14 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                             Thread.interrupted();
                         }
                     }
-                } else if (entry.getKey().equals(OP_BACKUP)) {
+                } else if (entry.getKey().equals(OP_BACKUP_WITH_INC_ID)) {
                     clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithBackup());
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithBackup(true));
+                } else if (entry.getKey().equals(OP_BACKUP_WITHOUT_INC_ID)) {
+                    clusterManager.getClusterManagerCallback()
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithBackup(false));
                 }
+
             } else {
                 log.info("onNext :: operation={}, key={}, payload={}, metadata={}", entry.getOperation().name(),
                         entry.getKey(), entry.getPayload(), entry.getMetadata());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
@@ -84,7 +84,7 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
             LogReplicationEntryMetadataMsg metadata = entry.getMetadata();
             if (metadata.getTimestamp() <= lastProcessedSeq) {
                 buffer.remove(metadata.getPreviousTimestamp());
-                log.warn("Removed {} from the buffer with no processing", metadata.getPreviousTimestamp());
+                log.warn("Remove entry without processing, ts={}, lastProcessed={}", metadata.getTimestamp(), lastProcessedSeq);
             } else if (metadata.getPreviousTimestamp() <= lastProcessedSeq && sinkManager.processMessage(entry)) {
                 ackCnt++;
                 buffer.remove(lastProcessedSeq);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
@@ -84,6 +84,7 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
             LogReplicationEntryMetadataMsg metadata = entry.getMetadata();
             if (metadata.getTimestamp() <= lastProcessedSeq) {
                 buffer.remove(metadata.getPreviousTimestamp());
+                log.warn("Removed {} from the buffer with no processing", metadata.getPreviousTimestamp());
             } else if (metadata.getPreviousTimestamp() <= lastProcessedSeq && sinkManager.processMessage(entry)) {
                 ackCnt++;
                 buffer.remove(lastProcessedSeq);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -1,7 +1,6 @@
 package org.corfudb.infrastructure.logreplication.replication.receive;
 
 import com.google.protobuf.TextFormat;
-import com.google.protobuf.Timestamp;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LogReplicationMetadataType;
@@ -75,7 +74,7 @@ public class LogEntryWriter extends SinkWriter {
         // value cannot be used here as its value needs to be changed in the lambda function below.
         AtomicBoolean registryTableUpdated = new AtomicBoolean(false);
         List<OpaqueEntry> opaqueEntryList = CorfuProtocolLogReplication.extractOpaqueEntries(txMessage);
-        log.warn("Number of opaqueEntries in the logEntry batch is {}", opaqueEntryList.size());
+        log.debug("Total opaqueEntries count={}", opaqueEntryList.size());
         for (OpaqueEntry opaqueEntry : opaqueEntryList) {
             try {
                 IRetry.build(IntervalRetry.class, () -> {
@@ -114,7 +113,7 @@ public class LogEntryWriter extends SinkWriter {
                         if (topologyConfigId != persistedTopologyConfigId || baseSnapshotTs != persistedSnapshotStart ||
                             baseSnapshotTs != persistedSnapshotDone || prevTs > persistedBatchTs) {
                             log.warn("Message metadata mismatch. Skip applying message {}, persistedTopologyConfigId={}," +
-                                    "persistedSnapshotStart={}, persistedSnapshotDone={}, persistedBatchTs={}. opaqueEntry.Version={}",
+                                    "persistedSnapshotStart={}, persistedSnapshotDone={}, persistedBatchTs={}, opaqueEntry.Version={}",
                                 txMessage.getMetadata(), persistedTopologyConfigId, persistedSnapshotStart,
                                 persistedSnapshotDone, persistedBatchTs, opaqueEntry.getVersion());
                             throw new IllegalArgumentException("Cannot apply log entry message due to metadata mismatch");
@@ -145,7 +144,7 @@ public class LogEntryWriter extends SinkWriter {
                             logReplicationMetadataManager.appendUpdate(txnContext,
                                 LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED,
                                 txMessage.getMetadata().getTimestamp());
-                            log.debug("updated LAST_LOG_ENTRY_BATCH_PROCESSED with {}",txMessage.getMetadata().getTimestamp());
+                            log.debug("Updated LAST_LOG_ENTRY_BATCH_PROCESSED with {}",txMessage.getMetadata().getTimestamp());
                         }
 
                         for (UUID streamId : opaqueEntry.getEntries().keySet()) {
@@ -190,7 +189,7 @@ public class LogEntryWriter extends SinkWriter {
                                 "batch ts {}, current log entry ts {}, ",  txMessage.getMetadata().getTimestamp(),opaqueEntry.getVersion(), tae);
                         throw new RetryNeededException();
                     } catch (Exception e) {
-                        log.error("Inside retry Caught exception while trying to apply the logEntryMsg..." +
+                        log.error("Inside retry - caught exception while trying to apply the logEntryMsg..." +
                                 "batch ts {}, current log entry ts {}, ", txMessage.getMetadata().getTimestamp(),opaqueEntry.getVersion(), e);
                         throw e;
                     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -439,6 +439,7 @@ public class LogReplicationMetadataManager {
             appendUpdate(txn, LogReplicationMetadataType.TOPOLOGY_CONFIG_ID, topologyConfigId);
             appendUpdate(txn, LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED, ts);
             appendUpdate(txn, LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED, ts);
+            appendUpdate(txn, LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED, ts);
 
             // Set 'isDataConsistent' flag on replication status table atomically with snapshot sync completed
             // information, to prevent any inconsistency between flag and state of snapshot sync completion in

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -245,6 +245,12 @@ public class StreamsLogEntryReader implements LogEntryReader {
 
             log.trace("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
                 currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
+            if (opaqueEntryList.size() > 0) {
+                log.warn("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
+                        currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
+                log.warn("The first entry in the batch {} and the last entry {}", opaqueEntryList.get(0).getVersion(),
+                        opaqueEntryList.get(opaqueEntryList.size() - 1).getVersion());
+            }
             final double currentMsgSizeSnapshot = currentMsgSize;
 
             messageSizeDistributionSummary.ifPresent(distribution -> distribution.record(currentMsgSizeSnapshot));
@@ -367,7 +373,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
                 return null;
 
             OpaqueEntry opaqueEntry = (OpaqueEntry) iterator.next();
-            log.trace("Address {} OpaqueEntry {}", opaqueEntry.getVersion(), opaqueEntry);
+            log.warn("Address {} OpaqueEntry {}", opaqueEntry.getVersion(), opaqueEntry);
             return opaqueEntry;
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -245,12 +245,6 @@ public class StreamsLogEntryReader implements LogEntryReader {
 
             log.trace("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
                 currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
-            if (opaqueEntryList.size() > 0) {
-                log.warn("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
-                        currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
-                log.warn("The first entry in the batch {} and the last entry {}", opaqueEntryList.get(0).getVersion(),
-                        opaqueEntryList.get(opaqueEntryList.size() - 1).getVersion());
-            }
             final double currentMsgSizeSnapshot = currentMsgSize;
 
             messageSizeDistributionSummary.ifPresent(distribution -> distribution.record(currentMsgSizeSnapshot));
@@ -373,7 +367,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
                 return null;
 
             OpaqueEntry opaqueEntry = (OpaqueEntry) iterator.next();
-            log.warn("Address {} OpaqueEntry {}", opaqueEntry.getVersion(), opaqueEntry);
+            log.trace("Address {} OpaqueEntry {}", opaqueEntry.getVersion(), opaqueEntry);
             return opaqueEntry;
         }
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -1603,6 +1603,28 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
+     * This test verifies the backup/restore workflow, and verifies LR behaviour when the topology update, pushed for
+     * simulating restore, has incremented the topologyConfigId
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testBackupRestoreWithIncrTopologyId() throws Exception {
+        backupRestoreWorkFlow(true);
+    }
+
+    /**
+     * This test verifies the backup/restore workflow, and verifies LR behaviour when the topology update, pushed for
+     * simulating restore, has the same topologyConfigId as the previous (initial) topology
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testBackupRestoreWorkflowWithOutIncrTopologyId() throws Exception {
+        backupRestoreWorkFlow(false);
+    }
+
+    /**
      * This test verifies log entry works after a force snapshot sync
      * in the backup/restore workflow.
      * <p>
@@ -1618,8 +1640,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      * 8. Verify the force snapshot sync is completed
      * 9. Write 5 entries to backup map, to verify Log Entry Sync
      */
-    @Test
-    public void testBackupRestoreWorkflow() throws Exception {
+    private void backupRestoreWorkFlow(boolean incrTopologyConfigId) throws Exception{
         Process backupCorfu = runServer(backupClusterCorfuPort, true);
         Process backupReplicationServer = runReplicationServer(backupReplicationServerPort, nettyPluginPath);
 
@@ -1697,7 +1718,11 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         }
 
         // Change the topology - brings up the backup cluster
-        updateTopology(activeCorfuStore, DefaultClusterManager.OP_BACKUP);
+        if (incrTopologyConfigId) {
+            updateTopology(activeCorfuStore, DefaultClusterManager.OP_BACKUP_WITH_INC_ID);
+        } else {
+            updateTopology(activeCorfuStore, DefaultClusterManager.OP_BACKUP_WITHOUT_INC_ID);
+        }
         log.info("Change the topology!!!");
 
         TimeUnit.SECONDS.sleep(shortInterval);


### PR DESCRIPTION
## Overview

Description:
set LAST_LOG_ENTRY_APPLIED on snapshot completion - Without this change, on a backup/restore when the backup is old and the restore regresses the log sequence, the first log-entry record gets dropped silently (L124 in LogEntryWriter.java) because the last_log_entry_applied still has the info of the cycle before the restore. 

Example : 
1. Active has data until ts 100, and standby has processed 100, hence  the last_log_entry_applied is 100
2. Backup that was taken when sequencer was at ts 50 is now restored on active. So active has regressed to sequence 50.
3. Active enforces a Snapshot sync at 50, and standby clears all the existing data and processes the incoming snapshot data - Metadata Last_snapshot_applied and last_log_entry_batch_processed says 50 but the last_log_entry_applied still says 100.
4. Active sends the first Log Entry sync at ts 55. The Standby silently drops the msg since it believes it has processed data until 100.  

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
