### PR TITLE
Populate cluster_id in LogReplication outbound Header

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -184,7 +185,8 @@ public class LogReplicationClientRouter implements IClientRouter {
 
         HeaderMsg.Builder header = HeaderMsg.newBuilder()
                 .setVersion(getDefaultProtocolVersionMsg())
-                .setIgnoreClusterId(true)
+                .setClusterId(getUuidMsg(UUID.fromString(parameters.getLocalClusterId())))
+                .setIgnoreClusterId(false)
                 .setIgnoreEpoch(true);
 
         if (isValidMessage(payload)) {


### PR DESCRIPTION
## Overview

Description: Set the local cluster ID in every outbound HeaderMsg from LogReplicationClientRouter so the standby GM server can cross-validate the transport-authenticated peer identity against the message-level identity

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
