### PR TITLE
Upgrade RocksDB JNI to 11.1.1.1

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
 
-        <rocksdb.version>8.9.1.2</rocksdb.version>
+        <rocksdb.version>11.1.1.1</rocksdb.version>
         <kryo.version>5.5.0</kryo.version>
         <kryo.serializers.version>0.45</kryo.serializers.version>
         <plexus.version>3.0.24</plexus.version>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CheckedRocksIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CheckedRocksIterator.java
@@ -7,6 +7,7 @@ import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksIteratorInterface;
+import org.rocksdb.Snapshot;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -181,6 +182,11 @@ public class CheckedRocksIterator implements RocksIteratorInterface, AutoCloseab
 
     @Override
     public void refresh() {
+        throw new UnsupportedOperationException("refresh");
+    }
+
+    @Override
+    public void refresh(Snapshot snapshot) {
         throw new UnsupportedOperationException("refresh");
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/WrappedRocksIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/WrappedRocksIterator.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.collections;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
+import org.rocksdb.Snapshot;
 import org.rocksdb.RocksIteratorInterface;
 
 import java.nio.ByteBuffer;
@@ -144,6 +145,11 @@ public class WrappedRocksIterator implements RocksIteratorInterface {
 
     @Override
     public void refresh(){
+        throw new UnsupportedOperationException("refresh");
+    }
+
+    @Override
+    public void refresh(Snapshot snapshot) {
         throw new UnsupportedOperationException("refresh");
     }
 


### PR DESCRIPTION
## Overview
- Bump org.corfudb:rocksdbjni 8.9.1.2 (RocksDB 8.9) -> 11.1.1.1 (RocksDB 11.1.1, latest upstream).
- Private build keeps PORTABLE=1 (no AVX2) and the OCC default flip kValidateParallel -> kValidateSerial (saves ~40 MB per OptimisticTransactionDB).
- Override RocksIteratorInterface.refresh(Snapshot) (new abstract in RocksJava 9.x) in CheckedRocksIterator and WrappedRocksIterator. CorfuDB never refreshes iterators, so both throw UnsupportedOperationException.
- The RocksDB 11.0.0 Java removals (snap_refresh_nanos, ReadOptions::managed, MaxMemCompactionLevel) do not affect CorfuDB.

Why should this be merged: maintenance upgrades  

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
