### PR TITLE
Failure Detection Livelock Fixes

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorService.java
@@ -18,10 +18,12 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.concurrent.SingletonResource;
 
-import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 @Builder
 @Slf4j
@@ -76,9 +78,22 @@ public class FailureDetectorService {
                 Optional<Long> unfilledSlot = pollReport.getLayoutSlotUnFilled(latestLayout);
                 // If the latest slot has not been filled, fill it with the previous known layout.
                 if (unfilledSlot.isPresent()) {
-                    log.info("Trying to fill an unfilled slot {}. PollReport: {}",
-                            unfilledSlot.get(), pollReport);
-                    failuresAgent.handleFailure(latestLayout, Collections.emptySet(), pollReport, endpoint).join();
+                    Set<String> locallyDetectedFailures = pollReport.getFailedNodes();
+
+                    long backoffMs = ThreadLocalRandom.current().nextLong(500, 2001);
+                    log.info("Trying to fill an unfilled slot {}. "
+                                    + "Backing off {}ms. Locally detected failures: {}. PollReport: {}",
+                            unfilledSlot.get(), backoffMs, locallyDetectedFailures, pollReport);
+
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(backoffMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return DetectorTask.NOT_COMPLETED;
+                    }
+
+                    failuresAgent.handleFailure(
+                            latestLayout, locallyDetectedFailures, pollReport, endpoint).join();
                     return DetectorTask.COMPLETED;
                 }
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorServiceTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/failuredetector/FailureDetectorServiceTest.java
@@ -1,18 +1,34 @@
 package org.corfudb.infrastructure.management.failuredetector;
 
+import com.google.common.collect.ImmutableMap;
+import org.corfudb.infrastructure.RemoteMonitoringService.DetectorTask;
 import org.corfudb.infrastructure.management.PollReport;
 import org.corfudb.infrastructure.management.failuredetector.FailureDetectorService.SequencerBootstrapper;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Layout;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class FailureDetectorServiceTest {
@@ -44,5 +60,161 @@ class FailureDetectorServiceTest {
         fdService.runFailureDetectorTask(pollReportMock, layoutMock, endpoint).whenComplete((result, ex) -> {
             assertEquals("Wrong epoch. [expected=123]", ex.getMessage());
         });
+    }
+
+    /**
+     * Sets up the common PollReport mock for unfilled-slot tests: sealed servers,
+     * unfilled slot present, wrong epochs empty.
+     */
+    private PollReport setupUnfilledSlotPollReport(Set<String> failedNodes) {
+        PollReport pollReportMock = mock(PollReport.class);
+        when(pollReportMock.areAllResponsiveServersSealed()).thenReturn(true);
+        when(pollReportMock.getLayoutSlotUnFilled(any())).thenReturn(Optional.of(535L));
+        when(pollReportMock.getFailedNodes()).thenReturn(failedNodes);
+        when(pollReportMock.getWrongEpochs()).thenReturn(ImmutableMap.of());
+        return pollReportMock;
+    }
+
+    /**
+     * When the unfilled-slot path is taken and PollReport.getFailedNodes() returns a dead node,
+     * failuresAgent.handleFailure() must be called with that dead node set, NOT empty set.
+     */
+    @Test
+    public void testUnfilledSlotPassesFailedNodesToHandler()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        ExecutorService fdWorker = Executors.newFixedThreadPool(3);
+        String endpoint = "localhost:9000";
+        String deadNode = "192.161.160.32:9000";
+
+        Layout layoutMock = mock(Layout.class);
+
+        EpochHandler epochHandler = mock(EpochHandler.class);
+        when(epochHandler.correctWrongEpochs(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(layoutMock));
+
+        Set<String> failedNodes = new HashSet<>();
+        failedNodes.add(deadNode);
+        PollReport pollReportMock = setupUnfilledSlotPollReport(failedNodes);
+
+        FailuresAgent failuresAgent = mock(FailuresAgent.class);
+        when(failuresAgent.handleFailure(any(), any(), any(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(DetectorTask.COMPLETED));
+
+        FailureDetectorService fdService = FailureDetectorService.builder()
+                .epochHandler(epochHandler)
+                .failureDetectorWorker(fdWorker)
+                .failuresAgent(failuresAgent)
+                .healingAgent(mock(HealingAgent.class))
+                .sequencerBootstrapper(mock(SequencerBootstrapper.class))
+                .build();
+
+        DetectorTask result = fdService
+                .runFailureDetectorTask(pollReportMock, layoutMock, endpoint)
+                .get(10, TimeUnit.SECONDS);
+
+        assertEquals(DetectorTask.COMPLETED, result);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<String>> failedNodesCaptor = ArgumentCaptor.forClass(Set.class);
+        verify(failuresAgent).handleFailure(
+                same(layoutMock), failedNodesCaptor.capture(), same(pollReportMock), eq(endpoint));
+
+        Set<String> capturedFailedNodes = failedNodesCaptor.getValue();
+        assertEquals(1, capturedFailedNodes.size());
+        assertTrue(capturedFailedNodes.contains(deadNode),
+                "handleFailure must receive the dead node, not an empty set");
+    }
+
+    /**
+     * When the unfilled-slot path is taken but PollReport.getFailedNodes() returns empty
+     * (no failures detected), handleFailure() should still be called with an empty set.
+     * This verifies no regression in the no-failure case.
+     */
+    @Test
+    public void testUnfilledSlotPassesEmptySetWhenNoFailures()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        ExecutorService fdWorker = Executors.newFixedThreadPool(3);
+        String endpoint = "localhost:9000";
+
+        Layout layoutMock = mock(Layout.class);
+
+        EpochHandler epochHandler = mock(EpochHandler.class);
+        when(epochHandler.correctWrongEpochs(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(layoutMock));
+
+        PollReport pollReportMock = setupUnfilledSlotPollReport(Collections.emptySet());
+
+        FailuresAgent failuresAgent = mock(FailuresAgent.class);
+        when(failuresAgent.handleFailure(any(), any(), any(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(DetectorTask.COMPLETED));
+
+        FailureDetectorService fdService = FailureDetectorService.builder()
+                .epochHandler(epochHandler)
+                .failureDetectorWorker(fdWorker)
+                .failuresAgent(failuresAgent)
+                .healingAgent(mock(HealingAgent.class))
+                .sequencerBootstrapper(mock(SequencerBootstrapper.class))
+                .build();
+
+        DetectorTask result = fdService
+                .runFailureDetectorTask(pollReportMock, layoutMock, endpoint)
+                .get(10, TimeUnit.SECONDS);
+
+        assertEquals(DetectorTask.COMPLETED, result);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<String>> failedNodesCaptor = ArgumentCaptor.forClass(Set.class);
+        verify(failuresAgent).handleFailure(
+                same(layoutMock), failedNodesCaptor.capture(), same(pollReportMock), eq(endpoint));
+
+        assertTrue(failedNodesCaptor.getValue().isEmpty(),
+                "handleFailure must receive empty set when no failures detected");
+    }
+
+    /**
+     * When the thread is interrupted during the backoff sleep in the unfilled-slot path,
+     * failuresAgent.handleFailure() must NOT be called (the interrupt skips it).
+     */
+    @Test
+    public void testUnfilledSlotInterruptDuringBackoff()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        ExecutorService fdWorker = Executors.newSingleThreadExecutor();
+        String endpoint = "localhost:9000";
+        String deadNode = "192.161.160.32:9000";
+
+        Layout layoutMock = mock(Layout.class);
+
+        EpochHandler epochHandler = mock(EpochHandler.class);
+        when(epochHandler.correctWrongEpochs(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(layoutMock));
+
+        Set<String> failedNodes = new HashSet<>();
+        failedNodes.add(deadNode);
+        PollReport pollReportMock = setupUnfilledSlotPollReport(failedNodes);
+
+        FailuresAgent failuresAgent = mock(FailuresAgent.class);
+
+        HealingAgent healingAgent = mock(HealingAgent.class);
+        when(healingAgent.detectAndHandleHealing(any(), any(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(DetectorTask.COMPLETED));
+
+        FailureDetectorService fdService = FailureDetectorService.builder()
+                .epochHandler(epochHandler)
+                .failureDetectorWorker(fdWorker)
+                .failuresAgent(failuresAgent)
+                .healingAgent(healingAgent)
+                .sequencerBootstrapper(mock(SequencerBootstrapper.class))
+                .build();
+
+        CompletableFuture<DetectorTask> future =
+                fdService.runFailureDetectorTask(pollReportMock, layoutMock, endpoint);
+
+        Thread.sleep(50);
+        fdWorker.shutdownNow();
+
+        future.get(10, TimeUnit.SECONDS);
+
+        verify(failuresAgent, never())
+                .handleFailure(any(), any(), any(), anyString());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
@@ -376,6 +378,14 @@ public class LayoutManagementView extends AbstractView {
             log.error("Conflict in updating layout by attemptConsensus:", oe);
             // Update rank to be able to outrank other competition and complete paxos.
             prepareRank = oe.getNewRank() + 1;
+            try {
+                long backoffMs = ThreadLocalRandom.current().nextLong(100, 1000);
+                log.info("attemptConsensus: Backing off {}ms after OutrankedException",
+                        backoffMs);
+                TimeUnit.MILLISECONDS.sleep(backoffMs);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
             throw oe;
         }
 

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1565,7 +1565,7 @@ public class ManagementViewTest extends AbstractViewTest {
             if (!corfuRuntime.getLayoutView().getLayout().getUnresponsiveServers().isEmpty()) {
                 break;
             }
-            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
         }
 
         Layout layout = new Layout(corfuRuntime.getLayoutView().getLayout());
@@ -1577,7 +1577,7 @@ public class ManagementViewTest extends AbstractViewTest {
             if (corfuRuntime.getLayoutView().getLayout().getEpoch() == layout.getEpoch()) {
                 break;
             }
-            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
         }
 
         assertThat(corfuRuntime.getLayoutView().getLayout()).isEqualTo(layout);


### PR DESCRIPTION
## Overview

Description:

The failure detector increments the cluster epoch when it detects an unresponsive node in order to push a new layout. This can cause other FDs in the cluster to detect an unfilled slot and attempt to propagate the older layout, producing proposals that keep dead nodes active for an extended period (minutes), causing disruption such as client restarts. Additionally, asymmetric latency between nodes can result in competing proposals that prevent committing a new layout. This patch fixes runFailureDetectorTask to correctly pass a failed nodes list to handleFailure and adds randomized backoff on outrank exceptions to desynchronize competing proposers.



Why should this be merged: reduces cluster reconfiguration latency and prevents clients from rebooting 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
