### PR TITLE
Build protoc cross-platform via auto-detected protocArtifact

### DIFF
--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -32,6 +32,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeMavenTypes>direct</includeMavenTypes>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -39,6 +39,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <inputDirectories>
                                 <include>proto</include>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -58,6 +58,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeMavenTypes>direct</includeMavenTypes>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -157,7 +157,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -166,6 +166,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                             <includeDirectories>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -38,6 +38,7 @@
                         </goals>
                         <configuration>
                             <protocVersion>${protobuf.version}</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
                             <includeStdTypes>true</includeStdTypes>
                             <addProtoSources>inputs</addProtoSources>
                                 <includeMavenTypes>direct</includeMavenTypes>


### PR DESCRIPTION
## Overview
The os72 protoc-jar-maven-plugin's protocVersion mode (3.11.1) ships no osx-aarch_64 protoc, so the build fails on Apple Silicon Macs. Upgrade the plugin to 3.11.4 and add a classifier-less protocArtifact (com.google.protobuf:protoc:${protobuf.version}) so protoc-jar auto-detects the platform and pulls the official protoc for it (osx-aarch_64, linux-x86_64, osx-x86_64, ...). protocVersion is kept so includeStdTypes=true keeps supplying the well-known types, so no proto files need to be vendored.

Verified: mvn clean install -DskipTests -T4 builds all 14 modules natively on Apple Silicon (osx-aarch_64) with no Rosetta; Linux behavior is unchanged from origin/master.

Why should this be merged: build fix for apple silicon


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
