### PR TITLE
Disable RoaringBitMap cardinality cache in StreamAddressSpace no-arg constructor

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.view.stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Longs;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
@@ -54,7 +55,7 @@ final public class StreamAddressSpace {
 
     public StreamAddressSpace() {
         // Note: caching of internal bitmap structures is disabled by default here.
-        this(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(), false);
+        this(false);
     }
 
     public StreamAddressSpace(boolean enableCaching) {
@@ -353,6 +354,11 @@ final public class StreamAddressSpace {
      */
     public long[] toArray() {
         return bitmap.toArray();
+    }
+
+    @VisibleForTesting
+    Roaring64NavigableMap getBitmap() {
+        return bitmap;
     }
 
     @Override

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -8,9 +8,11 @@ import io.netty.buffer.Unpooled;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.view.Address;
 import org.junit.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.io.DataInputStream;
 import java.io.DataOutput;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -377,5 +379,24 @@ public class StreamAddressSpaceTest {
         assertThat(sas.toString()).isEqualTo("[4, 4]@-1 size 1");
         sas.trim(4L);
         assertThat(sas.toString()).isEqualTo("[-6, -6]@4 size 0");
+    }
+
+    @Test
+    public void testNoArgConstructor() {
+        StreamAddressSpace sas = new StreamAddressSpace();
+        assertThat(getDoCacheCardinalities(sas.getBitmap())).isFalse();
+
+        sas = new StreamAddressSpace(true);
+        assertThat(getDoCacheCardinalities(sas.getBitmap())).isTrue();
+    }
+
+    private boolean getDoCacheCardinalities(Roaring64NavigableMap map) {
+        try {
+            Field field = Roaring64NavigableMap.class.getDeclaredField("doCacheCardinalities");
+            field.setAccessible(true);
+            return field.getBoolean(map);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to access doCacheCardinalities", e);
+        }
     }
 }


### PR DESCRIPTION
## Overview

Description:
It is intended that cardinality cache of RoaringBitmap should be disabled by default in order to avoid non-theadsafe bitmap anomalies. This PR fixes the no-arg constructor of StreamAddressSpace to disable the cache.

Why should this be merged: 
Read operations of Roaring64NavigableMap could mutate internal cache states if cardinality cache is enabled. This leads to undefined exceptions including IllegalStateException and ArrayIndexOutOfBoundsException.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
