### PR TITLE
Silent Data Loss Fixes

### DIFF
--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -31,8 +31,8 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>${protobuf.version}</protocVersion>
-                            <includeStdTypes>true</includeStdTypes>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
+                            <includeStdTypes>false</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeMavenTypes>direct</includeMavenTypes>
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -123,10 +123,7 @@ public class InMemoryStreamLog implements StreamLog {
 
     @Override
     public synchronized TailsResponse getAllTails() {
-        Map<UUID, Long> tails = new HashMap<>(logMetadata.getStreamTails().size());
-        for (Map.Entry<UUID, Long> entry : logMetadata.getStreamTails().entrySet()) {
-            tails.put(entry.getKey(), entry.getValue());
-        }
+        Map<UUID, Long> tails = logMetadata.getStreamTails();
         return new TailsResponse(logMetadata.getGlobalTail(), tails);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -3,7 +3,6 @@ package org.corfudb.infrastructure.log;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
@@ -13,8 +12,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.corfudb.infrastructure.log.StreamLogFiles.RECORDS_PER_LOG_FILE;
 
@@ -73,13 +72,37 @@ public class LogMetadata {
             updateStreamSpace(streamId, entryAddress, initialize);
         }
 
-        // We should also consider checkpoint metadata while updating the tails and stream trim mark.
-        // This is important because there could be streams which data is completely checkpointed,
-        // i.e., no actual entries on the regular stream but only on the checkpoint stream.
-        // If those streams are not updated with this info, then clients would observe those
-        // streams as empty, which is not correct.
-        if (entry.hasCheckpointMetadata()) {
-            updateFromCheckpoint(entry, initialize);
+        // We can assume that every stream table/tag will have at least a No-op hole
+        // with valid backpointers because of the following:
+        // 1. The checkpointer captures a MinToken before it starts checkpointing
+        // 2. The table checkpointer will emit a No-Op hope with backpointers before it writes the checkpoint
+        // 3. The prefix trim will only happen after a full checkpoint cycle
+        // 4. The prefix trim will always issue a trim based on the MinToken
+
+        if (initialize && entry.isHole() && !entry.getBackpointerMap().isEmpty()) {
+            for (var streamId : entry.getStreams()) {
+                streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
+                    var backPointer = entry.getBackpointer(streamId);
+                    Objects.nonNull(backPointer);
+
+                    // This metadata update path is called during node initialization (i.e., restarts) and
+                    // during state transfer when redundancy is being restored on a replica. As a result, the
+                    // updates for differnt parts of the log can appear out-of-order which would result in a
+                    // temporarily incorrect StreamAddressSpace but not observable to external clients or
+                    // sequencer bootstrap workflows. Additionally, since state transfer can interleave with prefix
+                    // trim operations, the larger prefix trim address will override the min calculations below only
+                    // if the bitmap is not empty.
+
+                    if (addressSpace == null) {
+                        return new StreamAddressSpace(backPointer, Collections.emptySet());
+                    } else if (addressSpace.getTrimMark() < 0) {
+                        addressSpace.setTrimMark(backPointer);
+                    } else {
+                        addressSpace.setTrimMark(Math.min(addressSpace.getTrimMark(), backPointer));
+                    }
+                    return addressSpace;
+                });
+            }
         }
     }
 
@@ -103,49 +126,6 @@ public class LogMetadata {
             addressSpace.addAddress(entryAddress, initialize);
             return addressSpace;
         });
-    }
-
-    /**
-     * Update's relevant info of a stream's space from a checkpoint, concretely:
-     * 1. Stream tail for those stream's that have all updates within a checkpoint.
-     * 2. Stream trim mark, i.e., last observed address for a stream subsumed by a checkpoint.
-     *
-     * @param entry log entry
-     * @param initialize true, if called on log unit initialization (full scan)
-     *                   false, otherwise.
-     */
-    private void updateFromCheckpoint(LogData entry, boolean initialize) {
-        UUID streamId = entry.getCheckpointedStreamId();
-        long lastUpdateToStream = entry.getCheckpointedStreamStartLogAddress();
-
-        if (Address.isAddress(lastUpdateToStream)) {
-            // Update stream trim mark
-            // This is only required on initialization as on all other paths trim mark will be set by
-            // explicit trimming.
-
-            // The trim mark is part of the address space information and is also required
-            // so clients can observe updates to streams that have been completely checkpointed.
-            // For instance, an empty address space with a stream trim mark != -6, requires data to be
-            // loaded from a checkpoint (vs. no data ever written to this stream).
-
-            // If we hit a checkpoint END record we can use this info to compute the stream trim mark,
-            // i.e., last observed update to the stream that has already been checkpointed, hence
-            // can be safely trimmed from the log.
-            if (initialize && entry.getCheckpointType() == CheckpointEntry.CheckpointEntryType.END) {
-                streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
-                    if (addressSpace == null) {
-                        // If this entry still does not exist, means no updates have been observed for
-                        // this stream yet. We can initialize the trim mark to the last observed update by the
-                        // checkpoint. If further entries are observed they will be added to the address space.
-                        return new StreamAddressSpace(lastUpdateToStream, Collections.EMPTY_SET);
-                    }
-                    // We will hold the maximum of these observed updates as the stream trim mark (highest
-                    // checkpointed address), as this guarantees data is available in a checkpoint (safe trim mark).
-                    addressSpace.setTrimMark(Long.max(addressSpace.getTrimMark(), lastUpdateToStream));
-                    return addressSpace;
-                });
-            }
-        }
     }
 
     public void updateGlobalTail(long newTail) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.corfudb.infrastructure.log.StreamLogFiles.RECORDS_PER_LOG_FILE;
 
