### PR TITLE
Bug fixes in Table FJP and Corfu browser

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -182,7 +182,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
                     .append(JsonFormat.printer().print(entry.getKey().getKey()));
             System.out.println(builder.toString());
         } catch (Exception e) {
-            log.info("invalid key: ", e);
+            log.info("invalid key: {}", entry.getKey().getKey(), e);
         }
     }
 
@@ -198,7 +198,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
                     .append(JsonFormat.printer().print(entry.getValue().getPayload()));
             System.out.println(builder.toString());
         } catch (Exception e) {
-            log.info("invalid payload: ", e);
+            log.info("invalid payload: {}", entry.getValue().getPayload(), e);
         }
     }
 
@@ -249,7 +249,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
                     .append(JsonFormat.printer().print(entry.getValue().getMetadata()));
             System.out.println(builder.toString());
         } catch (Exception e) {
-            log.info("invalid metadata: ", e);
+            log.info("invalid metadata: {}", entry.getValue().getMetadata(), e);
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -60,12 +61,24 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     // gets block on parallel stream, because the pool is exhausted with threads that are trying to acquire the VLO
     // look, which creates a circular dependency. In other words, a deadlock.
 
-    protected static final ForkJoinPool pool = new ForkJoinPool(Math.max(Runtime.getRuntime().availableProcessors() / 2, 1),
+    private static final int FJP_PARALLELISM = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
+
+    protected static final ForkJoinPool pool = new ForkJoinPool(
+            FJP_PARALLELISM,
             pool -> {
                 final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
                 worker.setName("Table-Forkjoin-pool-" + worker.getPoolIndex());
                 return worker;
-            }, null, true);
+            },
+            null,
+            true,
+            2 * FJP_PARALLELISM, // corePoolSize == 2 * parallelism to avoid bug JDK-8330017
+            Integer.MAX_VALUE, // default to FJP.MAX_CAP
+            1,
+            null,
+            60,
+            TimeUnit.SECONDS
+            );
 
     private ICorfuTable<K, CorfuRecord<V, M>> corfuTable;
 


### PR DESCRIPTION
1. Set Table ForkJoinPool corePoolSize to 2 * parallelism. This is a workaround to a known FJP bug (JDK-8330017) in JDK11 and JDK17.

2. Corfu browser logs protobuf string upon Json printer failure. There is a known issue in Protobuf's Json printer that it can't print a protobuf message with Any fields without a type registry. Log raw protobuf messages when corfu browser can't convert it to Json.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
