### PR TITLE
stop leaking NettyClientRouters after CorfuRuntime shutdown

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -1259,25 +1259,10 @@ public class CorfuRuntime {
      * @param layout The latest layout.
      */
     private void pruneRemovedRouters(@Nonnull Layout layout) {
-        nodeRouterPool.getNodeRouters().keySet().stream()
-                // Check if endpoint is present in the layout.
-                .filter(endpoint -> !layout.getAllServers()
-                        // Converting to legacy endpoint format as the layout only contains
-                        // legacy format - host:port.
-                        .contains(endpoint.toEndpointUrl()))
-                .forEach(endpoint -> {
-                    try {
-                        IClientRouter router = nodeRouterPool.getNodeRouters().remove(endpoint);
-                        if (router != null) {
-                            // Stop the channel from keeping connecting/reconnecting to server.
-                            // Also if channel is not closed properly, router will be garbage collected.
-                            router.stop();
-                        }
-                    } catch (Exception e) {
-                        log.warn("fetchLayout: Exception in stopping and removing "
-                                + "router connection to node {} :", endpoint, e);
-                    }
-                });
+        // Delegates to NodeRouterPool itself rather than reading/mutating its router map
+        // directly: removal must be decided under the same lock getRouter()/shutdown()/
+        // reconnect() use.
+        nodeRouterPool.pruneRemovedRouters(layout.getAllServers());
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/NodeRouterPool.java
+++ b/runtime/src/main/java/org/corfudb/runtime/NodeRouterPool.java
@@ -1,13 +1,16 @@
 package org.corfudb.runtime;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.util.NodeLocator;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -15,11 +18,16 @@ import java.util.function.Function;
  * Pool of client routers.
  *
  * <p>Created by zlokhandwala on 2/20/18.
+ *
+ * <p>All mutation of and iteration over the router map lives in this class, behind this
+ * object's own monitor -- nothing outside this class touches the map directly. That is
+ * deliberate: every method here must agree on what "the pool is shut down" means at the
+ * same instant, or a router can end up created (or left behind) outside anything that will
+ * ever call stop() on it. See {@link #getRouter} for the specific failure this prevents.
  */
 @Slf4j
 public class NodeRouterPool {
 
-    @Getter(AccessLevel.PROTECTED)
     private final Map<NodeLocator, IClientRouter> nodeRouters = new ConcurrentHashMap<>();
 
     /**
@@ -31,6 +39,13 @@ public class NodeRouterPool {
     @Setter
     private Function<String, IClientRouter> createRouterFunction;
 
+    /**
+     * Set once {@link #shutdown()} has run. Guarded by this object's own monitor along with
+     * {@link #nodeRouters}; see {@link #getRouter} for why a router created after this point
+     * must not be tracked the same way as one created before it.
+     */
+    private boolean shutdown = false;
+
     NodeRouterPool(Function<String, IClientRouter> createRouterFunction) {
         this.createRouterFunction = createRouterFunction;
     }
@@ -38,30 +53,102 @@ public class NodeRouterPool {
     /**
      * Fetches a router from the pool if already present. Else creates a new router using the
      * provided function and adds it to the pool.
+     * <p>
+     * If the pool has already been shut down, a router is still created and returned,
+     * but it is stopped before being handed back, and it is never added to the
+     * pool. Without this, such a router would never be visited by any future shutdown() sweep
+     * and could keep retrying its target forever, invisible to anything that only inspects a
+     * tracked NodeRouterPool.
      *
      * @param endpoint Endpoint to connect the router.
      * @return IClientRouter.
      */
     public IClientRouter getRouter(NodeLocator endpoint) {
-        return nodeRouters.computeIfAbsent(endpoint,
-                s -> createRouterFunction.apply(s.toEndpointUrl()));
+        synchronized (this) {
+            if (!shutdown) {
+                return nodeRouters.computeIfAbsent(endpoint,
+                        s -> createRouterFunction.apply(s.toEndpointUrl()));
+            }
+        }
+        // Pool is already shut down. Construction and stop() both happen outside the lock,
+        // same as every other router I/O in this class: neither touches nodeRouters, and
+        // stop() can block (e.g. closing a Netty channel), which would otherwise stall every
+        // concurrent getRouter()/shutdown()/reconnect()/pruneRemovedRouters() caller.
+        IClientRouter router = createRouterFunction.apply(endpoint.toEndpointUrl());
+        router.stop();
+        return router;
     }
 
     /**
-     * Shutdown all the routers in the pool.
+     * Shutdown all the routers in the pool, and ensure no router created from this point on
+     * can be left untracked. See {@link #getRouter} for why untracked routers are a problem.
      */
     public void shutdown() {
-        for (IClientRouter r : nodeRouters.values()) {
+        List<IClientRouter> toStop;
+        synchronized (this) {
+            shutdown = true;
+            toStop = new ArrayList<>(nodeRouters.values());
+        }
+        for (IClientRouter r : toStop) {
             r.stop();
         }
     }
 
     /**
-     * Reestablish all connections in the pool.
+     * Reestablish all connections in the pool. A no-op once the pool has been shut down --
+     * there is nothing left to reestablish, and reconnecting after shutdown() has already
+     * begun its sweep would race it for no benefit.
      */
     public void reconnect() {
-        for (IClientRouter r : nodeRouters.values()) {
+        List<IClientRouter> toReconnect;
+        synchronized (this) {
+            if (shutdown) {
+                return;
+            }
+            toReconnect = new ArrayList<>(nodeRouters.values());
+        }
+        for (IClientRouter r : toReconnect) {
             r.reconnect();
+        }
+    }
+
+    /**
+     * Stop and remove every tracked router whose endpoint is not in {@code validEndpoints}.
+     *
+     * <p>This is the only place routers are removed from the pool. Removal and stop() must
+     * be decided under the same lock used by {@link #getRouter}/{@link #shutdown}/
+     * {@link #reconnect} -- if a caller outside this class read the router map, decided what
+     * to remove, and mutated it separately, that decision could be based on a view that is
+     * already stale by the time it acts on it, racing whichever of those methods runs
+     * concurrently.
+     *
+     * @param validEndpoints The full set of endpoints (in {@code host:port} form) that
+     *                        should remain tracked.
+     */
+    public void pruneRemovedRouters(@Nonnull Set<String> validEndpoints) {
+        List<IClientRouter> toStop = new ArrayList<>();
+        synchronized (this) {
+            if (shutdown) {
+                return;
+            }
+            for (NodeLocator endpoint : new ArrayList<>(nodeRouters.keySet())) {
+                if (!validEndpoints.contains(endpoint.toEndpointUrl())) {
+                    IClientRouter router = nodeRouters.remove(endpoint);
+                    if (router != null) {
+                        toStop.add(router);
+                    }
+                }
+            }
+        }
+        for (IClientRouter router : toStop) {
+            try {
+                // Stop the channel from keeping connecting/reconnecting to server.
+                // Also if channel is not closed properly, router will be garbage collected.
+                router.stop();
+            } catch (Exception e) {
+                log.warn("pruneRemovedRouters: Exception in stopping and removing "
+                        + "router connection: ", e);
+            }
         }
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyClientRouterTest.java
@@ -53,4 +53,60 @@ public class NettyClientRouterTest {
         assertThat(router.getEventLoopGroup().isShutdown()).isFalse();
     }
 
+    /**
+     * {@link NodeRouterPool#getRouter} has no shutdown-awareness: it will create and
+     * register a new {@link NettyClientRouter} regardless of whether the owning
+     * {@link CorfuRuntime} has already been shut down. Once created, a router's
+     * Netty-level reconnect loop is self-sustaining and needs nothing further from
+     * {@link CorfuRuntime}/{@link NodeRouterPool} to keep running -- the only way to
+     * stop it is an explicit {@link NettyClientRouter#stop()} call.
+     *
+     * <p>A caller that still holds a reference to a {@link CorfuRuntime} and calls
+     * {@link CorfuRuntime#getRouter} on it -- not knowing that something else already
+     * called {@link CorfuRuntime#shutdown} on the same instance -- is a real, ordinary
+     * usage pattern: {@code FailureDetector} and {@code ManagementView} both call
+     * {@code getRouter()} directly. The router such a call returns is fully armed and
+     * will keep reconnecting to its target forever, invisible to anything that only
+     * inspects a tracked {@link NodeRouterPool}.
+     */
+    @Test
+    public void testGetRouterAfterShutdownLeaksNettyClientRouter() {
+        CorfuRuntime.overrideGetRouterFunction = null;
+
+        CorfuRuntime victimRuntime = CorfuRuntime.fromParameters(
+                CorfuRuntime.CorfuRuntimeParameters.builder().build());
+
+        // Shut the runtime down first. At this point its NodeRouterPool is empty, so there
+        // is nothing to stop.
+        victimRuntime.shutdown();
+
+        NettyClientRouter orphanRouter = (NettyClientRouter) victimRuntime.getRouter("localhost:9000");
+        assertThat(orphanRouter).isNotNull();
+
+        // The bug: shutdown was false -- nothing will ever call stop() on this router, so it
+        // remains fully armed and will keep retrying this endpoint forever, invisible to
+        // anything that only inspects a tracked NodeRouterPool.
+        assertThat(orphanRouter.shutdown).isTrue();
+    }
+
+    /**
+     * Complementary to {@link #testGetRouterAfterShutdownLeaksNettyClientRouter}: a router
+     * obtained from an already-shut-down {@link NodeRouterPool} must not be memoized. If it
+     * were, a later caller could look it up by endpoint and mistake it for a live, tracked
+     * router instead of the orphan it actually is.
+     */
+    @Test
+    public void testGetRouterAfterShutdownDoesNotMemoizeRouter() {
+        CorfuRuntime.overrideGetRouterFunction = null;
+
+        CorfuRuntime victimRuntime = CorfuRuntime.fromParameters(
+                CorfuRuntime.CorfuRuntimeParameters.builder().build());
+        victimRuntime.shutdown();
+
+        NettyClientRouter firstRouter = (NettyClientRouter) victimRuntime.getRouter("localhost:9000");
+        NettyClientRouter secondRouter = (NettyClientRouter) victimRuntime.getRouter("localhost:9000");
+
+        assertThat(secondRouter).isNotSameAs(firstRouter);
+    }
+
 }


### PR DESCRIPTION
NodeRouterPool::getRouter had no shutdown-awareness. A caller still holding a runtime reference after shutdown() could get back a brand new NettyClientRouter that nothing would ever stop, so it retried its target forever, invisible to any live pool. getRouter() now returns an already-stopped router in that case instead of tracking it, and related methods are synchronized against it.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
