### PR TITLE
Expose some essential functions from DynamicProtobufSerializer

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -257,7 +257,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * @return FileDescriptor.
      * @throws DescriptorValidationException If FileDescriptor construction fails.
      */
-    protected FileDescriptor getDescriptor(String name) throws DescriptorValidationException {
+    public FileDescriptor getDescriptor(String name) throws DescriptorValidationException {
 
         if (fileDescriptorMap.containsKey(name)) {
             return fileDescriptorMap.get(name);
@@ -308,7 +308,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * @param message Any message.
      * @return Full name of the message.
      */
-    protected String getFullMessageName(Any message) {
+    public String getFullMessageName(Any message) {
         String typeUrl = message.getTypeUrl();
         return typeUrl.substring(typeUrl.lastIndexOf('/') + 1);
     }
@@ -342,6 +342,13 @@ public class DynamicProtobufSerializer implements ISerializer {
             return null;
         }
         return builder.build();
+    }
+
+    public DynamicMessage createDynamicMessage(Any message) throws DescriptorValidationException, InvalidProtocolBufferException {
+        String fullMessageName = getFullMessageName(message);
+        FileDescriptor valueFileDescriptor = getDescriptor(messagesFdProtoNameMap.get(fullMessageName));
+        Descriptors.Descriptor valueDescriptor = valueFileDescriptor.findMessageTypeByName(getMessageName(message));
+        return DynamicMessage.parseFrom(valueDescriptor, message.getValue());
     }
 
     /**


### PR DESCRIPTION
## Overview
Description:
Why should this be merged: 
This avoids having to duplicate code in other areas and makes this layer re-usable.
+Simple IT to validate the new exposed api.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
