### PR TITLE
Revert "Upgrade Netty Version from 4.1.111.Final to 4.1.119.Final (#4053)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- Dependency versions -->
         <slf4j.version>2.0.16</slf4j.version>
-        <netty.version>4.1.119.Final</netty.version>
+        <netty.version>4.1.111.Final</netty.version>
         <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
         <protobuf.version>3.21.12</protobuf.version>
         <commons.io.version>2.18.0</commons.io.version>


### PR DESCRIPTION
Reverts CorfuDB/CorfuDB#4061

Reason: Postponed to next release - corfu-0.4.2.4.