### PR TITLE
Silent Failures During Stream Sync

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -16,6 +16,8 @@ import org.corfudb.runtime.exceptions.LogUnitException;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -161,6 +163,7 @@ public class StreamLogFiles implements StreamLog {
     private void initializeLogMetadata() {
         long startingSegment = getStartingSegment();
         long tailSegment = dataStore.getTailSegment();
+        long currentTrimMark = getTrimMark();
 
         long start = System.currentTimeMillis();
         // Scan the log in reverse, this will ease stream trim mark resolution (as we require the
@@ -176,6 +179,19 @@ public class StreamLogFiles implements StreamLog {
                     }
                     LogData logEntry = read(address);
                     logMetadata.update(logEntry, true);
+                }
+            }
+        }
+
+        // For streams whose trimMark was not resolved by a checkpoint END record,
+        // set the trim mark so the sequencer bootstraps with correct per-stream trim
+        // data. All bitmap entries are already >= startingAddress (scan skips trimmed
+        // entries), so setTrimMark is sufficient — no bitmap entries need removal.
+        if (currentTrimMark > 0) {
+            long lastTrimmedAddress = currentTrimMark - 1;
+            for (StreamAddressSpace sas : logMetadata.getStreamsAddressSpaceMap().values()) {
+                if (sas.getTrimMark() == Address.NON_EXIST) {
+                    sas.setTrimMark(lastTrimmedAddress);
                 }
             }
         }

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -558,10 +558,12 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
                 tableB.insert(String.valueOf(i), i);
             }
 
-            // Checkpoint A with snapshot @ 9
-            CheckpointWriter<PersistentCorfuTable<String, Integer>> cpw =
-                    new CheckpointWriter<>(runtime, CorfuRuntime.getStreamID(streamNameA), "checkpointer-test", tableA);
-            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1), Optional.empty());
+            // Checkpoint both tables (matching production where all tables are
+            // checkpointed before trim). Checkpoint A at snapshot @ 9.
+            MultiCheckpointWriter<PersistentCorfuTable<String, Integer>> mcw = new MultiCheckpointWriter<>();
+            mcw.addMap(tableA);
+            mcw.addMap(tableB);
+            Token cpAddress = mcw.appendCheckpoints(runtime, "checkpointer-test");
 
             // Trim the log
             runtime.getAddressSpaceView().prefixTrim(cpAddress);
@@ -580,9 +582,9 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameB));
 
-            // Verify address space and trim mark is properly set for the given stream.
-            assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.size()).isEqualTo(insertions);
+            // With both tables checkpointed, streamB's trimMark is set by
+            // trim() during prefixTrim (highest removed bitmap address).
+            assertThat(addressSpaceB.getTrimMark()).isNotEqualTo(Address.NON_EXIST);
 
             // Open tableB new runtime
             PersistentCorfuTable<String, Integer> tableBNewRuntime = createCorfuTable(rt2, streamNameB);
@@ -606,9 +608,9 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameB));
 
-            // Verify address space and trim mark is properly set for the given stream.
-            assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.size()).isEqualTo(insertions);
+            // After restart, initializeLogMetadata or checkpoint END record
+            // ensures streamB's trimMark is set.
+            assertThat(addressSpaceB.getTrimMark()).isNotEqualTo(Address.NON_EXIST);
 
             // Open tableB after restart
             PersistentCorfuTable<String, Integer> tableBRestart = createCorfuTable(runtimeRestart, streamNameB);

