### PR TITLE
Upgrade Netty Version from 4.1.111.Final to 4.1.119.Final (#4053)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- Dependency versions -->
         <slf4j.version>2.0.16</slf4j.version>
-        <netty.version>4.1.111.Final</netty.version>
+        <netty.version>4.1.119.Final</netty.version>
         <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
         <protobuf.version>3.21.12</protobuf.version>
         <commons.io.version>2.18.0</commons.io.version>


### PR DESCRIPTION
Fixes CVE-2024-47535.
This CL updates Netty alone without upgrading gRPC and protobuf versions.
I have tested that this newer version is compatible with the current gRPC and protobuf versions.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
