### PR TITLE
fix: replace AbsaOSS/k3d-action with direct k3d binary download

### DIFF
--- a/.github/workflows/cloud-deployment-test.yml
+++ b/.github/workflows/cloud-deployment-test.yml
@@ -71,13 +71,17 @@ jobs:
       - name: Create k3d volume directory
         run: mkdir -p /tmp/k3dvol
 
+      - name: Install k3d
+        run: |
+          curl -Lo /usr/local/bin/k3d "https://github.com/k3d-io/k3d/releases/download/v5.8.3/k3d-linux-amd64"
+          chmod +x /usr/local/bin/k3d
+          k3d version
+
       - name: Create k3d Cluster
-        uses: AbsaOSS/k3d-action@v2
-        with:
-          cluster-name: "corfu"
-          args: >-
-            --volume /tmp/k3dvol:/tmp/k3dvol
-            --agents 2
+        run: |
+          k3d cluster create corfu \
+            --volume /tmp/k3dvol:/tmp/k3dvol \
+            --agents 2 \
             --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*"
 
       - name: install corfu package


### PR DESCRIPTION
The k3d-action@v2 install script calls github.com/k3d-io/k3d/releases/latest which started returning 404 after GitHub's May 2025 unauthenticated rate-limit changes. Replace with a direct curl of the pinned v5.8.3 release asset and create the cluster via the k3d CLI directly.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
