### PR TITLE
Fix Rocksdb options leak in DiskBackedCoruTable

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/DiskBackedCorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/DiskBackedCorfuTable.java
@@ -176,8 +176,12 @@ public class DiskBackedCorfuTable<K, V> implements
             }
             this.rocksDbOptions.setTableFormatConfig(tableConfig);
             this.reportingFrequency = persistenceOptions.getReportingFrequency();
-            rocksDbOptions.setStatistics(statistics);
-            persistenceOptions.getWriteBufferSize().map(rocksDbOptions::setWriteBufferSize);
+            // NOTE: do not configure `rocksDbOptions` (the parameter) here. Every caller passes
+            // the shared static `defaultOptions`, so writing to it mutates process-global state:
+            // it races with the `new Options(defaultOptions)` copy made by other threads opening
+            // tables concurrently, and bleeds one table's settings into the template that later
+            // tables are built from. The per-table copy `this.rocksDbOptions` is configured above
+            // and is the instance actually handed to RocksDB.
 
             final RocksDbStore<DiskBackedCorfuTable<K, V>> rocksDbStore = new RocksDbStore<>(
                     persistenceOptions.getDataPath(), this.rocksDbOptions, writeOptions);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -218,6 +218,13 @@ public class Table<K extends Message, V extends Message, M extends Message> impl
      * This is useful for JVMs who do not wish to keep the entire table
      * around in memory.
      * DO NOT USE THIS METHOD WITH NO_CACHE TABLES
+     *
+     * WARNING: this is close-then-reopen, not a release. For a disk-backed
+     * ({@link org.corfudb.runtime.collections.PersistedCorfuTable}) table it tears down the
+     * RocksDB instance and immediately builds a fresh one at the same path, so it frees no
+     * native memory and discards the materialized data as well. Callers trying to give back a
+     * disk-backed table's off-heap footprint must use {@link #close()} instead.
+     *
      * @param runtime - the runtime that was used to create this table
      */
     public void resetTableData(CorfuRuntime runtime) {


### PR DESCRIPTION
## Overview
Description:
The DiskBackedCorfuTable constructor takes an `Options rocksDbOptions` parameter and immediately makes a private copy of it:

    this.rocksDbOptions = new Options(rocksDbOptions);

Two lines further down duplicated configuration already applied to that copy, but with `this.` omitted, so they wrote to the parameter instead:

    this.rocksDbOptions.setStatistics(statistics);          // correct
    ...
    rocksDbOptions.setStatistics(statistics);               // removed
    persistenceOptions.getWriteBufferSize()
        .map(rocksDbOptions::setWriteBufferSize);           // removed

Every caller passes the same object - Table.initializeCorfuTable passes DiskBackedCorfuTable.defaultOptions, and the two-arg constructor defaults to it - and defaultOptions is a `public static final Options`, one instance per JVM. It is also the template that every subsequent table copies at construction. So each table open was writing into process-global state.

Why should this be merged: 
Consequences, in the order that matters:

1. A data race. TableRegistry notes that some clients open a large number of tables in parallel using ForkJoin pools. One thread can be executing `new Options(defaultOptions)` while another calls setStatistics on that same object; copy-constructing a C++ Options while another thread reassigns its shared_ptr member is unsynchronized on this path.

2. Settings bleeding between unrelated tables. getWriteBufferSize() is an Optional and nothing currently sets it, so that line was dormant - but any client that starts setting a write buffer would have it written into defaultOptions, and a later table that sets none would silently inherit it instead of the RocksDB default, because its own .map() never fires to correct the copy.

3. A small native leak. defaultOptions retains a shared_ptr to the last Statistics set on it, so one StatsLevel.ALL Statistics stays pinned for the life of the process even after its table is closed. Only one is retained at a time, since each setStatistics replaces the previous pointer. This is not a use-after-free: close() disposes the Java handle, but the C++ Options holds its own reference, so the object stays alive.

Removing the two lines is behaviour-preserving for the table being built. The bare parameter is referenced exactly once, by the copy on line 153, and everything handed to RocksDbStore uses this.rocksDbOptions. +fix comment in resetTableData is close-then-reopen and not a release

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