@@ -39,14 +40,18 @@ public class LogMetadata {
     @Getter
     private final Map<UUID, StreamAddressSpace> streamsAddressSpaceMap;
 
-    @Getter
-    private final Map<UUID, Long> streamTails;
-
     public LogMetadata(StreamLogDataStore dataStore) {
         this.globalTail = Address.NON_ADDRESS;
-        this.streamTails = new HashMap<>();
         this.streamsAddressSpaceMap = new HashMap<>();
         this.dataStore = dataStore;
+    }
+
+    public Map<UUID, Long> getStreamTails() {
+        Map<UUID, Long> res = HashMap.newHashMap(streamsAddressSpaceMap.size());
+        streamsAddressSpaceMap.forEach((uuid, space) ->
+                res.put(uuid, space.getTail())
+        );
+        return res;
     }
 
     public void update(List<LogData> entries) {
@@ -87,10 +92,6 @@ public class LogMetadata {
      * @param entryAddress stream address.
      */
     private void updateStreamSpace(UUID streamId, long entryAddress, boolean initialize) {
-        // Update stream tails
-        long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
-        streamTails.put(streamId, Math.max(currentStreamTail, entryAddress));
-
         // Update stream address space (used for sequencer recovery), add this entry as a valid address for this stream.
         streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
             if (addressSpace == null) {
@@ -118,11 +119,7 @@ public class LogMetadata {
         long lastUpdateToStream = entry.getCheckpointedStreamStartLogAddress();
 
         if (Address.isAddress(lastUpdateToStream)) {
-            // 1. Update stream tail
-            long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
-            streamTails.put(streamId, Math.max(currentStreamTail, lastUpdateToStream));
-
-            // 2. Update stream trim mark
+            // Update stream trim mark
             // This is only required on initialization as on all other paths trim mark will be set by
             // explicit trimming.
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -204,10 +204,7 @@ public class StreamLogFiles implements StreamLog {
 
     @Override
     public TailsResponse getTails(List<UUID> streams) {
-        Map<UUID, Long> tails = new HashMap<>();
-        streams.forEach(stream -> {
-            tails.put(stream, logMetadata.getStreamTails().get(stream));
-        });
+        Map<UUID, Long> tails = logMetadata.getStreamTails();
         return new TailsResponse(logMetadata.getGlobalTail(), tails);
     }
 
@@ -218,7 +215,7 @@ public class StreamLogFiles implements StreamLog {
 
     @Override
     public TailsResponse getAllTails() {
-        Map<UUID, Long> tails = new HashMap<>(logMetadata.getStreamTails());
+        Map<UUID, Long> tails = logMetadata.getStreamTails();
         return new TailsResponse(logMetadata.getGlobalTail(), tails);
     }
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -38,8 +38,8 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>${protobuf.version}</protocVersion>
-                            <includeStdTypes>true</includeStdTypes>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
+                            <includeStdTypes>false</includeStdTypes>
                             <inputDirectories>
                                 <include>proto</include>
                                 <include>proto/service</include>

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -231,24 +231,6 @@ public class Layout {
     }
 
     /**
-     * Return a list of segments which contain global
-     * addresses less than or equal to the given address
-     * (known as the prefix).
-     *
-     * @param globalAddress The global address prefix
-     *                      to use.
-     * @return              A list of segments which
-     *                      contain addresses less than
-     *                      or equal to the global
-     *                      address.
-     */
-    public @Nonnull List<LayoutSegment> getPrefixSegments(long globalAddress) {
-        return segments.stream()
-                .filter(p -> p.getEnd() <= globalAddress)
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Return layout segment stripe.
      *
      * @param globalAddress The global address.

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -199,12 +199,13 @@ public class Layout {
     /**
      * Get all the unique log unit server endpoints in the layout.
      *
-     * @return a set of all log unit server endpoints
+     * @return a list of all log unit server endpoints ordered by HEAD -> Tail node
      */
-    public Set<String> getAllLogServers() {
+    public List<String> getAllLogServers() {
         return segments.stream()
                 .flatMap(seg -> seg.getAllLogServers().stream())
-                .collect(Collectors.toSet());
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -254,19 +254,16 @@ public class Utils {
     }
 
   /**
-   * Find the chain's head node of each segment
+   * Return the head node in the chain which contains the complete log (i.e.,
+   * superset)
    *
    * @param layout layout to search in
-   * @return returns a set of nodes the represent the first node in all segments
+   * @return returns the head node
    */
-  private static Set<String> getChainHeadFromAllSegments(Layout layout) {
+  private static String getHeadNode(Layout layout) {
     validateSegments(layout.getSegments());
     List<Layout.LayoutSegment> segments = layout.getSegments();
-    return segments.stream()
-        .map(Layout.LayoutSegment::getFirstStripe)
-        .map(Layout.LayoutStripe::getLogServers)
-        .map(strip -> strip.get(0))
-        .collect(Collectors.toSet());
+    return segments.get(0).getFirstStripe().getLogServers().get(0);
   }
 
   /** Throws a WrongEpochException if the actual and expected epochs don't match. */
@@ -285,24 +282,10 @@ public class Utils {
   public static long getLogTail(RuntimeLayout runtimeLayout) {
     // Since a node can exist as a head for multiple segments we need to a set to
     // coalesce the candidates to unique nodes only
-    Set<String> segmentsHeadNodes = getChainHeadFromAllSegments(runtimeLayout.getLayout());
-    List<CompletableFuture<TailsResponse>> cfs =
-        segmentsHeadNodes.stream()
-            .map(node -> runtimeLayout.getLogUnitClient(node).getLogTail())
-            .collect(Collectors.toList());
-
-    long globalLogTail =
-        cfs.stream()
-            .map(CFUtils::getUninterruptibly)
-            .mapToLong(
-                resp -> {
-                  epochCheck(resp.getEpoch(), runtimeLayout.getLayout().getEpoch());
-                  return resp.getLogTail();
-                })
-            .max()
-            .orElseThrow(NoSuchElementException::new);
-
-    log.trace("getLogTail: nodes selected {} global tail {}", segmentsHeadNodes, globalLogTail);
+    String headNode = getHeadNode(runtimeLayout.getLayout());
+    CompletableFuture<TailsResponse> cf = runtimeLayout.getLogUnitClient(headNode).getLogTail();
+    long globalLogTail = CFUtils.getUninterruptibly(cf).getLogTail();
+    log.trace("getLogTail: nodes selected {} global tail {}", headNode, globalLogTail);
     return globalLogTail;
   }
 
@@ -317,32 +300,17 @@ public class Utils {
   public static TailsResponse getAllTails(RuntimeLayout runtimeLayout) {
     // Since a node can exist as a head for multiple segments we need to a set to
     // coalesce the candidates to unique nodes only
-    Set<String> segmentsHeadNodes = getChainHeadFromAllSegments(runtimeLayout.getLayout());
+    String headNode = getHeadNode(runtimeLayout.getLayout());
 
-    AtomicLong globalTail = new AtomicLong(Address.NON_EXIST);
-    final Map<UUID, Long> streamTails = new HashMap<>();
-
-    List<CompletableFuture<TailsResponse>> cfs =
-        segmentsHeadNodes.stream()
-            .map(node -> runtimeLayout.getLogUnitClient(node).getAllTails())
-            .collect(Collectors.toList());
-
-    cfs.stream()
-        .map(CFUtils::getUninterruptibly)
-        .forEach(
-            resp -> {
-              // All responses should be computed on the same epoch
-              epochCheck(resp.getEpoch(), runtimeLayout.getLayout().getEpoch());
-              // Find the global max global tail and stream tails across all responses
-              globalTail.set(Long.max(resp.getLogTail(), globalTail.get()));
-              resp.getStreamTails().forEach((k, v) -> streamTails.merge(k, v, Long::max));
-            });
+    TailsResponse res = CFUtils.getUninterruptibly(runtimeLayout.getLogUnitClient(headNode).getAllTails());
+    epochCheck(res.getEpoch(), runtimeLayout.getLayout().getEpoch());
+    long globalTail = Long.max(res.getLogTail(), Address.NON_EXIST);
 
     if (log.isTraceEnabled()) {
-        log.trace("getAllTails: nodes selected {} stream tails {}", segmentsHeadNodes, streamTails);
+        log.trace("getAllTails: nodes selected {} stream tails {}", headNode, res.getStreamTails());
     }
 
-    return new TailsResponse(runtimeLayout.getLayout().getEpoch(), globalTail.get(), streamTails);
+    return new TailsResponse(runtimeLayout.getLayout().getEpoch(), globalTail, res.getStreamTails());
   }
 
   /**
@@ -355,31 +323,18 @@ public class Utils {
   public static StreamsAddressResponse getLogAddressSpace(RuntimeLayout runtimeLayout) {
     // Since a node can exist as a head for multiple segments we need to a set to
     // coalesce the candidates to unique nodes only
-    Set<String> segmentsHeadNodes = getChainHeadFromAllSegments(runtimeLayout.getLayout());
-    AtomicLong globalTail = new AtomicLong(Address.NON_EXIST);
-    final Map<UUID, StreamAddressSpace> streamsAddressSpace = new HashMap<>();
-    List<CompletableFuture<StreamsAddressResponse>> cfs =
-        segmentsHeadNodes.stream()
-            .map(node -> runtimeLayout.getLogUnitClient(node).getLogAddressSpace())
-            .collect(Collectors.toList());
+    String headNode = getHeadNode(runtimeLayout.getLayout());
+    StreamsAddressResponse res = CFUtils.getUninterruptibly(runtimeLayout.getLogUnitClient(headNode)
+            .getLogAddressSpace());
 
-    cfs.stream()
-        .map(CFUtils::getUninterruptibly)
-        .forEach(
-            resp -> {
-              // All responses should be computed on the same epoch
-              epochCheck(resp.getEpoch(), runtimeLayout.getLayout().getEpoch());
-              // Find the global max global tail and stream tails across all responses
-              globalTail.set(Long.max(resp.getLogTail(), globalTail.get()));
-              resp.getAddressMap()
-                  .forEach((k, v) -> streamsAddressSpace.merge(k, v, StreamAddressSpace::merge));
-            });
+    epochCheck(res.getEpoch(), runtimeLayout.getLayout().getEpoch());
+    long globalTail = Long.max(res.getLogTail(), Address.NON_EXIST);
 
     log.debug(
         "getLogAddressSpace: nodes selected {} log tail {} stream addresses {}",
-        segmentsHeadNodes,
-        globalTail.get(),
-        streamsAddressSpace);
-    return new StreamsAddressResponse(globalTail.get(), streamsAddressSpace);
+        headNode,
+        globalTail,
+        res.getAddressMap());
+    return new StreamsAddressResponse(globalTail, res.getAddressMap());
   }
 }

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -203,15 +203,11 @@ public class Utils {
      * @param address a token with address to trim
      */
     public static void prefixTrim(RuntimeLayout runtimeLayout, Token address) {
-        List<CompletableFuture<Void>> futures = runtimeLayout
-                .getLayout()
-                .getAllLogServers()
-                .stream()
-                .map(runtimeLayout::getLogUnitClient)
-                .map(lu -> lu.prefixTrim(address))
-                .collect(Collectors.toList());
-
-        futures.forEach(CFUtils::getUninterruptibly);
+        for (var server : runtimeLayout.getLayout().getAllLogServers()) {
+            var lu = runtimeLayout.getLogUnitClient(server);
+            var future = lu.prefixTrim(address);
+            CFUtils.getUninterruptibly(future);
+        }
     }
 
     /**

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -57,8 +57,8 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>${protobuf.version}</protocVersion>
-                            <includeStdTypes>true</includeStdTypes>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
+                            <includeStdTypes>false</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeMavenTypes>direct</includeMavenTypes>
                             <includeDirectories>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -165,8 +165,8 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>${protobuf.version}</protocVersion>
-                            <includeStdTypes>true</includeStdTypes>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
+                            <includeStdTypes>false</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeDirectories>
                                 <includeDirectory>../runtime/proto</includeDirectory>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -37,8 +37,8 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>${protobuf.version}</protocVersion>
-                            <includeStdTypes>true</includeStdTypes>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
+                            <includeStdTypes>false</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                                 <includeMavenTypes>direct</includeMavenTypes>
                             <inputDirectories>


### PR DESCRIPTION
## Overview

There are various cluster reconfiguration scenarios that result in
silent data loss and/or inconsistent views of streams and tables due
to incorrect initialization of per-stream trim marks on the logunit
that end up being propagated to the sequencer during bootstrapping.
Since only the prefix trim mark is persisted on the logunit, the
per-stream trim marks are inferred from checkpoint metadata, which
might not reflect the real trim mark. Also, streams for tags do not
have checkpoints; when the logunit reinitializes, the trim mark is
set to a non-address, causing it to regress. This causes the client
to fail to detect missing stream entries and keep syncing forward
instead of throwing a TrimmedException and rebuilding its state,
or failing to deliver change notifications to clients because they
are silently dropped.

This patch changes the logunit metadata initialization logic to
derive per-stream trim marks from materialized backpointers,
resolving the client/sequencer coordination issues caused by trim
mark regressions.


Why should this be merged: closes various streaming and table inconsistencies bugs

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [x] Public API has Javadoc
