### PR TITLE
Update prior snapshot sync info on LOG_ENTRY_SYNC_REQUEST

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -568,6 +568,59 @@ public class LogReplicationMetadataManager {
     }
 
     /**
+     * Update replication status table's prior sync info as COMPLETED.
+     *
+     * @param clusterId standby cluster id
+     * @param baseSnapshot Corfu log timestamp at which the last snapshot was based
+     */
+    public void setPriorSnapshotInfoComplete(String clusterId, long baseSnapshot) {
+        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
+        ReplicationStatusVal updatedStatusVal;
+
+        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+
+            CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> record = txn.getRecord(replicationStatusTable, key);
+
+            if (record.getPayload() == null) {
+                log.error("Remote Cluster {} not found in Replication Status Table.", clusterId);
+                return;
+            }
+
+            ReplicationStatusVal previousStatusVal = record.getPayload();
+            SnapshotSyncInfo previousSyncInfo = previousStatusVal.getSnapshotSyncInfo();
+            SnapshotSyncInfo updatedSyncInfo;
+
+            if (previousSyncInfo.getStatus().equals(SyncStatus.COMPLETED)) {
+                log.info("Previous sync already marked complete, skipping update of previous sync info.");
+                return;
+            }
+
+            Instant time = Instant.now();
+            Timestamp timestamp = Timestamp.newBuilder().setSeconds(time.getEpochSecond())
+                    .setNanos(time.getNano()).build();
+            updatedSyncInfo = previousSyncInfo.toBuilder()
+                    .setStatus(SyncStatus.COMPLETED)
+                    .setBaseSnapshot(baseSnapshot)
+                    .setCompletedTime(timestamp)
+                    .build();
+
+            snapshotSyncTimerSample
+                    .flatMap(sample -> MeterRegistryProvider.getInstance()
+                            .map(registry -> {
+                                Timer timer = registry.timer("logreplication.snapshot.duration");
+                                return sample.stop(timer);
+                            }));
+
+            updatedStatusVal = previousStatusVal.toBuilder()
+                    .setSnapshotSyncInfo(updatedSyncInfo)
+                    .build();
+
+            txn.putRecord(replicationStatusTable, key, updatedStatusVal, null);
+            txn.commit();
+        }
+    }
+
+    /**
      * Update replication status table's sync status
      *
      * Note: TransactionAbortedException has been handled by upper level.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -281,7 +281,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
 
             /*
              * In the event during the last snapshot sync, apply had processed on the sink, but active had
-             * been interrupted before updating the replication metadata then we should update the prior sync's info.
+             * been interrupted (e.g. leadership change, network partition, active leader restart) before
+             * updating the replication metadata then we should update the prior sync's info.
              */
             fsm.getSourceManager().getAckReader().setBaseSnapshot(negotiationResponse.getSnapshotApplied());
             fsm.getSourceManager().getAckReader().markPriorSnapshotInfoCompleted();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -278,6 +278,13 @@ public class NegotiatingState implements LogReplicationRuntimeState {
         if (negotiationResponse.getSnapshotStart() == negotiationResponse.getSnapshotTransferred() &&
                 negotiationResponse.getSnapshotStart() == negotiationResponse.getSnapshotApplied() &&
                 negotiationResponse.getLastLogEntryTimestamp() >= negotiationResponse.getSnapshotStart()) {
+
+            /*
+             * In the event during the last snapshot sync, apply had processed on the sink, but active had
+             * been interrupted before updating the replication metadata then we should update the prior sync's info.
+             */
+            fsm.getSourceManager().getAckReader().markPriorSnapshotInfoCompleted();
+
             /*
              * If the next log entry is not trimmed, restart with log entry sync,
              * otherwise, start snapshot full sync.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -283,6 +283,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
              * In the event during the last snapshot sync, apply had processed on the sink, but active had
              * been interrupted before updating the replication metadata then we should update the prior sync's info.
              */
+            fsm.getSourceManager().getAckReader().setBaseSnapshot(negotiationResponse.getSnapshotApplied());
             fsm.getSourceManager().getAckReader().markPriorSnapshotInfoCompleted();
 
             /*

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -411,6 +411,14 @@ public class AbstractIT extends AbstractCorfuTest {
                 .runServer();
     }
 
+    public Process runReplicationServer(int port, int waitInSnapshotApplyMs) throws IOException {
+        return new CorfuReplicationServerRunner()
+                .setHost(DEFAULT_HOST)
+                .setPort(port)
+                .setWaitSnapshotApplyMs(waitInSnapshotApplyMs)
+                .runServer();
+    }
+
     public Process runReplicationServerWaitInSnapshotApply(int port, String pluginConfigFilePath,
                                                            int lockLeaseDuration, int waitInSnapshotApplyMs)
                                                         throws IOException {

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -411,14 +411,6 @@ public class AbstractIT extends AbstractCorfuTest {
                 .runServer();
     }
 
-    public Process runReplicationServer(int port, int waitInSnapshotApplyMs) throws IOException {
-        return new CorfuReplicationServerRunner()
-                .setHost(DEFAULT_HOST)
-                .setPort(port)
-                .setWaitSnapshotApplyMs(waitInSnapshotApplyMs)
-                .runServer();
-    }
-
     public Process runReplicationServerWaitInSnapshotApply(int port, String pluginConfigFilePath,
                                                            int lockLeaseDuration, int waitInSnapshotApplyMs)
                                                         throws IOException {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -1506,12 +1506,10 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(mapActive.count()).isEqualTo(firstBatch);
         assertThat(mapStandby.count()).isZero();
 
-
         int waitInSnapshotApplyMs = 10000;
         activeReplicationServer = runReplicationServer(activeReplicationServerPort);
         standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, waitInSnapshotApplyMs);
         log.info("Replication servers started...");
-
 
         // Verify Sync Status
         Sleep.sleepUninterruptibly(Duration.ofSeconds(3));
@@ -1538,14 +1536,15 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
             }
         }
 
-        log.info("Restart active to simulate blip...");
+        // Shutdown active while sync is ongoing
         shutdownCorfuServer(activeReplicationServer);
-        activeReplicationServer = runReplicationServer(activeReplicationServerPort);
 
         // Wait for apply to complete on the sink
         waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
         assertThat(mapStandby.count()).isEqualTo(firstBatch);
 
+        // Restart active after apply on sink
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort);
 
         // Status should be updated on active to reflect the last snapshot sync was completed
         while (true) {


### PR DESCRIPTION
## Overview

Description:

Mark previous snapshot info as completed when transitioning from INITIALIZED -> LOG_ENTRY_SYNC

Why should this be merged: 

In cases where the reception of the snapshot apply ack was interrupted on source but the apply had completed on the sink, ex. during a network blip and we start negotiation, we will know to continue to log entry from the sinks negotiation response but will never mark the prior snapshot sync's info as complete. 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
