### PR TITLE
fix: replace blocking reconnect sleep with scheduled retry in Netty client routers (#4127)

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
@@ -29,11 +29,13 @@ import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.security.sasl.SaslUtils;
 import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
 import org.corfudb.security.tls.SslContextConstructor;
-import org.corfudb.util.Sleep;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @ChannelHandler.Sharable
@@ -74,6 +76,12 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
      * Thread pool for this channel to use
      */
     private final EventLoopGroup eventLoopGroup;
+
+    /**
+     * A handle on the reconnection attempt that is currently scheduled, if any, so that it can be
+     * cancelled when this channel is closed.
+     */
+    private volatile ScheduledFuture<?> pendingReconnect;
 
     private SslContext sslContext;
 
@@ -164,6 +172,10 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
     public void close() {
         log.debug("Close channel to {}", node.getNodeId());
         shutdown = true;
+        ScheduledFuture<?> scheduledReconnect = pendingReconnect;
+        if (scheduledReconnect != null) {
+            scheduledReconnect.cancel(false);
+        }
         adapter.onError(new NetworkException("Channel closed", node.getClusterId()));
         if (channel != null && channel.isOpen()) {
             channel.close();
@@ -242,15 +254,33 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
             log.info("connectAsync[{}]: Channel connected.", node);
         } else {
             // Otherwise, the connection failed. If we're not shutdown, try reconnecting after
-            // a sleep period.
+            // the retry interval.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.info("connectAsync[{}]: Channel connection failed, reconnecting...", node);
-                // Call connect, which will retry the call again.
-                // Note that this is not recursive, because it is called in the
-                // context of the handler future.
-                connectAsync(bootstrap);
+                log.info("connectAsync[{}]: Channel connection failed, reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Schedule connect, which will retry the call again.
+                scheduleReconnect(bootstrap);
             }
+        }
+    }
+
+    /**
+     * Schedule a reconnection attempt once the retry interval has elapsed.
+     *
+     * <p>This is invoked from Netty channel future listeners, which run on the event loop thread
+     * that owns the channel. Sleeping on that thread would stall every other channel registered
+     * to it - including channels to healthy nodes - so the retry is scheduled instead of blocking.
+     *
+     * @param bootstrap The channel bootstrap to use
+     */
+    private void scheduleReconnect(@Nonnull Bootstrap bootstrap) {
+        try {
+            // connectAsync re-checks the shutdown flag, so a retry that is scheduled concurrently
+            // with close() is a no-op rather than a resurrected connection.
+            pendingReconnect = eventLoopGroup.schedule(() -> connectAsync(bootstrap),
+                    timeoutRetry, TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException ree) {
+            log.debug("scheduleReconnect[{}]: event loop is shutting down, not reconnecting", node);
         }
     }
 
@@ -268,10 +298,10 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
 
             // If we aren't shutdown, reconnect.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting...", node);
-                // Asynchronously connect again.
-                connectAsync(bootstrap);
+                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Asynchronously connect again, once the retry interval has elapsed.
+                scheduleReconnect(bootstrap);
             }
         });
     }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -46,7 +46,6 @@ import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
 import org.corfudb.security.tls.SslContextConstructor;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.NodeLocator;
-import org.corfudb.util.Sleep;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
@@ -59,6 +58,8 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -171,6 +172,12 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
      * Thread pool for this channel to use
      */
     private final EventLoopGroup eventLoopGroup;
+
+    /**
+     * A handle on the reconnection attempt that is currently scheduled, if any, so that it can be
+     * cancelled when the router is stopped.
+     */
+    private volatile ScheduledFuture<?> pendingReconnect;
 
     @Data
     @Builder
@@ -356,10 +363,10 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
             });
             // If we aren't shutdown, reconnect.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting...", node);
-                // Asynchronously connect again.
-                connectAsync(bootstrap);
+                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Asynchronously connect again, once the retry interval has elapsed.
+                scheduleReconnect(bootstrap);
             }
         });
     }
@@ -394,15 +401,33 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
             log.debug("connectAsync[{}]: Channel connected.", node);
         } else {
             // Otherwise, the connection failed. If we're not shutdown, try reconnecting after
-            // a sleep period.
+            // the retry interval.
             if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.debug("connectAsync[{}]: Channel connection failed, reconnecting...", node);
-                // Call connect, which will retry the call again.
-                // Note that this is not recursive, because it is called in the
-                // context of the handler future.
-                connectAsync(bootstrap);
+                log.debug("connectAsync[{}]: Channel connection failed, reconnecting in {}ms...",
+                        node, timeoutRetry);
+                // Schedule connect, which will retry the call again.
+                scheduleReconnect(bootstrap);
             }
+        }
+    }
+
+    /**
+     * Schedule a reconnection attempt once the retry interval has elapsed.
+     *
+     * <p>This is invoked from Netty channel future listeners, which run on the event loop thread
+     * that owns the channel. Sleeping on that thread would stall every other channel registered
+     * to it - including channels to healthy nodes - so the retry is scheduled instead of blocking.
+     *
+     * @param bootstrap The channel bootstrap to use
+     */
+    private void scheduleReconnect(@Nonnull Bootstrap bootstrap) {
+        try {
+            // connectAsync re-checks the shutdown flag, so a retry that is scheduled concurrently
+            // with stop() is a no-op rather than a resurrected connection.
+            pendingReconnect = eventLoopGroup.schedule(() -> connectAsync(bootstrap),
+                    timeoutRetry, TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException ree) {
+            log.debug("scheduleReconnect[{}]: event loop is shutting down, not reconnecting", node);
         }
     }
 
@@ -413,6 +438,10 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
     public void stop() {
         log.debug("stop: Shutting down router for {}", node);
         shutdown = true;
+        ScheduledFuture<?> scheduledReconnect = pendingReconnect;
+        if (scheduledReconnect != null) {
+            scheduledReconnect.cancel(false);
+        }
         connectionFuture.completeExceptionally(new NetworkException("Router stopped", node));
         if (channel != null && channel.isOpen()) {
             channel.close().syncUninterruptibly();


### PR DESCRIPTION
This is a crossport of PR https://github.com/CorfuDB/CorfuDB/pull/4127 to corfu-0.9.1.0 branch.

NettyClientRouter and CorfuNettyClientChannel retried failed/closed connections by calling Sleep.sleepUninterruptibly() directly inside a Netty channel future listener, which runs on the shared client EventLoopGroup. A single unreachable peer parks that thread for the full retry interval, and round-robin channel registration spreads the stall across every other channel (including healthy peers) sharing the group, inflating unrelated request latency during any node outage.

Replace the blocking sleep with a scheduled reconnect via eventLoopGroup.schedule(), and cancel any pending reconnect on stop()/close() so shutdown doesn't race a still-scheduled retry.
