### PR TITLE
911 cherry picks from master - remove plexus-utils, javassist, immutables, commons-fileupload

### DIFF
--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -80,11 +80,6 @@
             <version>2.4.3</version>
         </dependency>
         <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <version>1.6.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.21.3</version>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,11 +17,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.roaringbitmap</groupId>
-            <artifactId>RoaringBitmap</artifactId>
-            <version>1.6.14</version>
-        </dependency>
-        <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>sizeof</artifactId>
             <version>0.4.4</version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -17,7 +17,6 @@
         <rocksdb.version>10.10.1.1</rocksdb.version>
         <kryo.version>5.6.2</kryo.version>
         <kryo.serializers.version>0.45</kryo.serializers.version>
-        <plexus.version>3.0.24</plexus.version>
         <javassist.version>3.31.0-GA</javassist.version>
         <commons.lang3.version>3.20.0</commons.lang3.version>
         <commons.compress.version>1.28.0</commons.compress.version>
@@ -105,11 +104,6 @@
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
             <version>${kryo.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>${plexus.version}</version>
         </dependency>
         <dependency>
             <groupId>de.javakaffee</groupId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -17,7 +17,6 @@
         <rocksdb.version>10.10.1.1</rocksdb.version>
         <kryo.version>5.6.2</kryo.version>
         <kryo.serializers.version>0.45</kryo.serializers.version>
-        <javassist.version>3.31.0-GA</javassist.version>
         <commons.lang3.version>3.20.0</commons.lang3.version>
         <commons.compress.version>1.28.0</commons.compress.version>
         <annotations.api.version>6.0.53</annotations.api.version>
@@ -116,11 +115,6 @@
             <version>${gson.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>${javassist.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
@@ -134,6 +128,11 @@
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
             <version>${rocksdb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>1.6.14</version>
         </dependency>
 
         <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -15,9 +15,6 @@
     <name>Corfu Utils</name>
     <url>http://maven.apache.org</url>
 
-    <properties>
-        <immutables.version>2.9.0</immutables.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>
@@ -25,18 +22,6 @@
             <version>${revision}</version>
         </dependency>
 
-        <!-- external dependencies -->
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>gson</artifactId>
-            <version>${immutables.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <version>${immutables.version}</version>
-        </dependency>
- 
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Overview

Description:
- fix: remove unused dependencies and move RoaringBitmap to correct module
  Remove 4 direct dependencies confirmed unused across the entire codebase
  (zero imports in declaring module and all downstream modules):
  - runtime: org.javassist:javassist 3.31.0-GA
  - utils: org.immutables:value + org.immutables:gson 2.9.0
  - cmdlets: commons-fileupload:commons-fileupload 1.6.0

- Move org.roaringbitmap:RoaringBitmap 1.6.14 from common to runtime, where
it is actually imported (StreamAddressSpace.java uses Roaring64NavigableMap
and LongIterator). common had zero usages; runtime consumed it transitively.

- fix: remove unused plexus-utils 3.0.24 dependency
plexus-utils was declared as a direct dependency in runtime/pom.xml but no source code in this repo imports or uses any org.codehaus.plexus class. Removing it eliminates the CVE-2025-67030 (CVSS 8.8)

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
