### PR TITLE
Multiple fixes

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -182,7 +182,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
                     .append(JsonFormat.printer().print(entry.getKey().getKey()));
             System.out.println(builder.toString());
         } catch (Exception e) {
-            log.info("invalid key: ", e);
+            log.info("invalid key: {}", entry.getKey().getKey(), e);
         }
     }
 
@@ -198,7 +198,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
                     .append(JsonFormat.printer().print(entry.getValue().getPayload()));
             System.out.println(builder.toString());
         } catch (Exception e) {
-            log.info("invalid payload: ", e);
+            log.info("invalid payload: {}", entry.getValue().getPayload(), e);
         }
     }
 
@@ -249,7 +249,7 @@ public class CorfuStoreBrowserEditor implements CorfuBrowserEditorCommands {
                     .append(JsonFormat.printer().print(entry.getValue().getMetadata()));
             System.out.println(builder.toString());
         } catch (Exception e) {
-            log.info("invalid metadata: ", e);
+            log.info("invalid metadata: {}", entry.getValue().getMetadata(), e);
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -60,12 +61,29 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     // gets block on parallel stream, because the pool is exhausted with threads that are trying to acquire the VLO
     // look, which creates a circular dependency. In other words, a deadlock.
 
-    protected static final ForkJoinPool pool = new ForkJoinPool(Math.max(Runtime.getRuntime().availableProcessors() / 2, 1),
+    private static final String FJP_METRICS_POOL_SIZE = "table.fjp.pool_size";
+    private static final String FJP_METRICS_RUNNING_THREAD_COUNT = "table.fjp.running_thread_count";
+    private static final String FJP_METRICS_ACTIVE_THREAD_COUNT = "table.fjp.active_thread_count";
+    private static final String FJP_METRICS_QUEUED_TASK_COUNT = "table.fjp.queued_task_count";
+
+    private static final int FJP_PARALLELISM = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
+
+    protected static final ForkJoinPool pool = new ForkJoinPool(
+            FJP_PARALLELISM,
             pool -> {
                 final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
                 worker.setName("Table-Forkjoin-pool-" + worker.getPoolIndex());
                 return worker;
-            }, null, true);
+            },
+            null,
+            true,
+            2 * FJP_PARALLELISM, // corePoolSize == 2 * parallelism to avoid bug JDK-8330017
+            Integer.MAX_VALUE, // default to FJP.MAX_CAP
+            1,
+            null,
+            60,
+            TimeUnit.SECONDS
+            );
 
     private ICorfuTable<K, CorfuRecord<V, M>> corfuTable;
 
@@ -165,6 +183,11 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
         } else {
             this.guidGenerator = null;
         }
+
+        MicroMeterUtils.gauge(FJP_METRICS_POOL_SIZE, pool, ForkJoinPool::getPoolSize);
+        MicroMeterUtils.gauge(FJP_METRICS_RUNNING_THREAD_COUNT, pool, ForkJoinPool::getRunningThreadCount);
+        MicroMeterUtils.gauge(FJP_METRICS_ACTIVE_THREAD_COUNT, pool, ForkJoinPool::getActiveThreadCount);
+        MicroMeterUtils.gauge(FJP_METRICS_QUEUED_TASK_COUNT, pool, ForkJoinPool::getQueuedTaskCount);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
@@ -10,6 +10,7 @@ public enum AbortCause {
     //TODO(Maithem): these types are redundant and should be removed,
     // we should just expose the throwable
     CONFLICT,
+    DEADLOCK,
     OVERWRITE, /** Aborted because of slow writer, i.e., continuously gets overwritten (hole filled by faster reader) */
     NEW_SEQUENCER,
     SIZE_EXCEEDED,


### PR DESCRIPTION
1. Set Table ForkJoinPool corePoolSize to 2 * parallelism as a workaround for
JDK-8330017.

This addresses a known ForkJoinPool bug (JDK-8330017) in JDK 11 and JDK 17,
where TC underflow can cause the pool to hang. The workaround increases
corePoolSize to 2 * parallelism, which ensures that TC (initialized as
-max(corePoolSize, parallelism)) starts at a lower absolute value. This reduces
the likelihood of TC reaching 0, which triggers the underflow.

The impact on performance and resource consumption is minimal because active
worker threads are still controlled by parallelism. A higher corePoolSize
primarily affects workloads with blocking tasks, where it helps retain more
worker threads.

This workaround does not completely prevent the TC underflow issue but makes it
less likely to occur.

2. Corfu browser logs protobuf string upon Json printer failure. There is a
known issue in Protobuf's Json printer that it can't print a protobuf message
with Any fields without a type registry. Log raw protobuf messages when corfu
browser can't convert it to Json.

3. Add AbortCause.DEADLOCK

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
