### PR TITLE
Upgrade dependencies

### DIFF
--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
-            <version>1.14</version>
+            <version>2.4.3</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.8.13</version>
+            <version>1.6.14</version>
         </dependency>
         <dependency>
             <groupId>org.ehcache</groupId>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.10.2</version>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.luben</groupId>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
 
-        <caffeine.version>2.8.5</caffeine.version>
+        <caffeine.version>3.2.3</caffeine.version>
         <docopt.version>0.6.0.20150202</docopt.version>
     </properties>
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/datastore/DataStore.java
@@ -1,10 +1,8 @@
 package org.corfudb.infrastructure.datastore;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import io.netty.buffer.ByteBuf;
@@ -16,7 +14,6 @@ import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.util.JsonUtils;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -120,7 +117,6 @@ public class DataStore implements KvDataStore {
         return Caffeine.newBuilder()
                 .recordStats()
                 .maximumSize(dsCacheSize)
-                .writer(new DataStoreCacheWriter())
                 .build();
     }
 
@@ -154,7 +150,16 @@ public class DataStore implements KvDataStore {
 
     @Override
     public <T> void put(KvRecord<T> key, T value) {
-        cache.put(key.getFullKeyName(), value);
+        String fullKey = key.getFullKeyName();
+        if (inMem) {
+            cache.put(fullKey, value);
+        } else {
+            // Caffeine 3 removed CacheWriter; use Map#compute for write-through persistence.
+            cache.asMap().compute(fullKey, (k, old) -> {
+                persistToDisk(k, value);
+                return value;
+            });
+        }
     }
 
     @Override
@@ -187,67 +192,61 @@ public class DataStore implements KvDataStore {
     }
 
 
-    private class DataStoreCacheWriter implements CacheWriter<String, Object> {
-
-        @Override
-        public void write(@Nonnull String key, @Nonnull Object value) {
-            if (value == NullValue.NULL_VALUE) {
-                return;
-            }
-
-            ByteBuf buffer = null;
-            FileChannel writeChannel = null;
-
-            try {
-                String dsFileName = key + EXTENSION;
-                Path path = Paths.get(logDirPath, dsFileName);
-                Path tmpPath = Paths.get(logDirPath, dsFileName + ".tmp");
-
-                String jsonPayload = JsonUtils.parser.toJson(value, value.getClass());
-                byte[] bytes = jsonPayload.getBytes();
-
-                buffer = Unpooled
-                        .directBuffer(bytes.length + Integer.BYTES)
-                        .writeInt(getChecksum(bytes))
-                        .writeBytes(bytes);
-                ByteBuffer nioBuffer = buffer.nioBuffer();
-
-                OpenOption[] attrs = {
-                        StandardOpenOption.WRITE,
-                        StandardOpenOption.CREATE,
-                        StandardOpenOption.TRUNCATE_EXISTING,
-                        StandardOpenOption.SYNC
-                };
-                writeChannel = FileChannel.open(tmpPath, attrs);
-
-                while (nioBuffer.hasRemaining()) {
-                    writeChannel.write(nioBuffer);
-                }
-
-                CopyOption[] moveAttrs = {
-                        StandardCopyOption.REPLACE_EXISTING,
-                        StandardCopyOption.ATOMIC_MOVE
-                };
-                Files.move(tmpPath, path, moveAttrs);
-
-                syncDirectory(logDirPath);
-                // Invoking the cleanup on each disk file write is fine for performance
-                // since DataStore files are not supposed to change too frequently
-                cleanupTask.accept(dsFileName);
-            } catch (IOException e) {
-                throw new DataCorruptionException(e);
-            } finally {
-                if (buffer != null) {
-                    buffer.release();
-                }
-                IOUtils.closeQuietly(writeChannel);
-            }
+    /**
+     * Persists a value to disk for the persistent DataStore. Evictions and invalidations do not
+     * remove on-disk files (previously a no-op in {@code CacheWriter#delete}).
+     */
+    private void persistToDisk(@Nonnull String key, @Nonnull Object value) {
+        if (value == NullValue.NULL_VALUE) {
+            return;
         }
 
-        @Override
-        public void delete(@Nonnull String key, @Nullable Object value, @Nonnull RemovalCause cause) {
-            // Delete should not remove the underlying file.
-            // Removal of underlying file is done by cleanupTask.
+        ByteBuf buffer = null;
+        FileChannel writeChannel = null;
+
+        try {
+            String dsFileName = key + EXTENSION;
+            Path path = Paths.get(logDirPath, dsFileName);
+            Path tmpPath = Paths.get(logDirPath, dsFileName + ".tmp");
+
+            String jsonPayload = JsonUtils.parser.toJson(value, value.getClass());
+            byte[] bytes = jsonPayload.getBytes();
+
+            buffer = Unpooled
+                    .directBuffer(bytes.length + Integer.BYTES)
+                    .writeInt(getChecksum(bytes))
+                    .writeBytes(bytes);
+            ByteBuffer nioBuffer = buffer.nioBuffer();
+
+            OpenOption[] attrs = {
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.SYNC
+            };
+            writeChannel = FileChannel.open(tmpPath, attrs);
+
+            while (nioBuffer.hasRemaining()) {
+                writeChannel.write(nioBuffer);
+            }
+
+            CopyOption[] moveAttrs = {
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE
+            };
+            Files.move(tmpPath, path, moveAttrs);
+
+            syncDirectory(logDirPath);
+            // Invoking the cleanup on each disk file write is fine for performance
+            // since DataStore files are not supposed to change too frequently
+            cleanupTask.accept(dsFileName);
+        } catch (IOException e) {
+            throw new DataCorruptionException(e);
+        } finally {
+            if (buffer != null) {
+                buffer.release();
+            }
+            IOUtils.closeQuietly(writeChannel);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
 
         <!-- Dependency versions -->
         <slf4j.version>2.0.16</slf4j.version>
-        <netty.version>4.1.128.Final</netty.version>
-        <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
+        <netty.version>4.2.12.Final</netty.version>
+        <netty.tcnative.version>2.0.75.Final</netty.tcnative.version>
         <protobuf.version>3.21.12</protobuf.version>
         <commons.io.version>2.18.0</commons.io.version>
         <lombok.version>1.18.42</lombok.version>

--- a/runtime/src/main/java/org/corfudb/security/tls/SslContextConstructor.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/SslContextConstructor.java
@@ -45,6 +45,13 @@ public class SslContextConstructor {
             sslContext = SslContextBuilder
                     .forClient()
                     .sslProvider(provider)
+                    // Netty 4.2 changed the client default of endpointIdentificationAlgorithm
+                    // from null to "HTTPS" (hostname verification enabled). Explicitly set
+                    // null to preserve the pre-4.2 behavior, where peer identity is asserted
+                    // solely via the configured trust manager. Flip to "HTTPS" only after
+                    // confirming all Corfu server certificates carry SANs matching the
+                    // hostnames clients dial.
+                    .endpointIdentificationAlgorithm(null)
                     .keyManager(kmf)
                     .trustManager(tmf)
                     .build();

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
-            <version>1.14</version>
+            <version>2.4.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Overview
Upgrades several core OSS dependencies to their latest stable versions. This PR includes necessary refactors for breaking changes in Caffeine 3.x and configuration adjustments for Netty 4.2.

**Major Changes:**
1. Caffeine 2.8.5 → 3.2.3: CacheWriter has been removed in 3.x. Updated DataStore.java to use Map#compute for write-through persistence to disk.
2. Netty 4.1.128 → 4.2.12: Netty 4.2 now enables HTTPS hostname verification by default. I have explicitly set endpointIdentificationAlgorithm(null) in SslContextConstructor.java to maintain current behavior.

**Other Bumps:**

- org.fusesource.jansi: 1.14 → 2.4.3
- org.roaringbitmap: 0.8.13 → 1.6.14
- netty.tcnative: 2.0.61.Final → 2.0.75.Final
- at.yawk.lz4: 1.10.2 → 1.11.0


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
