### PR TITLE
Add FJPGuard to monitor and reset FJP's RC

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
@@ -18,6 +17,7 @@ import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.runtime.view.ObjectsView.ObjectID;
 import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.util.FJPGuard;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.SafeProtobufSerializer;
 
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -62,37 +61,16 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
     // gets block on parallel stream, because the pool is exhausted with threads that are trying to acquire the VLO
     // look, which creates a circular dependency. In other words, a deadlock.
 
-    private static final String FJP_METRICS_POOL_SIZE = "table.fjp.pool_size";
-    private static final String FJP_METRICS_RUNNING_THREAD_COUNT = "table.fjp.running_thread_count";
-    private static final String FJP_METRICS_ACTIVE_THREAD_COUNT = "table.fjp.active_thread_count";
-    private static final String FJP_METRICS_QUEUED_TASK_COUNT = "table.fjp.queued_task_count";
-
-    private static final int FJP_PARALLELISM = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
-
-    protected static final ForkJoinPool pool = new ForkJoinPool(
-            FJP_PARALLELISM,
+    protected static final ForkJoinPool pool = new ForkJoinPool(Math.max(Runtime.getRuntime().availableProcessors() / 2, 1),
             pool -> {
                 final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
                 worker.setName("Table-Forkjoin-pool-" + worker.getPoolIndex());
                 return worker;
-            },
-            null,
-            true,
-            2 * FJP_PARALLELISM, // corePoolSize == 2 * parallelism to avoid bug JDK-8330017
-            Integer.MAX_VALUE, // default to FJP.MAX_CAP
-            1,
-            null,
-            60,
-            TimeUnit.SECONDS
-            );
+            }, null, true);
 
     static {
-        if (MeterRegistryProvider.getInstance().isPresent()) {
-            MicroMeterUtils.gauge(FJP_METRICS_POOL_SIZE, pool, ForkJoinPool::getPoolSize);
-            MicroMeterUtils.gauge(FJP_METRICS_RUNNING_THREAD_COUNT, pool, ForkJoinPool::getRunningThreadCount);
-            MicroMeterUtils.gauge(FJP_METRICS_ACTIVE_THREAD_COUNT, pool, ForkJoinPool::getActiveThreadCount);
-            MicroMeterUtils.gauge(FJP_METRICS_QUEUED_TASK_COUNT, pool, ForkJoinPool::getQueuedTaskCount);
-        }
+        FJPGuard fjpGuard = new FJPGuard(pool);
+        fjpGuard.start();
     }
 
     private ICorfuTable<K, CorfuRecord<V, M>> corfuTable;

--- a/runtime/src/main/java/org/corfudb/util/FJPGuard.java
+++ b/runtime/src/main/java/org/corfudb/util/FJPGuard.java
@@ -1,0 +1,115 @@
+package org.corfudb.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ScheduledExecutorService;
+
+
+/**
+ * This class is used to monitor and protect the FJP ReleaseCount (RC) from
+ * leaking to a max value and causing the FJP to stop executing tasks.
+ *
+ * <p>This class is a workaround for JDK-8330017.
+ *
+ * <p>See this issue for more details:
+ * <a href="https://bugs.openjdk.org/browse/JDK-8330017">JDK-8330017</a>
+ */
+@Slf4j
+public class FJPGuard {
+
+    private static final int RC_RESET_LIMIT = -10_000;
+
+    private static final int RC_RESET_VALUE = -100;
+
+    private static final int RC_SHIFT = 48;
+
+    private static final long NON_RC_MASK = 0x0000FFFFFFFFFFFFL;
+
+    private volatile int lastRc;
+
+    private final ForkJoinPool pool;
+
+    private final ScheduledExecutorService scheduler;
+
+    public FJPGuard(ForkJoinPool pool) {
+        this.pool = pool;
+        this.scheduler = Executors.newScheduledThreadPool(1, r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            t.setName("FJP-guard");
+            return t;
+        });
+    }
+
+    public void start() {
+        scheduler.scheduleWithFixedDelay(
+            () -> LambdaUtils.runSansThrow(this::checkAndUpdateCtl),
+            60,
+            60,
+            java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    private void checkAndUpdateCtl() {
+        try {
+            Field ctlField = pool.getClass().getDeclaredField("ctl");
+            ctlField.setAccessible(true);
+            VarHandle ctlHandle = MethodHandles.privateLookupIn(ForkJoinPool.class, MethodHandles.lookup())
+                    .unreflectVarHandle(ctlField);
+
+            long ctl = (long) ctlHandle.getVolatile(pool);
+            log.info(ctlAsBinary(ctl));
+
+            // if the last RC value is less than the reset limit, reset the ctl
+            if (lastRc < RC_RESET_LIMIT) {
+                long newCtl = ((long)RC_RESET_VALUE << RC_SHIFT) | (ctl & NON_RC_MASK);
+                boolean success = ctlHandle.compareAndSet(pool, ctl, newCtl);
+
+                if (success) {
+                    log.info("Successfully reset ctl to: {}", ctlAsBinary(newCtl));
+                } else {
+                    log.info("Failed to reset ctl, will retry in next cycle.");
+                }
+            }
+        } catch (Throwable t) {
+            log.error("Failed to access/reset FJP ctl!", t);
+        }
+    }
+
+    private String ctlAsBinary(long value) {
+        // convert and pad zeros
+        String binaryCtl = String.format("%64s", Long.toBinaryString(value)).replace(' ', '0');
+        String binaryRc = binaryCtl.substring(0, 16);
+        String binaryTc = binaryCtl.substring(16, 32);
+        String binarySs = binaryCtl.substring(32, 48);
+        String binaryId = binaryCtl.substring(48, 64);
+
+        lastRc = binaryToInt(binaryRc);
+
+        return "CTL=(" + value + "), " +
+                "RC=(" + prettifyBinary(binaryRc) + ", " + binaryToInt(binaryRc) + "), " +
+                "TC=(" + prettifyBinary(binaryTc) + ", " + binaryToInt(binaryTc) + "), " +
+                "SS=(" + prettifyBinary(binarySs) + ", " + binaryToInt(binarySs) + "), " +
+                "ID=(" + prettifyBinary(binaryId) + ", " + binaryToInt(binaryId) + ")";
+    }
+
+    private int binaryToInt(String binary) {
+        int decimalValue = Integer.parseInt(binary, 2);
+
+        // For negative value, subtract 2^16
+        if (binary.charAt(0) == '1') {
+            decimalValue -= (1 << 16);
+        }
+        return decimalValue;
+    }
+
+    // Add a space after 8 bits
+    private String prettifyBinary(String binary) {
+        return binary.replaceAll("(.{8})", "$1 ");
+    }
+
+}


### PR DESCRIPTION
## Overview

    As it turned out that previous PR https://github.com/CorfuDB/CorfuDB/pull/4043
    doesn't fix the RC underflow issue especially when parallelStream() is used,
    this is the second workaround which uses a daemon thread to periodically
    monitor and reset ctl's RC. Note that this workaround doesn't fix the broken
    FJP pool resizing, but nor does it worsen the original issue.


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
