### PR TITLE
LR: reconcile LogReplicationStatus table on ACTIVE leadership acquisition

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -71,13 +71,17 @@ jobs:
       - name: Create k3d volume directory
         run: mkdir -p /tmp/k3dvol
 
+      - name: Install k3d
+        run: |
+          curl -Lo /usr/local/bin/k3d "https://github.com/k3d-io/k3d/releases/download/v5.8.3/k3d-linux-amd64"
+          chmod +x /usr/local/bin/k3d
+          k3d version
+
       - name: Create k3d Cluster
-        uses: AbsaOSS/k3d-action@v2
-        with:
-          cluster-name: "corfu"
-          args: >-
-            --volume /tmp/k3dvol:/tmp/k3dvol
-            --agents 2
+        run: |
+          k3d cluster create corfu \
+            --volume /tmp/k3dvol:/tmp/k3dvol \
+            --agents 2 \
             --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*"
 
       - name: install corfu package

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -492,6 +492,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 }
                 logReplicationEventListener.start();
                 replicationManager.setTopology(topologyDescriptor);
+                replicationManager.reconcileStatusTable();
                 replicationManager.start();
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
                 processCountOnLockAcquire(localClusterDescriptor.getRole());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -244,6 +244,27 @@ public class CorfuReplicationManager {
     }
 
     /**
+     * Reconcile the LogReplicationStatus table against the current topology on leadership acquisition.
+     *
+     * <p>{@link #processStandbyChange} only cleans up clusters that leave the topology while this
+     * leader is running; clusters decommissioned before this leader started leave ghost rows behind.
+     *
+     * <p>Must be called after {@link #setTopology} and before {@link #start}.
+     */
+    public void reconcileStatusTable() {
+        Set<String> clustersInStatusTable = new HashSet<>(metadataManager.getReplicationRemainingEntries().keySet());
+        Set<String> clustersInTopology = topology.getStandbyClusters().keySet();
+
+        for (String clusterId : clustersInStatusTable) {
+            if (!clustersInTopology.contains(clusterId)) {
+                log.warn("Leadership reconciliation: removing stale LogReplicationStatus entry " +
+                        "for cluster {} not present in current topology", clusterId);
+                removeClusterInfoFromStatusTable(clusterId);
+            }
+        }
+    }
+
+    /**
      * Stop the current log replication event and start a full snapshot sync for the given remote cluster.
      */
     public void enforceSnapshotSync(DiscoveryServiceEvent event) {

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/CorfuReplicationManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/CorfuReplicationManagerTest.java
@@ -1,0 +1,88 @@
+package org.corfudb.infrastructure.logreplication;
+
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CorfuReplicationManager}.
+ */
+public class CorfuReplicationManagerTest {
+
+    private static final String CURRENT_STANDBY_ID = "current-standby";
+    private static final String GHOST_CLUSTER_ID_1  = "ghost-cluster-1";
+    private static final String GHOST_CLUSTER_ID_2  = "ghost-cluster-2";
+
+    @Mock private LogReplicationMetadataManager metadataManager;
+    @Mock private TopologyDescriptor topology;
+    @Mock private LogReplicationContext context;
+    @Mock private LogReplicationConfigManager configManager;
+
+    private CorfuReplicationManager replicationManager;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(topology.getStandbyClusters()).thenReturn(
+                Collections.singletonMap(CURRENT_STANDBY_ID, new ClusterDescriptor(CURRENT_STANDBY_ID)));
+
+        replicationManager = new CorfuReplicationManager(context, null, metadataManager, null, null, configManager);
+        replicationManager.setTopology(topology);
+    }
+
+    /**
+     * Ghost entries — rows for clusters decommissioned before the current leader started — must be
+     * removed from the LogReplicationStatus table when {@link CorfuReplicationManager#reconcileStatusTable()}
+     * is called.  Without the call in {@code CorfuReplicationDiscoveryService.onLeadershipAcquire()},
+     * ghost entries persist and {@code queryReplicationStatus()} can non-deterministically return a
+     * stale STOPPED status, blocking switchover indefinitely.
+     */
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testReconcileStatusTableRemovesGhostEntries() {
+        Map entries = new HashMap();
+        entries.put(CURRENT_STANDBY_ID, null);
+        entries.put(GHOST_CLUSTER_ID_1,  null);
+        entries.put(GHOST_CLUSTER_ID_2,  null);
+        doReturn(entries).when(metadataManager).getReplicationRemainingEntries();
+
+        replicationManager.reconcileStatusTable();
+
+        verify(metadataManager, never()).removeFromStatusTable(CURRENT_STANDBY_ID);
+        verify(metadataManager).removeFromStatusTable(GHOST_CLUSTER_ID_1);
+        verify(metadataManager).removeFromStatusTable(GHOST_CLUSTER_ID_2);
+    }
+
+    /**
+     * When the status table already contains only current standbys, reconciliation must be a no-op.
+     */
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testReconcileStatusTableIsNoOpWhenTableIsClean() {
+        Map entries = new HashMap();
+        entries.put(CURRENT_STANDBY_ID, null);
+        doReturn(entries).when(metadataManager).getReplicationRemainingEntries();
+
+        replicationManager.reconcileStatusTable();
+
+        verify(metadataManager, never()).removeFromStatusTable(any());
+    }
+}


### PR DESCRIPTION

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
