### PR TITLE
fix: bump netty to 4.2.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <!-- Dependency versions -->
         <slf4j.version>2.0.17</slf4j.version>
-        <netty.version>4.2.12.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
         <netty.tcnative.version>2.0.77.Final</netty.tcnative.version>
         <protobuf.version>3.25.8</protobuf.version>
         <commons.io.version>2.22.0</commons.io.version>


### PR DESCRIPTION
Netty 4.2.12.Final is in the vulnerable range for a batch of CVEs fixed across 4.2.13.Final and 4.2.15.Final: request smuggling/desync in netty-codec-http (CVE-2026-42581, CVE-2026-42580, CVE-2026-42584, CVE-2026-42585, CVE-2026-42587, CVE-2026-41417), DNS codec validation (CVE-2026-42579), proxy handler (CVE-2026-42578), MQTT codec (CVE-2026-44248), native epoll RST-after- half-close busy-loop (CVE-2026-42577), and SCTP reassembly memory exhaustion (CVE-2026-46340, only fixed in 4.2.15.Final). 4.2.15.Final is the minimum version closing all of them.

Pure dependency version bump on netty.version; no source changes.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
