### PR TITLE
build: fix Maven install and upgrade protobuf plugin

### DIFF
--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -32,6 +32,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeMavenTypes>direct</includeMavenTypes>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
 
     <repositories>
         <repository>
+            <id>google-maven-central</id>
+            <name>Google Maven Central</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+        </repository>
+
+        <repository>
             <id>clojars.org</id>
             <url>https://clojars.org/repo</url>
         </repository>
@@ -103,6 +109,14 @@
             <url>https://s01.oss.sonatype.org/content/repositories/orgcorfudb-1014</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>google-maven-central</id>
+            <name>Google Maven Central</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <reporting>
         <plugins>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -41,6 +41,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <inputDirectories>
                                 <include>proto</include>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -58,6 +58,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeMavenTypes>direct</includeMavenTypes>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -157,7 +157,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -166,6 +166,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeDirectories>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -53,6 +53,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                                 <includeMavenTypes>direct</includeMavenTypes>


### PR DESCRIPTION
- Add Google Maven Central to repositories and pluginRepositories for reliable dependency resolution.
- Upgrade protoc-jar-maven-plugin from 3.11.1 to 3.11.4 across all submodules.
- Configure protocArtifact explicitly to fetch the exact protoc binary corresponding to protobuf.version.

Multiple issues are found:
1. Maven central rate limiting
2. com.github.os72:protoc-jar-maven-plugin can't properly resolve the name of the recently upgraded protobuf 3.25.8.