### PR TITLE
[9.0] Avoid FJP bug in Compactor's liveness validator

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
@@ -133,7 +133,7 @@ public class LivenessValidator {
                 .getStreamAddressSpace(new StreamAddressRange(cpStreamId, Address.MAX, Address.NON_ADDRESS)).getTail();
     }
 
-    private int getIdleCount() {
+    public int getIdleCount() {
         int idleCount = 0;
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             Set<TableName> checkpointTableNames = txn.keySet(CompactorMetadataTables.CHECKPOINT_STATUS_TABLE_NAME);

--- a/test/src/test/java/org/corfudb/infrastructure/LivenessValidatorUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LivenessValidatorUnitTest.java
@@ -82,9 +82,8 @@ public class LivenessValidatorUnitTest {
     @Test
     public void shouldChangeManagerStatusTest() {
         List<CorfuStoreEntry<? extends Message, ? extends Message, ? extends Message>> mockList = mock(List.class);
-        when(txn.executeQuery(anyString(), any(Predicate.class))).thenReturn(mockList);
+        doReturn(1).when(livenessValidatorSpy).getIdleCount();
 
-        when(mockList.size()).thenReturn(1);
         Assert.assertEquals(LivenessValidator.Status.NONE,
                 livenessValidatorSpy.shouldChangeManagerStatus(Duration.ofSeconds(0)));
 


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Existing use of executeQuery() was vulnerable to the FJP bug [JDK-8330017](https://bugs.openjdk.org/browse/JDK-8330017?jql=labels%20%3D%20reproducer-hard)

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
