### PR TITLE
Dump multiple tables at once reusing connection

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuBrowserEditorCommands.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuBrowserEditorCommands.java
@@ -41,6 +41,15 @@ public interface CorfuBrowserEditorCommands {
     int printTable(String namespace, String tablename);
 
     /**
+     * Prints the key, payload and metadata for all tables in inputFile
+     *
+     * @param inputFile - file with list of namespace$tableName rows
+     * @param outputDirectory - directory path where the dumps of the tables will go to
+     * @return - number of tables dumped
+     */
+    int printTables(String inputFile, String outputDirectory);
+
+    /**
      * List all tables in CorfuStore
      *
      * @param namespace - the namespace where the table belongs

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuOfflineBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuOfflineBrowserEditor.java
@@ -223,7 +223,7 @@ public class CorfuOfflineBrowserEditor implements CorfuBrowserEditorCommands {
         if (namespace.equals(TableRegistry.CORFU_SYSTEM_NAMESPACE)
                 && tableName.equals(TableRegistry.REGISTRY_TABLE_NAME)) {
             getTableData(namespace, tableName);
-            return printTableRegistry(dynamicProtobufSerializer);
+            return printTableRegistry(dynamicProtobufSerializer, null);
         }
 
         if (namespace.equals(TableRegistry.CORFU_SYSTEM_NAMESPACE)
@@ -236,11 +236,22 @@ public class CorfuOfflineBrowserEditor implements CorfuBrowserEditorCommands {
         Set<Map.Entry<CorfuDynamicKey, CorfuDynamicRecord>> entries = cachedTable.entrySet();
 
         for (Map.Entry<CorfuDynamicKey, CorfuDynamicRecord> entry : entries) {
-            printKey(entry);
-            printPayload(entry);
-            printMetadata(entry);
+            printKey(entry, null);
+            printPayload(entry, null);
+            printMetadata(entry, null);
         }
         return cachedTable.size();
+    }
+
+    /**
+     * Prints the payload and metadata in the given table
+     * @param inputFile - input file with namespace$TableName rows
+     * @param outputDirectory - directory where the output files should be placed.
+     * @return - number of tables dumped.
+     */
+    @Override
+    public int printTables(String inputFile, String outputDirectory) {
+        return 0;
     }
 
     /**

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
@@ -30,6 +30,7 @@ public class CorfuStoreBrowserEditorMain {
         loadTable,
         infoTable,
         showTable,
+        showTables,
         listenOnTable,
         clearTable,
         listAllProtos,
@@ -57,13 +58,15 @@ public class CorfuStoreBrowserEditorMain {
         "[--itemSize=<sizeOfEachRecordValue>] "
         + "[--keyToEdit=<keyToEdit>] [--newRecord=<newRecord>] [--tag=<tag>]"
         + "[--keyToDelete=<keyToDelete>]"
+        + "[--tablesToDumpInputFile=<tablesToDumpInputFile>]"
+        + "[--tablesToDumpOutputDir=<tablesToDumpOutputDir>]"
         + "[--keysToDeleteFilePath=<keysToDeleteFilePath>]"
         + "[--keyToAdd=<keyToAdd>] [--valueToAdd=<valueToAdd>] [--metadataToAdd=<metadataToAdd>]"
         + "[--tlsEnabled=<tls_enabled>]\n"
         + "Options:\n"
         + "--host=<host>   Hostname\n"
         + "--port=<port>   Port\n"
-        + "--operation=<listTables|infoTable|showTable|clearTable"
+        + "--operation=<listTables|infoTable|showTable|showTables|clearTable"
         + "|editTable|deleteRecord|loadTable|listenOnTable|listTags|listTagsMap"
         + "|listTablesForTag|listTagsForTable|listAllProtos> Operation\n"
         + "--namespace=<namespace>   Namespace\n"
@@ -78,6 +81,8 @@ public class CorfuStoreBrowserEditorMain {
         + "--address=<address> Log global address\n"
         + "--batchSize=<batchSize> Number of records per transaction for loadTable\n"
         + "--itemSize=<itemSize> Size of each item's payload for loadTable\n"
+        + "--tablesToDumpInputFile=<tablesToDumpInputFile> Path to input file with namespace$tableName rows\n"
+        + "--tablesToDumpOutputDir=<tablesToDumpOutputDir> Path to dir (with write permissions) for table dumps\n"
         + "--keyToEdit=<keyToEdit> Key of the record to edit\n"
         + "--keyToDelete=<keyToDelete> Key of the record to be deleted\n"
         + "--keysToDeleteFilePath=<keysToDeleteFilePath> Path to file having all keys in one json array\n"
@@ -238,6 +243,24 @@ public class CorfuStoreBrowserEditorMain {
                 Preconditions.checkArgument(isValid(tableName),
                         "Table name is null or empty.");
                 return browser.printTable(namespace, tableName);
+            case showTables:
+                String inputFile = "--tablesToDumpInputFile";
+                String outputDir = "--tablesToDumpOutputDir";
+                Preconditions.checkArgument(isValid(inputFile),
+                        "--tablesToDumpInputFile is null or empty.");
+                Preconditions.checkArgument(isValid(outputDir),
+                        "tablesToDumpOutputDir is null or empty.");
+                if (opts.get(inputFile) != null) {
+                    inputFile = String.valueOf(opts.get(inputFile));
+                    Preconditions.checkNotNull(inputFile,
+                            "--tablesToDumpInputFile is Null.");
+                }
+                if (opts.get(outputDir) != null) {
+                    outputDir = String.valueOf(opts.get(outputDir));
+                    Preconditions.checkNotNull(outputDir,
+                            "--tablesToDumpOutputDir is Null.");
+                }
+                return browser.printTables(inputFile, outputDir);
             case editTable:
                 String keyToEdit = null;
                 String newRecord = null;


### PR DESCRIPTION
This allows triaging tools to simultaneously dump
several tables at once and re-use the connection made by the tool to CorfuServer saving time in setup & teardown.
Also make the output in full parseable json format for easy tooling. For example, it is now possible to check if a big table dump carries a record with something like `jq '.[] | select(.key == "foo")' tableName.json`

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
