### PR TITLE
fix: throttle FileWatcher retries when watched dir is missing

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/FileWatcher.java
+++ b/runtime/src/main/java/org/corfudb/util/FileWatcher.java
@@ -2,6 +2,7 @@ package org.corfudb.util;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.Closeable;
@@ -23,10 +24,20 @@ import java.util.concurrent.ExecutorService;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 public class FileWatcher implements Closeable {
+
+    // Default backoff between retries when reloadNewWatchService() fails, e.g. because the
+    // watched file's parent directory does not exist yet (this can legitimately happen for a
+    // couple of seconds during first-boot provisioning). This value only bounds log volume
+    // during the race, not whether it resolves: start()'s retry loop retries indefinitely
+    // regardless of how long provisioning takes. Package-visible/settable so tests can shorten
+    // it rather than waiting on the production delay.
+    private static final long DEFAULT_RETRY_BACKOFF_MILLIS = 1000;
 
     private final File file;
 
@@ -43,6 +54,15 @@ public class FileWatcher implements Closeable {
 
     @Getter
     private final AtomicBoolean isRegistered = new AtomicBoolean(false);
+
+    @Setter
+    private long retryBackoffMillis = DEFAULT_RETRY_BACKOFF_MILLIS;
+
+    // Counts calls to backoffBeforeRetry(), i.e. how many times reloadNewWatchService() has
+    // failed and backed off. Exposed for tests to verify the retry loop is actually throttled,
+    // rather than just observing that registration eventually succeeds.
+    @Getter
+    private final AtomicInteger retryCount = new AtomicInteger(0);
 
     public FileWatcher(String filePath, Runnable onChange, ExecutorService executorService){
         this.file = Paths.get(filePath).toFile();
@@ -155,7 +175,22 @@ public class FileWatcher implements Closeable {
             isRegistered.set(true);
             log.info("FileWatcher: parent dir {} for file {} registered.", path, file.getAbsoluteFile());
         } catch (IOException ioe) {
+            // The parent directory (e.g. a keystore's private/ dir) can legitimately not exist
+            // yet for a brief window during appliance/cluster bootstrap, before it is
+            // provisioned. Without a backoff here, start()'s retry loop spins on this failure
+            // with no throttling, flooding the log with hundreds of identical exceptions in a
+            // fraction of a second until the directory appears.
+            backoffBeforeRetry();
             throw new IllegalStateException("Failed to start a new watch service!", ioe);
+        }
+    }
+
+    private void backoffBeforeRetry() {
+        retryCount.incrementAndGet();
+        try {
+            TimeUnit.MILLISECONDS.sleep(retryBackoffMillis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/runtime/src/test/java/org/corfudb/runtime/utils/FileWatcherTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/utils/FileWatcherTest.java
@@ -46,6 +46,8 @@ public class FileWatcherTest {
     private ExecutorService executorService;
     private static final int SLEEP_TIMER_1S = 1;
     private static final int MAX_RETRY_LIMIT = 20;
+    private static final long TEST_RETRY_BACKOFF_MS = 200;
+    private static final long BACKOFF_TEST_WINDOW_MS = 600;
 
     @Before
     public void setup() throws IOException {
@@ -189,5 +191,46 @@ public class FileWatcherTest {
         assertThat(executorService.isShutdown()).isTrue();
         assertThat(fileWatcher.getIsStopped()).isTrue();
         assertThat(fileWatcher.getIsRegistered()).isFalse();
+    }
+
+    /**
+     * Test that when the watched file's parent directory does not exist yet, the FileWatcher's
+     * retry loop backs off between attempts instead of spinning unthrottled. Regression test for
+     * a bug where hundreds of NoSuchFileException/IllegalStateException were logged within a
+     * fraction of a second while the directory was still being provisioned.
+     */
+    @Test
+    public void testFileWatcherBacksOffWhenParentDirMissing() throws IOException, InterruptedException {
+        // Point the watcher at a file whose parent directory does not exist.
+        Path missingParentDir = Paths.get(PATH, "not-yet-provisioned");
+        Path missingFilePath = missingParentDir.resolve("keystore.jks");
+
+        AtomicInteger onChangeCounter = new AtomicInteger(0);
+        fileWatcher = new FileWatcher(missingFilePath.toFile().getAbsolutePath(), onChangeCounter::incrementAndGet);
+        fileWatcher.setRetryBackoffMillis(TEST_RETRY_BACKOFF_MS);
+
+        // Let the retry loop run for a bounded window, then assert the actual retry count is
+        // capped to roughly window/backoff, not the thousands of attempts an unthrottled spin
+        // would produce in the same window.
+        TimeUnit.MILLISECONDS.sleep(BACKOFF_TEST_WINDOW_MS);
+
+        assertThat(fileWatcher.getIsRegistered()).isFalse();
+        long maxExpectedRetries = (BACKOFF_TEST_WINDOW_MS / TEST_RETRY_BACKOFF_MS) + 2;
+        assertThat(fileWatcher.getRetryCount().get())
+                .isPositive()
+                .isLessThanOrEqualTo((int) maxExpectedRetries);
+
+        // Now provision the directory; the watcher should pick it up on a subsequent retry
+        // without needing an unbounded number of attempts.
+        Files.createDirectories(missingParentDir);
+        Files.createFile(missingFilePath);
+
+        for (int i = 0; i < MAX_RETRY_LIMIT; i += 1) {
+            if (fileWatcher.getIsRegistered().get()) {
+                break;
+            }
+            TimeUnit.MILLISECONDS.sleep(TEST_RETRY_BACKOFF_MS);
+        }
+        assertThat(fileWatcher.getIsRegistered()).isTrue();
     }
 }


### PR DESCRIPTION
FileWatcher.start() retries poll() in a tight loop with no delay whenever reloadNewWatchService() fails, e.g. because the watched file's parent directory (a keystore's private/ dir) does not exist yet during a brief, legitimate provisioning race at appliance/cluster boot. With no backoff, this produces hundreds of NoSuchFileException/ IllegalStateException log lines within a fraction of a second before the directory shows up and the watcher self-heals.

Add a bounded sleep in reloadNewWatchService()'s failure path before rethrowing, so the retry loop backs off instead of spinning. The delay is configurable via a package-visible setter so tests don't have to wait on the production interval. A retryCount counter is exposed so tests can assert the retry cadence is actually bounded, rather than only observing that registration eventually succeeds.

The backoff value only bounds log volume during the race, not whether it resolves -- the retry loop retries indefinitely regardless of how long provisioning takes. Set to 1s for extra headroom on slow/loaded boots; the companion nsx fix (Before=corfu-nonconfig-server.service on nsx-cluster-boot-manager.service) addresses the actual boot-time ordering gap this retry loop is compensating for.

## Overview

Description:

Why should this be merged: 
1.4s of delay of keystore file creation by other service lead to 673 error log statements in nonconfig corfu server. Added a backoff timer when we hit an exception to avoid log spew.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