--- a/test/src/test/java/org/corfudb/integration/StreamSyncSilentDataLossIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamSyncSilentDataLossIT.java
@@ -1,0 +1,82 @@
+package org.corfudb.integration;
+
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.stream.IStreamView;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces the silent trim gap scenario that leads to data loss.
+ *
+ * The client syncs part of a stream, then a prefix trim occurs, the server
+ * restarts, and more data is appended. Without the fix, the client fails to
+ * detect the gap between its last synced position and the trim mark, silently
+ * skipping trimmed entries. With the fix, remaining() throws TrimmedException.
+ *
+ * This exercises the IStreamView / AddressMapStreamView code path.
+ *
+ * Adapted from PR #3328 (Maithem, 2022-08-18).
+ */
+@SuppressWarnings("PMD.ClassNamingConventions")
+public class StreamSyncSilentDataLossIT extends AbstractIT {
+
+    @Test
+    public void testIStreamViewDetectsTrimGapAfterRestart() throws Exception {
+        final String host = "localhost";
+        final int port = 9000;
+        final String endpoint = host + ":" + port;
+
+        Process p = new CorfuServerRunner()
+                .setHost(host)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(host, port))
+                .setSingle(true)
+                .runServer();
+
+        CorfuRuntime rt = new CorfuRuntime(endpoint).connect();
+
+        try {
+            IStreamView sv1 = rt.getStreamsView().get(CorfuRuntime.getStreamID("stream1"));
+
+            final int numWrites = 10;
+            final int payloadSize = 4000;
+            byte[] payload = new byte[payloadSize];
+
+            for (int x = 0; x < numWrites; x++) {
+                sv1.append(payload);
+            }
+
+            assertThat(sv1.remaining().size()).isNotZero();
+
+            sv1.append(payload);
+            sv1.append(payload);
+
+            Token tail = rt.getSequencerView().query().getToken();
+
+            rt.getAddressSpaceView().prefixTrim(tail);
+
+            // Write one more entry that survives the trim (simulates a
+            // checkpoint entry or a late write above the trim point).
+            sv1.append(payload);
+
+            rt.getLayoutView().getRuntimeLayout().getBaseClient(endpoint).restart().join();
+
+            // After restart, the server rebuilds LogMetadata with the
+            // initializeLogMetadata() fix which sets correct per-stream trim
+            // marks. The sequencer bootstraps with correct data.
+            // remaining() should detect that our position is behind the trim.
+            assertThatThrownBy(sv1::remaining).isInstanceOf(TrimmedException.class);
+
+            sv1.append(payload);
+
+            assertThatThrownBy(sv1::remaining).isInstanceOf(TrimmedException.class);
+        } finally {
+            rt.shutdown();
+            p.destroy();
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/StreamingSilentTrimGapIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingSilentTrimGapIT.java
@@ -1,0 +1,221 @@
+package org.corfudb.integration;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.exceptions.StreamingException;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.test.SampleSchema.SampleTableAMsg;
+import org.corfudb.test.SampleSchema.Uuid;
+import org.junit.Test;
+
+import org.awaitility.Awaitility;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration test for the silent trim gap fix, exercising the
+ * DeltaStream / StreamingManager / CorfuStore subscription path.
+ *
+ * Scenario: write entries, subscribe and consume them, prefix trim past
+ * the subscription point, restart the server, then re-subscribe at the
+ * old position. The subscription or the first poll must raise a
+ * StreamingException wrapping TrimmedException.
+ */
+@Slf4j
+@SuppressWarnings("PMD.ClassNamingConventions")
+public class StreamingSilentTrimGapIT extends AbstractIT {
+
+    private static final String NAMESPACE = "test_namespace";
+    private static final String TABLE_NAME = "trim_gap_table";
+    private static final String STREAM_TAG = "sample_streamer_1";
+
+    private static class ErrorCapturingListener implements StreamListener {
+        @Getter
+        private final LinkedList<CorfuStreamEntries> updates = new LinkedList<>();
+        @Getter
+        private volatile Throwable error;
+        private final CountDownLatch errorLatch;
+        private final CountDownLatch updateLatch;
+
+        ErrorCapturingListener(CountDownLatch errorLatch, CountDownLatch updateLatch) {
+            this.errorLatch = errorLatch;
+            this.updateLatch = updateLatch;
+        }
+
+        @Override
+        public void onNext(CorfuStreamEntries results) {
+            updates.add(results);
+            if (updateLatch != null) {
+                updateLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            this.error = throwable;
+            if (errorLatch != null) {
+                errorLatch.countDown();
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void testStreamingDetectsTrimGapAfterRestart() throws Exception {
+        final String host = DEFAULT_HOST;
+        final int port = DEFAULT_PORT;
+        final String endpoint = host + ":" + port;
+
+        Process corfuServer = new CorfuServerRunner()
+                .setHost(host)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(host, port))
+                .setSingle(true)
+                .runServer();
+
+        CorfuRuntime runtime = createRuntime(endpoint);
+        CorfuStore store = new CorfuStore(runtime);
+
+        try {
+            Table<Uuid, SampleTableAMsg, Uuid> table = store.openTable(
+                    NAMESPACE, TABLE_NAME,
+                    Uuid.class, SampleTableAMsg.class, Uuid.class,
+                    TableOptions.fromProtoSchema(SampleTableAMsg.class)
+            );
+
+            // Phase 1: Write entries and subscribe to consume them.
+            // Subscribe from before the writes so DeltaStream delivers them.
+            Timestamp beforeWrites = Timestamp.newBuilder()
+                    .setEpoch(0L)
+                    .setSequence(Address.NON_ADDRESS)
+                    .build();
+
+            final int numUpdates = 10;
+            for (int i = 0; i < numUpdates; i++) {
+                try (TxnContext tx = store.txn(NAMESPACE)) {
+                    Uuid key = Uuid.newBuilder().setMsb(i).setLsb(i).build();
+                    SampleTableAMsg val = SampleTableAMsg.newBuilder()
+                            .setPayload("val" + i).build();
+                    tx.putRecord(table, key, val, key);
+                    tx.commit();
+                }
+            }
+
+            CountDownLatch updateLatch = new CountDownLatch(numUpdates);
+            ErrorCapturingListener listener1 = new ErrorCapturingListener(null, updateLatch);
+            store.subscribeListener(listener1, NAMESPACE, STREAM_TAG,
+                    Collections.singletonList(TABLE_NAME), beforeWrites);
+
+            assertThat(updateLatch.await(10, TimeUnit.SECONDS)).isTrue();
+            assertThat(listener1.getUpdates().size()).isEqualTo(numUpdates);
+
+            long lastSeenSequence = listener1.getUpdates().getLast()
+                    .getTimestamp().getSequence();
+
+            store.unsubscribeListener(listener1);
+
+            // Phase 2: Write more entries then prefix trim past what listener1 saw
+            for (int i = numUpdates; i < numUpdates * 2; i++) {
+                try (TxnContext tx = store.txn(NAMESPACE)) {
+                    Uuid key = Uuid.newBuilder().setMsb(i).setLsb(i).build();
+                    SampleTableAMsg val = SampleTableAMsg.newBuilder()
+                            .setPayload("val" + i).build();
+                    tx.putRecord(table, key, val, key);
+                    tx.commit();
+                }
+            }
+
+            runtime.getAddressSpaceView().prefixTrim(
+                    runtime.getSequencerView().query().getToken());
+
+            // Write one more entry above the trim so the stream has
+            // surviving data in the log after restart.
+            try (TxnContext tx = store.txn(NAMESPACE)) {
+                Uuid key = Uuid.newBuilder().setMsb(999).setLsb(999).build();
+                SampleTableAMsg val = SampleTableAMsg.newBuilder()
+                        .setPayload("post-trim").build();
+                tx.putRecord(table, key, val, key);
+                tx.commit();
+            }
+
+            // Phase 3: Restart the server
+            runtime.getLayoutView().getRuntimeLayout()
+                    .getBaseClient(endpoint).restart().join();
+
+            // Poll until the server is responsive after restart
+            Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .until(() -> {
+                        try {
+                            runtime.invalidateLayout();
+                            runtime.getLayoutView().getLayout();
+                            return true;
+                        } catch (Exception e) {
+                            return false;
+                        }
+                    });
+
+            // Phase 4: Re-subscribe at the old position (lastSeenSequence).
+            // With both fixes applied (trim() + initializeLogMetadata),
+            // the restarted log unit sends correct per-stream trim marks
+            // to the sequencer during bootstrap. The subscription should
+            // either throw immediately in validateSyncAddress() or the
+            // DeltaStream should detect the gap on the first poll and
+            // propagate onError with a StreamingException/TrimmedException.
+
+            Timestamp oldTs = Timestamp.newBuilder()
+                    .setEpoch(0L)
+                    .setSequence(lastSeenSequence)
+                    .build();
+
+            // Re-open the table (fresh runtime state after restart)
+            store.openTable(NAMESPACE, TABLE_NAME,
+                    Uuid.class, SampleTableAMsg.class, Uuid.class,
+                    TableOptions.fromProtoSchema(SampleTableAMsg.class));
+
+            CountDownLatch errorLatch = new CountDownLatch(1);
+            ErrorCapturingListener listener2 = new ErrorCapturingListener(errorLatch, null);
+
+            try {
+                store.subscribeListener(listener2, NAMESPACE, STREAM_TAG,
+                        Collections.singletonList(TABLE_NAME), oldTs);
+
+                // If subscribe didn't throw, the error should arrive via onError
+                // within a few poll cycles.
+                assertThat(errorLatch.await(30, TimeUnit.SECONDS))
+                        .as("onError must be called with a trim exception")
+                        .isTrue();
+
+                assertThat(listener2.getError())
+                        .isNotNull()
+                        .isInstanceOfAny(StreamingException.class, TrimmedException.class);
+
+            } catch (StreamingException e) {
+                assertThat(e.getCause()).isInstanceOf(TrimmedException.class);
+            }
+
+            // No post-gap data should have been delivered
+            assertThat(listener2.getUpdates())
+                    .as("no data should be delivered after the trim gap")
+                    .isEmpty();
+        } finally {
+            runtime.shutdown();
+            shutdownCorfuServer(corfuServer);
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/streaming/DeltaStreamTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -26,6 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.corfudb.AbstractCorfuTest.PARAMETERS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("checkstyle:magicnumber")
@@ -316,5 +319,57 @@ public class DeltaStreamTest {
         for (int x = 0; x < numToProduce; x++) {
             assertThat(consumed.get(x).getGlobalAddress()).isEqualTo(x);
         }
+    }
+
+    /**
+     * Verifies that when the sequencer returns a correct per-stream trim mark
+     * (as it will after the StreamAddressSpace.trim() and log unit init fixes),
+     * DeltaStream.refresh() detects the gap and next() throws TrimmedException
+     * WITHOUT delivering any post-gap data.
+     *
+     * Scenario: client subscribed at position 100, trim advanced to 500,
+     * new addresses at 600 and 700 are discovered. The trim mark from the
+     * sequencer is 500. DeltaStream must throw before delivering 600 or 700.
+     */
+    @Test
+    public void trimGapDetectedBeforeDataDelivery() {
+        UUID streamId = UUID.randomUUID();
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        final int bufferSize = 10;
+        final long lastAddressRead = 100;
+        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+
+        StreamAddressSpace sas = new StreamAddressSpace(500L, Set.of(600L, 700L));
+
+        stream.refresh(sas);
+
+        assertThat(stream.hasNext()).isTrue();
+        assertThatThrownBy(stream::next)
+                .isInstanceOf(TrimmedException.class);
+
+        verify(addressSpaceView, never()).read(600L, options);
+        verify(addressSpaceView, never()).read(700L, options);
+    }
+
+    /**
+     * With NON_ADDRESS trim mark (broken sequencer state before the fix),
+     * DeltaStream does NOT detect the gap and would deliver post-gap data.
+     * This test documents the pre-fix behavior to show the fix is needed.
+     */
+    @Test
+    public void nonAddressTrimMarkDoesNotDetectGap() {
+        UUID streamId = UUID.randomUUID();
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        final int bufferSize = 10;
+        final long lastAddressRead = 100;
+        DeltaStream stream = new DeltaStream(addressSpaceView, streamId, lastAddressRead, bufferSize);
+
+        StreamAddressSpace sas = new StreamAddressSpace(Address.NON_ADDRESS, Set.of(600L, 700L));
+
+        stream.refresh(sas);
+
+        assertThat(stream.availableSpace())
+                .as("with NON_ADDRESS trim mark, addresses are buffered (gap not detected)")
+                .isEqualTo(bufferSize - 2);
     }
 }


### PR DESCRIPTION
## Overview

This PR addresses silent failures that happen during syncing: by not properly detecting trim gaps, updates can be lost or delivered out of order. The core issue stems from two root causes that propagate through the system on cluster reconfiguration and node restarts:

Bug 1: Incorrect trim mark updates for empty streams (i.e., bitmap rank <= 0).

Bug 2: Incorrect trim mark initialization during logunit initialization.

Together these bugs allowed streaming clients to subscribe/sync at stale positions, resulting in silent data loss.

Tests written by Cursor.

Why should this be merged: addresses #3328 and other bugs

Related issue(s) (if applicable): #3328 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
