### PR TITLE
fix: replace blocking reconnect sleep with scheduled retry in Netty client routers

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
@@ -29,11 +29,13 @@ import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.security.sasl.SaslUtils;
 import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
 import org.corfudb.security.tls.SslContextConstructor;
-import org.corfudb.util.Sleep;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @ChannelHandler.Sharable
@@ -74,6 +76,12 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
      * Thread pool for this channel to use
      */
     private final EventLoopGroup eventLoopGroup;
+
+    /**
+     * A handle on the reconnection attempt that is currently scheduled, if any, so that it can be
+     * cancelled when this channel is closed.
+     */
+    private volatile ScheduledFuture<?> pendingReconnect;
 
     private SslContext sslContext;
 
@@ -164,6 +172,10 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
     public void close() {
         log.debug("Close channel to {}", node.getNodeId());
         shutdown = true;
+        ScheduledFuture<?> scheduledReconnect = pendingReconnect;
+        if (scheduledReconnect != null) {
+            scheduledReconnect.cancel(false);
+        }
         adapter.onError(new NetworkException("Channel closed", node.getClusterId()));
         if (channel != null && channel.isOpen()) {
             channel.close();
@@ -242,15 +254,33 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
             log.info("connectAsync[{}]: Channel connected.", node);
         } else {
             // Otherwise, the connection failed. If we're not shutdown, try reconnecting after
-            // a sleep period.
+            // the retry interval.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.info("connectAsync[{}]: Channel connection failed, reconnecting...", node);
-                // Call connect, which will retry the call again.
-                // Note that this is not recursive, because it is called in the
-                // context of the handler future.
-                connectAsync(bootstrap);
+                log.info("connectAsync[{}]: Channel connection failed, reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Schedule connect, which will retry the call again.
+                scheduleReconnect(bootstrap);
             }
+        }
+    }
+
+    /**
+     * Schedule a reconnection attempt once the retry interval has elapsed.
+     *
+     * <p>This is invoked from Netty channel future listeners, which run on the event loop thread
+     * that owns the channel. Sleeping on that thread would stall every other channel registered
+     * to it - including channels to healthy nodes - so the retry is scheduled instead of blocking.
+     *
+     * @param bootstrap The channel bootstrap to use
+     */
+    private void scheduleReconnect(@Nonnull Bootstrap bootstrap) {
+        try {
+            // connectAsync re-checks the shutdown flag, so a retry that is scheduled concurrently
+            // with close() is a no-op rather than a resurrected connection.
+            pendingReconnect = eventLoopGroup.schedule(() -> connectAsync(bootstrap),
+                    timeoutRetry, TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException ree) {
+            log.debug("scheduleReconnect[{}]: event loop is shutting down, not reconnecting", node);
         }
     }
 
@@ -268,10 +298,10 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
 
             // If we aren't shutdown, reconnect.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting...", node);
-                // Asynchronously connect again.
-                connectAsync(bootstrap);
+                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Asynchronously connect again, once the retry interval has elapsed.
+                scheduleReconnect(bootstrap);
             }
         });
     }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -46,7 +46,6 @@ import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
 import org.corfudb.security.tls.SslContextConstructor;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.NodeLocator;
-import org.corfudb.util.Sleep;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
@@ -59,6 +58,8 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -171,6 +172,12 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
      * Thread pool for this channel to use
      */
     private final EventLoopGroup eventLoopGroup;
+
+    /**
+     * A handle on the reconnection attempt that is currently scheduled, if any, so that it can be
+     * cancelled when the router is stopped.
+     */
+    private volatile ScheduledFuture<?> pendingReconnect;
 
     @Data
     @Builder
@@ -356,10 +363,10 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
             });
             // If we aren't shutdown, reconnect.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting...", node);
-                // Asynchronously connect again.
-                connectAsync(bootstrap);
+                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Asynchronously connect again, once the retry interval has elapsed.
+                scheduleReconnect(bootstrap);
             }
         });
     }
@@ -394,15 +401,33 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
             log.debug("connectAsync[{}]: Channel connected.", node);
         } else {
             // Otherwise, the connection failed. If we're not shutdown, try reconnecting after
-            // a sleep period.
+            // the retry interval.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.debug("connectAsync[{}]: Channel connection failed, reconnecting...", node);
-                // Call connect, which will retry the call again.
-                // Note that this is not recursive, because it is called in the
-                // context of the handler future.
-                connectAsync(bootstrap);
+                log.debug("connectAsync[{}]: Channel connection failed, reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Schedule connect, which will retry the call again.
+                scheduleReconnect(bootstrap);
             }
+        }
+    }
+
+    /**
+     * Schedule a reconnection attempt once the retry interval has elapsed.
+     *
+     * <p>This is invoked from Netty channel future listeners, which run on the event loop thread
+     * that owns the channel. Sleeping on that thread would stall every other channel registered
+     * to it - including channels to healthy nodes - so the retry is scheduled instead of blocking.
+     *
+     * @param bootstrap The channel bootstrap to use
+     */
+    private void scheduleReconnect(@Nonnull Bootstrap bootstrap) {
+        try {
+            // connectAsync re-checks the shutdown flag, so a retry that is scheduled concurrently
+            // with stop() is a no-op rather than a resurrected connection.
+            pendingReconnect = eventLoopGroup.schedule(() -> connectAsync(bootstrap),
+                    timeoutRetry, TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException ree) {
+            log.debug("scheduleReconnect[{}]: event loop is shutting down, not reconnecting", node);
         }
     }
 
@@ -413,6 +438,10 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
     public void stop() {
         log.debug("stop: Shutting down router for {}", node);
         shutdown = true;
+        ScheduledFuture<?> scheduledReconnect = pendingReconnect;
+        if (scheduledReconnect != null) {
+            scheduledReconnect.cancel(false);
+        }
         connectionFuture.completeExceptionally(new NetworkException("Router stopped", node));
         if (channel != null && channel.isOpen()) {
             channel.close().syncUninterruptibly();


### PR DESCRIPTION
### Problem

When a Corfu peer becomes unreachable, every other server-internal client that talks to it — the failure detector, layout/seal RPCs, the compactor, orchestrator workflows — shares the same outbound Netty EventLoopGroup (ServerContext.getNewClientGroup(), default 4 threads). NettyClientRouter's reconnect logic retried a failed or closed connection by calling Sleep.sleepUninterruptibly(connectionRetryRate) directly inside the Netty channel-future listener that fires the retry — i.e., on the event-loop thread that owns the channel:

```
// channelConnectionFutureHandler / addReconnectionOnCloseFuture (before)
if (!shutdown) {
    Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate()); // blocks the event loop thread
    connectAsync(bootstrap);
}
```

Netty round-robins new channel registrations across the group's threads (group().next()), so the reconnect loop for one dead node rotates through every thread in the group over time — parking each one in turn. Since those same threads also service the write/read path for channels to healthy peers, one unreachable node degrades request latency cluster-wide, not just requests aimed at the dead node. The same pattern existed in the LR transport's CorfuNettyClientChannel.

### Evidence

Reproduced on a live 3-node cluster: stopping one node dropped the healthy-peer (and self-ping) failure-detector latency from a ~0.6–1.0 ms baseline to ~250–450 ms, with upper values pinned almost exactly at connectionRetryRate (1000 ms) — the fingerprint of a request queued behind a parked thread rather than a slow response. Thread dumps confirmed 2 of 4 client event-loop threads permanently asleep in:

NioEventLoop.run -> processSelectedKey -> finishConnect -> fulfillConnectPromise
 -> notifyListeners -> NettyClientRouter.channelConnectionFutureHandler
  -> Sleep.sleepUninterruptibly -> Thread.sleep

with the sleeping threads rotating across the group as predicted by round-robin registration.

### Fix

Replace the blocking sleep with eventLoopGroup.schedule(() -> connectAsync(bootstrap), timeoutRetry, MILLISECONDS) in both retry sites in NettyClientRouter and both in CorfuNettyClientChannel. This preserves the exact retry cadence (one attempt per connectionRetryRate/timeoutRetry) but frees the thread immediately instead of parking it — no more channel starves another channel on the same event loop.

Two supporting changes, same in both classes:
- Scheduling goes through the shared eventLoopGroup, not future.channel().eventLoop(), since a failed initAndRegister() may leave the channel without a usable event loop.
- A volatile ScheduledFuture<?> pendingReconnect handle is cancelled in stop()/close() right after the shutdown flag is set, and RejectedExecutionException is caught in case the group is already shutting down when a retry is scheduled. connectAsync already re-checks shutdown, so this is just clean teardown, not a correctness requirement.


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
